### PR TITLE
Update MDN links in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ import { DOMParser } from 'xmldom'
 API Reference
 =====
 
- * [DOMParser](https://developer.mozilla.org/en/DOMParser):
+ * [DOMParser](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser):
 
 	```javascript
 	parseFromString(xmlsource,mimeType)
@@ -74,7 +74,7 @@ API Reference
 		
 	```
 
- * [XMLSerializer](https://developer.mozilla.org/en/XMLSerializer)
+ * [XMLSerializer](https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer)
  
 	```javascript
 	serializeToString(node)


### PR DESCRIPTION
The URLs to these articles seems to have changed. They are currently pointing to 404 pages.
This Pull Requests updates the links.