### PR TITLE
fix: Restore `&nbsp;` behavior from v0.1.27

### DIFF
--- a/lib/entities.js
+++ b/lib/entities.js
@@ -69,7 +69,7 @@ exports.entityMap = {
        yacute: "ý",
        thorn: "þ",
        yuml: "ÿ",
-       nbsp: " ",
+       nbsp: "\u00a0",
        iexcl: "¡",
        cent: "¢",
        pound: "£",

--- a/test/html/normalize.vows.js
+++ b/test/html/normalize.vows.js
@@ -13,13 +13,8 @@ wows.describe('html normalizer').addBatch({
     	assert(dom+'', '<div xmlns="http://www.w3.org/1999/xhtml">&lt;123e>&amp;&lt;a<br/></div>');
     	
     	var dom = new DOMParser().parseFromString('<div>&nbsp;&copy;&nbsp&copy</div>','text/html');
-    	assert.skip(
-    		dom+'', '<div xmlns="http://www.w3.org/1999/xhtml">\u00a0\u00a9&amp;nbsp&amp;copy</div>',
-				'see https://github.com/xmldom/xmldom/issues/57'
-			);
-    	assert(dom+'', '<div xmlns="http://www.w3.org/1999/xhtml"> \u00a9&amp;nbsp&amp;copy</div>');
+    	assert(dom+'', '<div xmlns="http://www.w3.org/1999/xhtml">\u00a0\u00a9&amp;nbsp&amp;copy</div>');
 
-    	
     	var dom = new DOMParser().parseFromString('<html xmlns:x="1"><body/></html>','text/html');
     	assert(dom+'', '<html xmlns:x="1" xmlns="http://www.w3.org/1999/xhtml"><body></body></html>');
 	},


### PR DESCRIPTION
Might be considered a breaking change.

fixes #57