### PR TITLE
fix: typecheck source param before parsing

### DIFF
--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -21,7 +21,7 @@ DOMParser.prototype.parseFromString = function(source,mimeType){
 		defaultNSMap['']= 'http://www.w3.org/1999/xhtml';
 	}
 	defaultNSMap.xml = defaultNSMap.xml || 'http://www.w3.org/XML/1998/namespace';
-	if(source){
+	if(source && typeof source === 'string'){
 		sax.parse(source,defaultNSMap,entityMap);
 	}else{
 		sax.errorHandler.error("invalid doc source");

--- a/test/parse/simple.vows.js
+++ b/test/parse/simple.vows.js
@@ -46,7 +46,39 @@ wows.describe('parse').addBatch({
 		var dom = parser.parseFromString(xmlLineError, "text/xml");
 		var node = dom.documentElement.firstChild.nextSibling
 		assert(node.lineNumber, 7);
-  }
+  },
+  'invalid input - falsy string': runParserWith(''),
+  'invalid input - not a string': runParserWith({}),
+  'invalid input - number': runParserWith(12345),
+  'invalid input - null': runParserWith(null)
 }).export(module);
 
+function runParserWith (testValue) {
+  return function () {
+    var parser = new DOMParser(rethrowErrorHandler());
 
+    try {
+      parser.parseFromString(testValue);
+      // If the above line doesn't throw then fail the test
+      assert.isTrue(false);
+    } catch (e) {
+      assert.isTrue(isInvalidDocSource(e));
+    }
+  }
+}
+
+function rethrowErrorHandler () {
+  return {
+    errorHandler: {
+      error: function (errorMessage) {
+        throw errorMessage;
+      }
+    }
+  }
+}
+
+function isInvalidDocSource (errorMessage) {
+  // Errors that are thrown are embedded within a string containing locator data. Infer the original
+  // error message via regex
+  return /^\[xmldom error\][\s]*invalid doc source[\s\S]*$/.test(errorMessage);
+}


### PR DESCRIPTION
Updates `DOMParser.parseFromString` to also check that the `source` provided is a string. To prevent sax from throwing undefined errors when calling `indexOf` on the source.

Adds unit tests to `test/parse/simple.vows.js` to cover this edge case.

Resolves #98 