### PR TITLE
use eslint-plugin-es5 to enforce ES5

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,6 +3,8 @@ env:
   commonjs: true
   es2020: true
   node: true
+plugins:
+  - es5
 # FUTURE TBD:
 # extends: 'eslint:recommended'
 parserOptions:

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,0 +1,2 @@
+extends:
+  - 'plugin:es5/no-es2015'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1008,6 +1008,12 @@
         }
       }
     },
+    "eslint-plugin-es5": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz",
+      "integrity": "sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@stryker-mutator/javascript-mutator": "^3.3.1",
     "dom-js": "0.0.9",
     "eslint": "^7.7.0",
+    "eslint-plugin-es5": "^1.5.0",
     "nodemon": "^2.0.4",
     "npm-run-all": "^4.1.5",
     "vows": "^0.8.3"


### PR DESCRIPTION
The purpose is to avoid ES6 items that may cause issues with older engines, as discussed in PR #87.

This should guard against newer ES6 syntax that could lead to issues with some ES5 environments such as:

- Jint - https://github.com/sebastienros/jint
- Duktape
- IE11
- Android pre-5.0 WebView (already past EOL)

This PR is based on PR #106.

I would appreciate a quick review from someone, if possible.