### PR TITLE
test: Stryker Jest runner with config workarounds

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -143,21 +143,24 @@ module.exports = {
   // Adds a location field to test results
   // testLocationInResults: false,
 
+  // TBD ENABLED to work with Stryker Jest runner:
   // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.[jt]s?(x)",
-  //   "**/?(*.)+(spec|test).[tj]s?(x)"
-  // ],
+  testMatch: [
+    "**/__tests__/**/*.[jt]s?(x)",
+    "**/?(*.)+(spec|test).[tj]s?(x)"
+  ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
+  testPathIgnorePatterns: [
   //   "/node_modules/"
-  // ],
+    "/test/test.js"
+  ],
 
+  // TBD NOT WORKING with Stryker Jest runner:
   // The regexp pattern or array of patterns that Jest uses to detect test files
-  testRegex: [
-  	/\.test\.js?$/
-	],
+  //  testRegex: [
+  //    /\.test\.js?$/
+  //  ],
 
   // This option allows the use of a custom results processor
   // testResultsProcessor: undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -864,6 +864,18 @@
         "weapon-regex": "~0.4.1"
       }
     },
+    "@stryker-mutator/jest-runner": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-4.5.1.tgz",
+      "integrity": "sha512-ei0YWdf3tjShChvU5cBBET3Eqa3PfshcfHxAG/RgYgrfZYGHL1GnT5dsGLojf4b5TEPY12Q9HVkSnsnoFvW5mQ==",
+      "dev": true,
+      "requires": {
+        "@stryker-mutator/api": "4.5.1",
+        "@stryker-mutator/util": "4.5.1",
+        "semver": "~6.3.0",
+        "tslib": "~2.1.0"
+      }
+    },
     "@stryker-mutator/util": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-4.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@stryker-mutator/core": "^4.5.1",
+    "@stryker-mutator/core": "4.5.1",
     "dom-js": "0.0.9",
     "eslint": "^7.24.0",
     "eslint-config-prettier": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {},
   "devDependencies": {
     "@stryker-mutator/core": "4.5.1",
+    "@stryker-mutator/jest-runner": "4.5.1",
     "dom-js": "0.0.9",
     "eslint": "^7.24.0",
     "eslint-config-prettier": "^8.2.0",

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -7,14 +7,11 @@
     "progress",
     "dashboard"
   ],
-  "testRunner": "command",
+  "testRunner": "jest",
+  "coverageAnalysis": "perTest",
   "dashboard": {
     "project": "github.com/brodybits/xmldom",
     "version": "master"
-  },
-  "coverageAnalysis": "off",
-  "commandRunner": {
-    "command": "npm run test:jest -- --bail --no-cache --ci --maxWorkers=1"
   },
   "timeoutMS_comment": "When all tests pass (mutant survives) our tests need some time. So this is configured to prevent 'timeout's",
   "timeoutMS": 15000


### PR DESCRIPTION
__updated:__ I reconfigured by removing `stryker.conf.json` from my work area, running `npx stryker init` again, and re-patching `stryker.conf.json` with some of the configuration from the master branch. The reconfiguration gave me the `coverageAnalysis` entry changed to `perTest`.

I was hoping to improve the speed on GitHub. I tried with and without this update on cloud instances with 2 vCPU, for 2 test runner processes, which seems to reflect what happens on GitHub. But it took about half minute longer with the Jest runner, which is insignificant considering that it takes almost 2 hours on GitHub with 2 test runner processes.

I had to update `jest.config.js` to configure `testMatch` instead of `testRegex`. From the debug tracing command, as directed when Stryker fails, it looked to me like with the Jest runner it was messing up the configuration of `testRegex`. I suspect that this is why the jest-runner did not work in PR #140 (update to Stryker 4). I think it would be ideal if we could get this fixed on Stryker at some point. My changes may need cleanup, and I am not sure if we need to configure `testPathIgnorePatterns` or not.

Test time was almost the same, maybe half a minute longer with the Jest runner. See <https://github.com/stryker-mutator/stryker-js/issues/1514#issuecomment-675571410>:

> Mutation switching _by itself_ will not have a significant impact on Jest projects unfortunately. You might have some performance improvement because Jest would be able to cache build results, but definitely not an order of magnitude. However, it does open up the way for coverage analysis in jest. Hot reload should theoretically also be possible with Jest, but not with their current public api alone. We'll be focussing on jest next, after we've released v4.

### End results with command runner

```console
Mutation testing  [==================================================] 100% (elapsed: ~1h 53m, remaining: n/a) 2014/2014 tested (695 survived, 41 timed out)
[...]
Ran 0.98 tests per mutant on average.
---------------|---------|----------|-----------|------------|----------|---------|
File           | % score | # killed | # timeout | # survived | # no cov | # error |
---------------|---------|----------|-----------|------------|----------|---------|
All files      |   65.49 |     1278 |        41 |        695 |        0 |       0 |
 dom-parser.js |   80.00 |      156 |         0 |         39 |        0 |       0 |
 dom.js        |   65.81 |      590 |        24 |        319 |        0 |       0 |
 entities.js   |    7.85 |       19 |         0 |        223 |        0 |       0 |
 sax.js        |   82.30 |      513 |        17 |        114 |        0 |       0 |
---------------|---------|----------|-----------|------------|----------|---------|
[...]
23:51:59 (1131) INFO MutationTestExecutor Done in 113 minutes 37 seconds.
```

### End results with Jest runner

```console
Mutation testing  [==================================================] 100% (elapsed: ~1h 53m, remaining: n/a) 1832/1832 tested (513 survived, 92 timed out)
[...]
Ran 183.07 tests per mutant on average.
---------------|---------|----------|-----------|------------|----------|---------|
File           | % score | # killed | # timeout | # survived | # no cov | # error |
---------------|---------|----------|-----------|------------|----------|---------|
All files      |   65.42 |     1223 |        92 |        513 |      182 |       4 |
 dom-parser.js |   80.00 |      149 |         7 |         24 |       15 |       0 |
 dom.js        |   65.81 |      585 |        29 |        168 |      151 |       0 |
 entities.js   |    7.85 |       19 |         0 |        223 |        0 |       0 |
 sax.js        |   82.19 |      470 |        56 |         98 |       16 |       4 |
---------------|---------|----------|-----------|------------|----------|---------|
[...]
23:55:19 (1135) INFO MutationTestExecutor Done in 114 minutes 11 seconds.
```

I would also like to investigate the 4 errors on `sax.js` at some point.