### PR TITLE
fix: Escape `<` when serializing attribute values

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1068,7 +1068,13 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		}
 		return;
 	case ATTRIBUTE_NODE:
-		return buf.push(' ',node.name,'="',node.value.replace(/[&"]/g,_xmlEncoder),'"');
+		/**
+		 * Well-formedness constraint: No < in Attribute Values
+		 * The replacement text of any entity referred to directly or indirectly in an attribute value must not contain a <.
+		 * @see https://www.w3.org/TR/xml/#CleanAttrVals
+		 * @see https://www.w3.org/TR/xml/#NT-AttValue
+		 */
+		return buf.push(' ',node.name,'="',node.value.replace(/[<&"]/g,_xmlEncoder),'"');
 	case TEXT_NODE:
 		/**
 		 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1074,7 +1074,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		 * @see https://www.w3.org/TR/xml/#CleanAttrVals
 		 * @see https://www.w3.org/TR/xml/#NT-AttValue
 		 */
-		return buf.push(' ',node.name,'="',node.value.replace(/[<&"]/g,_xmlEncoder),'"');
+		return buf.push(' ', node.name, '="', node.value.replace(/[<&"]/g,_xmlEncoder), '"');
 	case TEXT_NODE:
 		/**
 		 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,

--- a/test/html/__snapshots__/normalize.test.js.snap
+++ b/test/html/__snapshots__/normalize.test.js.snap
@@ -44,13 +44,13 @@ Object {
 
 exports[`html normalizer <div test="a<b&&a< c && a>d"></div> 1`] = `
 Object {
-  "actual": "<div test=\\"a<b&amp;&amp;a< c &amp;&amp; a>d\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></div>",
+  "actual": "<div test=\\"a&lt;b&amp;&amp;a&lt; c &amp;&amp; a>d\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></div>",
 }
 `;
 
 exports[`html normalizer <div test="alert('<br/>')"/> 1`] = `
 Object {
-  "actual": "<div test=\\"alert('<br/>')\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></div>",
+  "actual": "<div test=\\"alert('&lt;br/>')\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></div>",
 }
 `;
 
@@ -90,7 +90,7 @@ Object {
 
 exports[`html normalizer <html test="a<b && a>b && '&amp;&&'"/> 1`] = `
 Object {
-  "actual": "<html test=\\"a<b &amp;&amp; a>b &amp;&amp; '&amp;&amp;&amp;'\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></html>",
+  "actual": "<html test=\\"a&lt;b &amp;&amp; a>b &amp;&amp; '&amp;&amp;&amp;'\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></html>",
 }
 `;
 

--- a/test/parse/__snapshots__/locator.test.js.snap
+++ b/test/parse/__snapshots__/locator.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DOMLocator attribute position 1`] = `
 Object {
-  "actual": "<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><body title=\\"1<2\\"><table></table>&lt;;test</body></html>",
+  "actual": "<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><body title=\\"1&lt;2\\"><table></table>&lt;;test</body></html>",
 }
 `;
 

--- a/test/parse/__snapshots__/simple.test.js.snap
+++ b/test/parse/__snapshots__/simple.test.js.snap
@@ -12,7 +12,7 @@ Object {
 
 exports[`parse simple 1`] = `
 Object {
-  "actual": "<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><body title=\\"1<2\\"></body></html>",
+  "actual": "<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><body title=\\"1&lt;2\\"></body></html>",
 }
 `;
 
@@ -49,6 +49,6 @@ Object {
 
 exports[`parse wrong closing tag 1`] = `
 Object {
-  "actual": "<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><body title=\\"1<2\\"><table></table>&lt;;test</body></html>",
+  "actual": "<html xmlns=\\"http://www.w3.org/1999/xhtml\\"><body title=\\"1&lt;2\\"><table></table>&lt;;test</body></html>",
 }
 `;

--- a/test/xmltest/__snapshots__/not-wf.test.js.snap
+++ b/test/xmltest/__snapshots__/not-wf.test.js.snap
@@ -112,7 +112,7 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 014.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"<foo>\\"/>",
+  "actual": "<doc a1=\\"&lt;foo>\\"/>",
 }
 `;
 

--- a/test/xmltest/__snapshots__/valid.test.js.snap
+++ b/test/xmltest/__snapshots__/valid.test.js.snap
@@ -293,7 +293,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 040.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"&quot;<&amp;>'\\"/>",
+  "actual": "<doc a1=\\"&quot;&lt;&amp;>'\\"/>",
   "expected": "<doc a1=\\"&quot;&lt;&amp;&gt;'\\"></doc>",
 }
 `;


### PR DESCRIPTION
to produce well formed XML.

> Well-formedness constraint: No `<` in Attribute Values
> The replacement text of any entity referred to directly or indirectly in an attribute value must not contain a `<`.

https://www.w3.org/TR/xml/#CleanAttrVals
https://www.w3.org/TR/xml/#NT-AttValue

fixes #198