### PR TITLE
docs: Configure `auto-changelog` for generating updated CHANGELOG.md

### DIFF
--- a/auto-changelog.hbs
+++ b/auto-changelog.hbs
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+{{#each releases}}
+  {{#if href}}
+    ## [{{title}}]({{href}}){{#if tag}} - {{isoDate}}{{/if}}
+  {{else}}
+    ## {{title}}{{#if tag}} - {{isoDate}}{{/if}}
+  {{/if}}
+
+  {{#if summary}}
+    {{summary}}
+  {{/if}}
+
+  {{#if merges}}
+    ### Merged
+
+    {{#each merges}}
+      - {{#if commit.breaking}}**Breaking change:** {{/if}}{{message}} {{#if href}}[`#{{id}}`]({{href}}){{/if}}
+    {{/each}}
+  {{/if}}
+
+  {{#if fixes}}
+    ### Fixed
+
+    {{#each fixes}}
+      - {{#if commit.breaking}}**Breaking change:** {{/if}}{{commit.subject}}{{#each fixes}} {{#if href}}[`#{{id}}`]({{href}}){{/if}}{{/each}}
+    {{/each}}
+  {{/if}}
+
+{{/each}}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "lint": "npm-run-all lint:eslint",
     "lint:eslint": "eslint lib test",
+    "changelog": "npx auto-changelog --unreleased-only",
     "start": "nodemon --watch package.json --watch lib --watch test --exec 'npm --silent run test'",
     "stryker": "stryker run",
     "test": "npm-run-all test:unit lint",
@@ -56,5 +57,11 @@
   "bugs": {
     "url": "https://github.com/xmldom/xmldom/issues"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "auto-changelog": {
+    "prepend": true,
+    "remote": "upstream",
+    "tagPrefix": "",
+    "template": "./auto-changelog.hbs"
+  }
 }


### PR DESCRIPTION
- added script `changelog` to add "Unreleased" section to changelog, so it can be tweaked manually
- `auto-changelog` is invoked using npx, so it's not a `devDependency`

https://github.com/CookPete/auto-changelog

PS: This is just #138 without any (real) changes to CHANGELOG.md


