### PR TITLE
modernize & improve the example in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,19 +19,22 @@ Install:
 Example:
 ====
 ```javascript
-var DOMParser = require('xmldom').DOMParser;
-var doc = new DOMParser().parseFromString(
-    '<xml xmlns="a" xmlns:c="./lite">\n'+
-        '\t<child>test</child>\n'+
-        '\t<child></child>\n'+
-        '\t<child/>\n'+
-    '</xml>'
-    ,'text/xml');
-doc.documentElement.setAttribute('x','y');
-doc.documentElement.setAttributeNS('./lite','c:x','y2');
-var nsAttr = doc.documentElement.getAttributeNS('./lite','x')
-console.info(nsAttr)
+const { DOMParser } = require('xmldom')
+
+const doc = new DOMParser().parseFromString(
+    '<xml xmlns="a" xmlns:c="./lite">\n' +
+        '\t<child>test</child>\n' +
+        '\t<child></child>\n' +
+        '\t<child/>\n' +
+        '</xml>',
+    'text/xml'
+)
+doc.documentElement.setAttribute('x', 'y')
+doc.documentElement.setAttributeNS('./lite', 'c:x', 'y2')
 console.info(doc)
+
+const nsAttr = doc.documentElement.getAttributeNS('./lite', 'x')
+console.info(nsAttr)
 ```
 API Reference
 =====


### PR DESCRIPTION
- used `prettier-standard --lint` to reformat the example, with semicolons removed, etc., but with 4-space indentation restored (by hand)
- replace `var` with `const`
- use destructured `const` to import the `DOMParser` object
- add blank lines
- move a `console` logging statement

triggered by discussion in issue #75

related to: PR #79 (add note about ES6 import)

✅ **tested** in a new npm package project in my work area

/cc @ajmas