### PR TITLE
[MAJOR RFC] drop LGPL 2.0 license option

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,5 @@
     "email": "jindw@xidea.org",
     "url": "http://github.com/xmldom/xmldom/issues"
   },
-  "license": "(LGPL-2.0 or MIT)"
+  "license": "MIT"
 }


### PR DESCRIPTION
(in package.json)

for the sake of simplicity

TODO:

- [ ] fix the LICENSE file (it should maybe contain the text of the MIT license)
- [ ] this should probably be in a new 0.x release since it should be considered a breaking change