### PR TITLE
single npm cit line in GitHub CI action

### DIFF
--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -24,5 +24,4 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm test
+    - run: npm cit


### PR DESCRIPTION
ref: https://docs.npmjs.com/cli/install-ci-test.html

as proposed by @timbru31 in <https://github.com/xmldom/xmldom/pull/68#pullrequestreview-439940271> (PR #68)

- [x] check that the vows test suite is still run in the CI build
- [ ] I wonder if this should be proposed in the template on GitHub