### PR TITLE
test: coverageAnalysis off in stryker.conf.json

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -14,5 +14,5 @@
     "project": "github.com/brodybits/xmldom",
     "version": "master"
   },
-  "coverageAnalysis": "all"
+  "coverageAnalysis": "off"
 }


### PR DESCRIPTION
Rationale: existing `"coverageAnalysis": "all"` does not work with the Stryker command runner that we are currently using and leads to failure when upgrading `@stryker-mutator` packages to `4.0.0-beta.2`. I am using this setting when running Stryker with this upgrade in my work area.

Alternative: I would be happier if we would use a newer test framework such as Jest and configure Stryker to the corresponding test runner which should run faster.