### PR TITLE
remove ES6 syntax from getElementsByClassName

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -609,10 +609,10 @@ Document.prototype = {
 	},
 	
 	getElementsByClassName: function(className) {
-		const pattern = new RegExp(`(^|\\s)${className}(\\s|$)`);
-		return new LiveNodeList(this, base => {
+		var pattern = new RegExp("(^|\\s)" + className + "(\\s|$)");
+		return new LiveNodeList(this, function(base) {
 			var ls = [];
-			_visitNode(base.documentElement, node => {
+			_visitNode(base.documentElement, function(node) {
 				if(node !== base && node.nodeType == ELEMENT_NODE) {
 					if(pattern.test(node.getAttribute('class'))) {
 						ls.push(node);


### PR DESCRIPTION
The new method getElementsByClassName uses ES6 syntax. This is a problem when trying to polyfill an older engine.