### PR TITLE
[testing] use COVERAGE environment variable

### DIFF
--- a/t/test
+++ b/t/test
@@ -6,7 +6,7 @@ echo ""
 
 (proof run t/*/*.t.js | tee .proof.out | proof progress) || (proof errors < .proof.out) || exit 1
 
-if [ "$TRAVIS" = "true" ]; then
+if [ "$COVERAGE" = "true" ]; then
   echo "running with coverage"
   t/cover
 


### PR DESCRIPTION
instead of $TRAVIS  to configure test coverage

ref: https://github.com/xmldom/xmldom/issues/3#issuecomment-568730589

this should ~~*hopefully*~~ _definitely_ give us a green Travis CI build ref: #2