### PR TITLE
ci(github-actions): Use `npm ci` instead of `npm install`

### DIFF
--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -24,5 +24,5 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
     - run: npm test


### PR DESCRIPTION
According to the documentation when the `package-lock.json` is committed to the repo,
`npm ci` is the preferred and reliable way to install dependencies on CI,
since it will not attempt to modify the lock file.
It will also fail in case the dependencies in `package.json`
do not match with the ones in the lock file.

https://docs.npmjs.com/cli/ci