### PR TITLE
remove .proof.out from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules
-/.proof.out


### PR DESCRIPTION
not needed since use of proof was removed by PR #59

/cc @karfau