### PR TITLE
Reduce time needed for stryker

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -14,5 +14,8 @@
     "project": "github.com/brodybits/xmldom",
     "version": "master"
   },
-  "coverageAnalysis": "all"
+  "coverageAnalysis": "all",
+  "commandRunner": {
+    "command": "npm run test:unit"
+  }
 }


### PR DESCRIPTION
By not running the tests for test/assert.js I think we can reduce the duration of the stryker run.
They shouldn't change the result since they are only test helpers that don't change how the actual code is tested.

- [ ] needs to be verified by running it (on github?)

Fixes #82 
