### PR TITLE
add Stryker action to update dashboard

### DIFF
--- a/.github/workflows/stryker.yml
+++ b/.github/workflows/stryker.yml
@@ -1,0 +1,28 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: run Stryker - Node.js CI
+
+on:
+  push:
+    branches: [ master, stryker-* ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run stryker
+      env:
+        STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.github/workflows/stryker.yml
+++ b/.github/workflows/stryker.yml
@@ -5,7 +5,7 @@ name: run Stryker - Node.js CI
 
 on:
   push:
-    branches: [ master, stryker-* ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@
 [![npm](https://img.shields.io/npm/v/xmldom?style=flat-square)](https://www.npmjs.com/package/xmldom)
 [![bug issues](https://img.shields.io/github/issues/xmldom/xmldom/bug?color=red&style=flat-square)](https://github.com/xmldom/xmldom/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 [!["help wanted" issues](https://img.shields.io/github/issues/xmldom/xmldom/help%20wanted?color=darkgreen&style=flat-square)](https://github.com/xmldom/xmldom/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+[![Mutation report](https://camo.githubusercontent.com/ee312c4ebce7784ce9f785757eba5d6e33e6d950/68747470733a2f2f696d672e736869656c64732e696f2f656e64706f696e743f7374796c653d666c61742675726c3d687474707325334125324625324662616467652d6170692e737472796b65722d6d757461746f722e696f2532466769746875622e636f6d25324662726f647962697473253246786d6c646f6d2532466d6173746572)](https://dashboard.stryker-mutator.io/reports/github.com/brodybits/xmldom/master)
 
 A JavaScript implementation of W3C DOM for Node.js, Rhino and the browser. Fully
 compatible with `W3C DOM level2`; and some compatible with `level3`. Supports

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -10,5 +10,9 @@
   ],
   "testRunner": "command",
   "transpilers": [],
+  "dashboard": {
+    "project": "github.com/brodybits/xmldom",
+    "version": "master"
+  },
   "coverageAnalysis": "all"
 }


### PR DESCRIPTION
as a Node.js action - __updated__

- [x] use API key to integrate with Stryker dashboard - working with workaround to use @brodybits dashboard as described below, now with brief reference to the workaround in the commit message
- [x] remove extra `stryker-*` from the list of trigger branches before merging (maybe)
- [x] add badge with link to the Stryker mutation report (now that PR #78 has been reviewed & merged): [![Mutation report](https://camo.githubusercontent.com/ee312c4ebce7784ce9f785757eba5d6e33e6d950/68747470733a2f2f696d672e736869656c64732e696f2f656e64706f696e743f7374796c653d666c61742675726c3d687474707325334125324625324662616467652d6170692e737472796b65722d6d757461746f722e696f2532466769746875622e636f6d25324662726f647962697473253246786d6c646f6d2532466d6173746572)](https://dashboard.stryker-mutator.io/reports/github.com/brodybits/xmldom/master)
- [ ] raise an issue to use proper dashboard based on this xmldom project location, once <https://github.com/stryker-mutator/stryker-dashboard/issues/156> is resolved

resolves #60

~~/cc @karfau~~