### PR TITLE
start xmldom 0.4.0-dev in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmldom",
-  "version": "0.3.0",
+  "version": "0.4.0-dev",
   "description": "A pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module.",
   "keywords": [
     "w3c",


### PR DESCRIPTION
I generally like to have "-dev" package version number on the master branch. This is what we generally do in Apache Cordova. This means that if someone does install from GitHub or tries out a proposal from a PR, it would not show released package version number.

A side point is that I think this should be merged by squash merge (quickest) or perhaps rebase merge, not a merge commit. I would like to avoid merge commits when possible, especially for small single-commit changes.