### PR TITLE
Replace regex with an equivalent using String.indexOf()

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -65,12 +65,15 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 			start = end
 		}
 	}
-	function position(p,m){
-		while(p>=lineEnd && (m = linePattern.exec(source))){
-			lineStart = m.index;
-			lineEnd = lineStart + m[0].length;
+	function findLineEnd(){
+		var newLine = source.indexOf('\n', lineEnd);
+		return newLine === -1 ? source.length : newLine + 1;
+	}
+	function position(p){
+		while(p>=lineEnd){
+			lineStart = lineEnd;
+			lineEnd = findLineEnd();
 			locator.lineNumber++;
-			//console.log('line++:',locator,startPos,endPos)
 		}
 		locator.columnNumber = p-lineStart+1;
 	}


### PR DESCRIPTION
Hi there,

I work for Seven West Media. We recently had an incident on our content aggregator service - a node server that ingests news stories from our partners. It uses xmldom to parse the stories. There was a particular package that was causing node to crash, and block other packages from processing. We narrowed the problem down to line 69 of sax.js - the `Regex.exec()`.

Our solution was to swap out the regex for a String.indexOf().

For legal reasons I can't actually send you the xml in question (470K, 2 lines, valid xml), but here is a quick profile of the regex vs indexOf versions:
```js
# test.js
var DOMParser = require('xmldom').DOMParser;
var fs = require('fs');
var data = fs.readFileSync('B881498861Z.1_20200325063359_000.xml', 'utf8');
var doc = new DOMParser().parseFromString(data);
console.log('done');
```
```
➜  xmldom git:(master) ✗ time node test.js
done
node test.js   39.12s  user 0.11s system 99% cpu 39.253 total

➜  xmldom git:(bugfix/replace-crashy-regex2) ✗ time node test.js
done
node test.js   0.17s  user 0.03s system 123% cpu 0.164 total
```