### PR TITLE
ci: run Stryker on Node.js 14

### DIFF
--- a/.github/workflows/stryker.yml
+++ b/.github/workflows/stryker.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Stryker seems to take 2 hours on GitHub, maybe a little longer with the recent update. I wonder if it may go faster on Node.js 14.