### PR TITLE
fix(dom): Escape `]]>` when serializing CharData

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -402,12 +402,17 @@ Node.prototype = {
     }
 };
 
+const AMP = '&amp;';
+const GT = '&gt;';
+const LT = '&lt;';
+const CDATA_END_ESCAPED = ']]'+GT;
+const QUOT = '&quot;';
 
 function _xmlEncoder(c){
-	return c == '<' && '&lt;' ||
-         c == '>' && '&gt;' ||
-         c == '&' && '&amp;' ||
-         c == '"' && '&quot;' ||
+	return c == '<' && LT ||
+         c == '>' && GT ||
+         c == '&' && AMP ||
+         c == '"' && QUOT ||
          '&#'+c.charCodeAt()+';'
 }
 
@@ -1083,7 +1088,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		 */
 		return buf.push(node.data
 			.replace(/[<&]/g,_xmlEncoder)
-			.replace(/]]>/g, ']]&gt;')
+			.replace(/]]>/g, CDATA_END_ESCAPED)
 		);
 	case CDATA_SECTION_NODE:
 		return buf.push( '<![CDATA[',node.data,']]>');

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -402,17 +402,12 @@ Node.prototype = {
     }
 };
 
-const AMP = '&amp;';
-const GT = '&gt;';
-const LT = '&lt;';
-const CDATA_END_ESCAPED = ']]'+GT;
-const QUOT = '&quot;';
 
 function _xmlEncoder(c){
-	return c == '<' && LT ||
-         c == '>' && GT ||
-         c == '&' && AMP ||
-         c == '"' && QUOT ||
+	return c == '<' && '&lt;' ||
+         c == '>' && '&gt;' ||
+         c == '&' && '&amp;' ||
+         c == '"' && '&quot;' ||
          '&#'+c.charCodeAt()+';'
 }
 
@@ -1088,7 +1083,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		 */
 		return buf.push(node.data
 			.replace(/[<&]/g,_xmlEncoder)
-			.replace(/]]>/g, CDATA_END_ESCAPED)
+			.replace(/]]>/g, ']]&gt;')
 		);
 	case CDATA_SECTION_NODE:
 		return buf.push( '<![CDATA[',node.data,']]>');

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1066,7 +1066,25 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 	case ATTRIBUTE_NODE:
 		return buf.push(' ',node.name,'="',node.value.replace(/[<&"]/g,_xmlEncoder),'"');
 	case TEXT_NODE:
-		return buf.push(node.data.replace(/[<&]/g,_xmlEncoder));
+		/**
+		 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,
+		 * except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section.
+		 * If they are needed elsewhere, they must be escaped using either numeric character references or the strings
+		 * `&amp;` and `&lt;` respectively.
+		 * The right angle bracket (>) may be represented using the string " &gt; ", and must, for compatibility,
+		 * be escaped using either `&gt;` or a character reference when it appears in the string `]]>` in content,
+		 * when that string is not marking the end of a CDATA section.
+		 *
+		 * In the content of elements, character data is any string of characters
+		 * which does not contain the start-delimiter of any markup
+		 * and does not include the CDATA-section-close delimiter, `]]>`.
+		 *
+		 * @see https://www.w3.org/TR/xml/#NT-CharData
+		 */
+		return buf.push(node.data
+			.replace(/[<&]/g,_xmlEncoder)
+			.replace(/]]>/g, ']]&gt;')
+		);
 	case CDATA_SECTION_NODE:
 		return buf.push( '<![CDATA[',node.data,']]>');
 	case COMMENT_NODE:

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -6,7 +6,7 @@ describe('XML Serializer', () => {
 	it('supports text node containing "]]>"', () => {
 		const doc = new DOMParser().parseFromString('<test/>', 'text/xml')
 		doc.documentElement.appendChild(doc.createTextNode('hello ]]> there'))
-		expect(doc.documentElement.firstChild.toString()).toBe('hello ]]> there')
+		expect(doc.documentElement.firstChild.toString()).toBe('hello ]]&gt; there')
 	})
 
 	it('supports <script> element with no children', () => {

--- a/test/xmltest/__snapshots__/not-wf.test.js.snap
+++ b/test/xmltest/__snapshots__/not-wf.test.js.snap
@@ -144,7 +144,7 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 018.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&lt;![CDATA [ stuff]]></doc>",
+  "actual": "<doc>&lt;![CDATA [ stuff]]&gt;</doc>",
 }
 `;
 
@@ -205,13 +205,13 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 025.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>]]></doc>",
+  "actual": "<doc>]]&gt;</doc>",
 }
 `;
 
 exports[`xmltest/not-wellformed standalone should match 026.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>]]]></doc>",
+  "actual": "<doc>]]]&gt;</doc>",
 }
 `;
 
@@ -237,7 +237,7 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 029.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>abc]]]>def</doc>",
+  "actual": "<doc>abc]]]&gt;def</doc>",
 }
 `;
 
@@ -831,7 +831,7 @@ Object {
 exports[`xmltest/not-wellformed standalone should match 108.xml with snapshot 1`] = `
 Object {
   "actual": "<doc>
-&lt;![CDATA [  ]]>
+&lt;![CDATA [  ]]&gt;
 </doc>",
 }
 `;
@@ -870,7 +870,7 @@ Object {
 exports[`xmltest/not-wellformed standalone should match 112.xml with snapshot 1`] = `
 Object {
   "actual": "<doc>
-&lt;![cdata[data]]>
+&lt;![cdata[data]]&gt;
 </doc>",
 }
 `;
@@ -1354,7 +1354,7 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 181.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;]]></doc>",
+  "actual": "<doc>&amp;e;]]&gt;</doc>",
   "error": Array [
     "[xmldom error]	entity not found:&e;
 @#[line:1,col:1]",


### PR DESCRIPTION
to adhere to the XML specification

https://www.w3.org/TR/xml/#NT-CharData
https://github.com/xmldom/xmldom/issues/58#issuecomment-743231935