### PR TITLE
refactor: Extract immutable conventions & entities, etc.

### DIFF
--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -40,6 +40,7 @@ var MIME_TYPE = freeze({
 	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring WHATWG HTML Spec
 	 */
 	HTML: 'text/html',
+
 	/**
 	 * Helper method to check a mime type if it indicates an HTML document
 	 *
@@ -53,6 +54,7 @@ var MIME_TYPE = freeze({
 	isHTML: function (value) {
 		return value === MIME_TYPE.HTML
 	},
+
 	/**
 	 * `application/xml`, the standard mime type for XML documents.
 	 *
@@ -61,6 +63,7 @@ var MIME_TYPE = freeze({
 	 * @see https://en.wikipedia.org/wiki/XML_and_MIME Wikipedia
 	 */
 	XML_APPLICATION: 'application/xml',
+
 	/**
 	 * `text/html`, an alias for `application/xml`.
 	 *
@@ -69,6 +72,7 @@ var MIME_TYPE = freeze({
 	 * @see https://en.wikipedia.org/wiki/XML_and_MIME Wikipedia
 	 */
 	XML_TEXT: 'text/xml',
+
 	/**
 	 * `application/xhtml+xml`, indicates an XML document that has the default HTML namespace,
 	 * but is parsed as an XML document.
@@ -78,6 +82,7 @@ var MIME_TYPE = freeze({
 	 * @see https://en.wikipedia.org/wiki/XHTML Wikipedia
 	 */
 	XML_XHTML_APPLICATION: 'application/xhtml+xml',
+
 	/**
 	 * `image/svg+xml`,
 	 *
@@ -100,6 +105,7 @@ var NAMESPACE = freeze({
 	 * @see http://www.w3.org/1999/xhtml
 	 */
 	HTML: 'http://www.w3.org/1999/xhtml',
+
 	/**
 	 * Checks if `uri` equals `NAMESPACE.HTML`.
 	 *
@@ -110,18 +116,21 @@ var NAMESPACE = freeze({
 	isHTML: function (uri) {
 		return uri === NAMESPACE.HTML
 	},
+
 	/**
 	 * The SVG namespace.
 	 *
 	 * @see http://www.w3.org/2000/svg
 	 */
 	SVG: 'http://www.w3.org/2000/svg',
+
 	/**
 	 * The `xml:` namespace.
 	 *
 	 * @see http://www.w3.org/XML/1998/namespace
 	 */
 	XML: 'http://www.w3.org/XML/1998/namespace',
+
 	/**
 	 * The `xmlns:` namespace
 	 *

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -1,0 +1,135 @@
+'use strict'
+
+/**
+ * "Shallow freezes" an object to render it immutable.
+ * Uses `Object.freeze` if available,
+ * otherwise the immutability is only in the type.
+ *
+ * Is used to create "enum like" objects.
+ *
+ * @template T
+ * @param {T} object the object to freeze
+ * @param {Pick<ObjectConstructor, 'freeze'> = Object} oc `Object` by default,
+ * 				allows to inject custom object constructor for tests
+ * @returns {Readonly<T>}
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
+ */
+function freeze(object, oc) {
+	if (oc === undefined) {
+		oc = Object
+	}
+	return oc && typeof oc.freeze === 'function' ? oc.freeze(object) : object
+}
+
+/**
+ * All mime types that are allowed as input to `DOMParser.parseFromString`
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02 MDN
+ * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparsersupportedtype WHATWG HTML Spec
+ * @see DOMParser.prototype.parseFromString
+ */
+var MIME_TYPE = freeze({
+	/**
+	 * `text/html`, the only mime type that triggers treating an XML document as HTML.
+	 *
+	 * @see DOMParser.SupportedType.isHTML
+	 * @see https://www.iana.org/assignments/media-types/text/html IANA MimeType registration
+	 * @see https://en.wikipedia.org/wiki/HTML Wikipedia
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString MDN
+	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring WHATWG HTML Spec
+	 */
+	HTML: 'text/html',
+	/**
+	 * Helper method to check a mime type if it indicates an HTML document
+	 *
+	 * @param {string=} value
+	 * @returns {boolean}
+	 *
+	 * @see https://www.iana.org/assignments/media-types/text/html IANA MimeType registration
+	 * @see https://en.wikipedia.org/wiki/HTML Wikipedia
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString MDN
+	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring 	 */
+	isHTML: function (value) {
+		return value === MIME_TYPE.HTML
+	},
+	/**
+	 * `application/xml`, the standard mime type for XML documents.
+	 *
+	 * @see https://www.iana.org/assignments/media-types/application/xml IANA MimeType registration
+	 * @see https://tools.ietf.org/html/rfc7303#section-9.1 RFC 7303
+	 * @see https://en.wikipedia.org/wiki/XML_and_MIME Wikipedia
+	 */
+	XML_APPLICATION: 'application/xml',
+	/**
+	 * `text/html`, an alias for `application/xml`.
+	 *
+	 * @see https://tools.ietf.org/html/rfc7303#section-9.2 RFC 7303
+	 * @see https://www.iana.org/assignments/media-types/text/xml IANA MimeType registration
+	 * @see https://en.wikipedia.org/wiki/XML_and_MIME Wikipedia
+	 */
+	XML_TEXT: 'text/xml',
+	/**
+	 * `application/xhtml+xml`, indicates an XML document that has the default HTML namespace,
+	 * but is parsed as an XML document.
+	 *
+	 * @see https://www.iana.org/assignments/media-types/application/xhtml+xml IANA MimeType registration
+	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument WHATWG DOM Spec
+	 * @see https://en.wikipedia.org/wiki/XHTML Wikipedia
+	 */
+	XML_XHTML_APPLICATION: 'application/xhtml+xml',
+	/**
+	 * `image/svg+xml`,
+	 *
+	 * @see https://www.iana.org/assignments/media-types/image/svg+xml IANA MimeType registration
+	 * @see https://www.w3.org/TR/SVG11/ W3C SVG 1.1
+	 * @see https://en.wikipedia.org/wiki/Scalable_Vector_Graphics Wikipedia
+	 */
+	XML_SVG_IMAGE: 'image/svg+xml',
+})
+
+/**
+ * Namespaces that are used in this code base.
+ *
+ * @see http://www.w3.org/TR/REC-xml-names
+ */
+var NAMESPACE = freeze({
+	/**
+	 * The XHTML namespace.
+	 *
+	 * @see http://www.w3.org/1999/xhtml
+	 */
+	HTML: 'http://www.w3.org/1999/xhtml',
+	/**
+	 * Checks if `uri` equals `NAMESPACE.HTML`.
+	 *
+	 * @param {string=} uri
+	 *
+	 * @see NAMESPACE.HTML
+	 */
+	isHTML: function (uri) {
+		return uri === NAMESPACE.HTML
+	},
+	/**
+	 * The SVG namespace.
+	 *
+	 * @see http://www.w3.org/2000/svg
+	 */
+	SVG: 'http://www.w3.org/2000/svg',
+	/**
+	 * The `xml:` namespace.
+	 *
+	 * @see http://www.w3.org/XML/1998/namespace
+	 */
+	XML: 'http://www.w3.org/XML/1998/namespace',
+	/**
+	 * The `xmlns:` namespace
+	 *
+	 * @see https://www.w3.org/2000/xmlns/
+	 */
+	XMLNS: 'http://www.w3.org/2000/xmlns/',
+})
+
+exports.freeze = freeze;
+exports.MIME_TYPE = MIME_TYPE;
+exports.NAMESPACE = NAMESPACE;

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -1,5 +1,6 @@
 var conventions = require("./conventions");
 var entities = require('./entities');
+
 var NAMESPACE = conventions.NAMESPACE;
 
 function DOMParser(options){

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -1,3 +1,7 @@
+var conventions = require("./conventions");
+var entities = require('./entities');
+var NAMESPACE = conventions.NAMESPACE;
+
 function DOMParser(options){
 	this.options = options ||{locator:{}};
 }
@@ -10,7 +14,7 @@ DOMParser.prototype.parseFromString = function(source,mimeType){
 	var locator = options.locator;
 	var defaultNSMap = options.xmlns||{};
 	var isHTML = /\/x?html?$/.test(mimeType);//mimeType.toLowerCase().indexOf('html') > -1;
-  	var entityMap = isHTML?htmlEntity.entityMap:{'lt':'<','gt':'>','amp':'&','quot':'"','apos':"'"};
+  	var entityMap = isHTML ? entities.HTML_ENTITIES : entities.XML_ENTITIES;
 	if(locator){
 		domBuilder.setDocumentLocator(locator)
 	}
@@ -18,9 +22,9 @@ DOMParser.prototype.parseFromString = function(source,mimeType){
 	sax.errorHandler = buildErrorHandler(errorHandler,domBuilder,locator);
 	sax.domBuilder = options.domBuilder || domBuilder;
 	if(isHTML){
-		defaultNSMap['']= 'http://www.w3.org/1999/xhtml';
+		defaultNSMap[''] = NAMESPACE.HTML;
 	}
-	defaultNSMap.xml = defaultNSMap.xml || 'http://www.w3.org/XML/1998/namespace';
+	defaultNSMap.xml = defaultNSMap.xml || NAMESPACE.XML;
 	if(source && typeof source === 'string'){
 		sax.parse(source,defaultNSMap,entityMap);
 	}else{
@@ -242,7 +246,6 @@ function appendElement (hander,node) {
 }//appendChild and setAttributeNS are preformance key
 
 //if(typeof require == 'function'){
-var htmlEntity = require('./entities');
 var sax = require('./sax');
 var XMLReader = sax.XMLReader;
 var ParseError = sax.ParseError;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,4 +1,5 @@
 var conventions = require("./conventions");
+
 var NAMESPACE = conventions.NAMESPACE;
 
 function copy(src,dest){
@@ -6,6 +7,7 @@ function copy(src,dest){
 		dest[p] = src[p];
 	}
 }
+
 /**
 ^\w+\.prototype\.([_\w]+)\s*=\s*((?:.*\{\s*?[\r\n][\s\S]*?^})|\S.*?(?=[;\r\n]));?
 ^\w+\.prototype\.([_\w]+)\s*=\s*(\S.*?(?=[;\r\n]));?
@@ -26,6 +28,7 @@ function _extends(Class,Super){
 		pt.constructor = Class
 	}
 }
+
 // Node Types
 var NodeType = {}
 var ELEMENT_NODE                = NodeType.ELEMENT_NODE                = 1;
@@ -82,6 +85,7 @@ function DOMException(code, message) {
 };
 DOMException.prototype = Error.prototype;
 copy(ExceptionCode,DOMException)
+
 /**
  * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177
  * The NodeList interface provides the abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented. NodeList objects in the DOM are live.
@@ -113,6 +117,7 @@ NodeList.prototype = {
 		return buf.join('');
 	}
 };
+
 function LiveNodeList(node,refresh){
 	this._node = node;
 	this._refresh = refresh
@@ -134,6 +139,7 @@ LiveNodeList.prototype.item = function(i){
 }
 
 _extends(LiveNodeList,NodeList);
+
 /**
  * Objects implementing the NamedNodeMap interface are used
  * to represent collections of nodes that can be accessed by name.
@@ -441,6 +447,7 @@ function _visitNode(node,callback){
 
 function Document(){
 }
+
 function _onAddAttribute(doc,el,newAttr){
 	doc && doc._inc++;
 	var ns = newAttr.namespaceURI ;
@@ -449,6 +456,7 @@ function _onAddAttribute(doc,el,newAttr){
 		el._nsMap[newAttr.prefix?newAttr.localName:''] = newAttr.value
 	}
 }
+
 function _onRemoveAttribute(doc,el,newAttr,remove){
 	doc && doc._inc++;
 	var ns = newAttr.namespaceURI ;
@@ -457,6 +465,7 @@ function _onRemoveAttribute(doc,el,newAttr,remove){
 		delete el._nsMap[newAttr.prefix?newAttr.localName:'']
 	}
 }
+
 function _onUpdateChild(doc,el,newChild){
 	if(doc && doc._inc){
 		doc._inc++;
@@ -973,6 +982,7 @@ function needNamespaceDefine(node,isHTML, visibleNamespaces) {
 	}
 	return true;
 }
+
 function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 	if(nodeFilter){
 		node = nodeFilter(node);
@@ -986,6 +996,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		}
 		//buf.sort.apply(attrs, attributeSorter);
 	}
+
 	switch(node.nodeType){
 	case ELEMENT_NODE:
 		if (!visibleNamespaces) visibleNamespaces = [];
@@ -1007,6 +1018,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 				visibleNamespaces.push({ prefix: '', namespace: attr.value });
 			}
 		}
+
 		for(var i=0;i<len;i++){
 			var attr = attrs.item(i);
 			if (needNamespaceDefine(attr,isHTML, visibleNamespaces)) {
@@ -1018,6 +1030,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 			}
 			serializeToString(attr,buf,isHTML,nodeFilter,visibleNamespaces);
 		}
+
 		// add namespace for current node		
 		if (needNamespaceDefine(node,isHTML, visibleNamespaces)) {
 			var prefix = node.prefix||'';
@@ -1224,10 +1237,12 @@ try{
 				return this.$$length;
 			}
 		});
+
 		Object.defineProperty(Node.prototype,'textContent',{
 			get:function(){
 				return getTextContent(this);
 			},
+
 			set:function(data){
 				switch(this.nodeType){
 				case ELEMENT_NODE:
@@ -1239,6 +1254,7 @@ try{
 						this.appendChild(this.ownerDocument.createTextNode(data));
 					}
 					break;
+
 				default:
 					this.data = data;
 					this.value = data;
@@ -1264,6 +1280,7 @@ try{
 				return node.nodeValue;
 			}
 		}
+
 		__set__ = function(object,key,value){
 			//console.log(value)
 			object['$$'+key] = value

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -952,13 +952,14 @@ function nodeSerializeToString(isHtml,nodeFilter){
 	//console.log('###',this.nodeType,uri,prefix,buf.join(''))
 	return buf.join('');
 }
+
 function needNamespaceDefine(node,isHTML, visibleNamespaces) {
 	var prefix = node.prefix||'';
 	var uri = node.namespaceURI;
 	if (!prefix && !uri){
 		return false;
 	}
-	if (prefix === "xml" && uri === NAMESPACE.XML || uri === NAMESPACE.XMLNS){
+	if (prefix === "xml" && uri === NAMESPACE.XML || uri === NAMESPACE.XMLNS) {
 		return false;
 	}
 	

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -996,9 +996,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		
 		isHTML = NAMESPACE.isHTML(node.namespaceURI) || isHTML
 		buf.push('<',nodeName);
-		
-		
-		
+
 		for(var i=0;i<len;i++){
 			// add namespaces for attributes
 			var attr = attrs.item(i);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,3 +1,6 @@
+var conventions = require("./conventions");
+var NAMESPACE = conventions.NAMESPACE;
+
 function copy(src,dest){
 	for(var p in src){
 		dest[p] = src[p];
@@ -23,7 +26,6 @@ function _extends(Class,Super){
 		pt.constructor = Class
 	}
 }
-var htmlns = 'http://www.w3.org/1999/xhtml' ;
 // Node Types
 var NodeType = {}
 var ELEMENT_NODE                = NodeType.ELEMENT_NODE                = 1;
@@ -133,8 +135,13 @@ LiveNodeList.prototype.item = function(i){
 
 _extends(LiveNodeList,NodeList);
 /**
- * 
- * Objects implementing the NamedNodeMap interface are used to represent collections of nodes that can be accessed by name. Note that NamedNodeMap does not inherit from NodeList; NamedNodeMaps are not maintained in any particular order. Objects contained in an object implementing NamedNodeMap may also be accessed by an ordinal index, but this is simply to allow convenient enumeration of the contents of a NamedNodeMap, and does not imply that the DOM specifies an order to these Nodes.
+ * Objects implementing the NamedNodeMap interface are used
+ * to represent collections of nodes that can be accessed by name.
+ * Note that NamedNodeMap does not inherit from NodeList;
+ * NamedNodeMaps are not maintained in any particular order.
+ * Objects contained in an object implementing NamedNodeMap may also be accessed by an ordinal index,
+ * but this is simply to allow convenient enumeration of the contents of a NamedNodeMap,
+ * and does not imply that the DOM specifies an order to these Nodes.
  * NamedNodeMap objects in the DOM are live.
  * used for attributes or DocumentType entities 
  */
@@ -437,7 +444,7 @@ function Document(){
 function _onAddAttribute(doc,el,newAttr){
 	doc && doc._inc++;
 	var ns = newAttr.namespaceURI ;
-	if(ns == 'http://www.w3.org/2000/xmlns/'){
+	if(ns === NAMESPACE.XMLNS){
 		//update namespace
 		el._nsMap[newAttr.prefix?newAttr.localName:''] = newAttr.value
 	}
@@ -445,7 +452,7 @@ function _onAddAttribute(doc,el,newAttr){
 function _onRemoveAttribute(doc,el,newAttr,remove){
 	doc && doc._inc++;
 	var ns = newAttr.namespaceURI ;
-	if(ns == 'http://www.w3.org/2000/xmlns/'){
+	if(ns === NAMESPACE.XMLNS){
 		//update namespace
 		delete el._nsMap[newAttr.prefix?newAttr.localName:'']
 	}
@@ -950,27 +957,18 @@ function needNamespaceDefine(node,isHTML, visibleNamespaces) {
 	if (!prefix && !uri){
 		return false;
 	}
-	if (prefix === "xml" && uri === "http://www.w3.org/XML/1998/namespace" 
-		|| uri == 'http://www.w3.org/2000/xmlns/'){
+	if (prefix === "xml" && uri === NAMESPACE.XML || uri === NAMESPACE.XMLNS){
 		return false;
 	}
 	
 	var i = visibleNamespaces.length 
-	//console.log('@@@@',node.tagName,prefix,uri,visibleNamespaces)
 	while (i--) {
 		var ns = visibleNamespaces[i];
 		// get namespace prefix
-		//console.log(node.nodeType,node.tagName,ns.prefix,prefix)
 		if (ns.prefix == prefix){
 			return ns.namespace != uri;
 		}
 	}
-	//console.log(isHTML,uri,prefix=='')
-	//if(isHTML && prefix ==null && uri == 'http://www.w3.org/1999/xhtml'){
-	//	return false;
-	//}
-	//node.flag = '11111'
-	//console.error(3,true,node.flag,node.prefix,node.namespaceURI)
 	return true;
 }
 function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
@@ -995,7 +993,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		var child = node.firstChild;
 		var nodeName = node.tagName;
 		
-		isHTML =  (htmlns === node.namespaceURI) ||isHTML 
+		isHTML = NAMESPACE.isHTML(node.namespaceURI) || isHTML
 		buf.push('<',nodeName);
 		
 		
@@ -1242,7 +1240,6 @@ try{
 					}
 					break;
 				default:
-					//TODO:
 					this.data = data;
 					this.value = data;
 					this.nodeValue = data;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -1,4 +1,28 @@
-exports.entityMap = {
+var freeze = require('./conventions').freeze;
+
+/**
+ * The entities that are predefined in every XML document.
+ *
+ * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-predefined-ent W3C XML 1.1
+ * @see https://www.w3.org/TR/2008/REC-xml-20081126/#sec-predefined-ent W3C XML 1.0
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML Wikipedia
+ */
+exports.XML_ENTITIES = freeze({amp:'&', apos:"'", gt:'>', lt:'<', quot:'"'})
+
+/**
+ * A map of currently 241 entities that are detected in an HTML document.
+ * They contain all entries from `XML_ENTITIES`.
+ *
+ * @see XML_ENTITIES
+ * @see DOMParser.parseFromString
+ * @see DOMImplementation.prototype.createHTMLDocument
+ * @see https://html.spec.whatwg.org/#named-character-references WHATWG HTML(5) Spec
+ * @see https://www.w3.org/TR/xml-entity-names/ W3C XML Entity Names
+ * @see https://www.w3.org/TR/html4/sgml/entities.html W3C HTML4/SGML
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Character_entity_references_in_HTML Wikipedia (HTML)
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Entities_representing_special_characters_in_XHTML Wikpedia (XHTML)
+ */
+exports.HTML_ENTITIES = freeze({
        lt: '<',
        gt: '>',
        amp: '&',
@@ -240,4 +264,9 @@ exports.entityMap = {
        clubs: "♣",
        hearts: "♥",
        diams: "♦"
-};
+});
+/**
+ * @deprecated use `HTML_ENTITIES` instead
+ * @see HTML_ENTITIES
+ */
+exports.entityMap = exports.HTML_ENTITIES

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -265,6 +265,7 @@ exports.HTML_ENTITIES = freeze({
        hearts: "♥",
        diams: "♦"
 });
+
 /**
  * @deprecated use `HTML_ENTITIES` instead
  * @see HTML_ENTITIES

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1,3 +1,5 @@
+var NAMESPACE = require("./conventions").NAMESPACE;
+
 //[4]   	NameStartChar	   ::=   	":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
 //[4a]   	NameChar	   ::=   	NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
 //[5]   	Name	   ::=   	NameStartChar (NameChar)*
@@ -191,7 +193,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 				
 				
 				
-				if(el.uri === 'http://www.w3.org/1999/xhtml' && !el.closed){
+				if(NAMESPACE.isHTML(el.uri) && !el.closed){
 					end = parseHtmlSpecialContent(source,end,el.tagName,entityReplacer,domBuilder)
 				}else{
 					end++;
@@ -329,7 +331,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 					errorHandler.warning('attribute "'+value+'" missed quot(")!');
 					addAttribute(attrName, value.replace(/&#?\w+;/g,entityReplacer), start)
 				}else{
-					if(currentNSMap[''] !== 'http://www.w3.org/1999/xhtml' || !value.match(/^(?:disabled|checked|selected)$/i)){
+					if(!NAMESPACE.isHTML(currentNSMap['']) || !value.match(/^(?:disabled|checked|selected)$/i)){
 						errorHandler.warning('attribute "'+value+'" missed value!! "'+value+'" instead!!')
 					}
 					addAttribute(value, value, start)
@@ -377,7 +379,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 				//case S_ATTR_NOQUOT_VALUE:void();break;
 				case S_ATTR_SPACE:
 					var tagName =  el.tagName;
-					if(currentNSMap[''] !== 'http://www.w3.org/1999/xhtml' || !attrName.match(/^(?:disabled|checked|selected)$/i)){
+					if(!NAMESPACE.isHTML(currentNSMap['']) || !attrName.match(/^(?:disabled|checked|selected)$/i)){
 						errorHandler.warning('attribute "'+attrName+'" missed value!! "'+attrName+'" instead2!!')
 					}
 					addAttribute(attrName, attrName, start);
@@ -436,7 +438,7 @@ function appendElement(el,domBuilder,currentNSMap){
 				//console.log(currentNSMap,1)
 			}
 			currentNSMap[nsPrefix] = localNSMap[nsPrefix] = value;
-			a.uri = 'http://www.w3.org/2000/xmlns/'
+			a.uri = NAMESPACE.XMLNS
 			domBuilder.startPrefixMapping(nsPrefix, value) 
 		}
 	}
@@ -446,7 +448,7 @@ function appendElement(el,domBuilder,currentNSMap){
 		var prefix = a.prefix;
 		if(prefix){//no prefix attribute has no namespace
 			if(prefix === 'xml'){
-				a.uri = 'http://www.w3.org/XML/1998/namespace';
+				a.uri = NAMESPACE.XML;
 			}if(prefix !== 'xmlns'){
 				a.uri = currentNSMap[prefix || '']
 				

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -191,9 +191,9 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 					}
 				}
 
-				if(NAMESPACE.isHTML(el.uri) && !el.closed){
+				if (NAMESPACE.isHTML(el.uri) && !el.closed) {
 					end = parseHtmlSpecialContent(source,end,el.tagName,entityReplacer,domBuilder)
-				}else{
+				} else {
 					end++;
 				}
 			}
@@ -377,7 +377,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 				//case S_ATTR_NOQUOT_VALUE:void();break;
 				case S_ATTR_SPACE:
 					var tagName =  el.tagName;
-					if(!NAMESPACE.isHTML(currentNSMap['']) || !attrName.match(/^(?:disabled|checked|selected)$/i)){
+					if (!NAMESPACE.isHTML(currentNSMap['']) || !attrName.match(/^(?:disabled|checked|selected)$/i)) {
 						errorHandler.warning('attribute "'+attrName+'" missed value!! "'+attrName+'" instead2!!')
 					}
 					addAttribute(attrName, attrName, start);

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -190,9 +190,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 						parseStack.push(el)
 					}
 				}
-				
-				
-				
+
 				if(NAMESPACE.isHTML(el.uri) && !el.closed){
 					end = parseHtmlSpecialContent(source,end,el.tagName,entityReplacer,domBuilder)
 				}else{

--- a/test/conventions/__snapshots__/mime-type.test.js.snap
+++ b/test/conventions/__snapshots__/mime-type.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MIME_TYPE should contain immutable HTML with correct value 1`] = `
+Array [
+  "HTML",
+  "text/html",
+]
+`;
+
+exports[`MIME_TYPE should contain immutable XML_APPLICATION with correct value 1`] = `
+Array [
+  "XML_APPLICATION",
+  "application/xml",
+]
+`;
+
+exports[`MIME_TYPE should contain immutable XML_SVG_IMAGE with correct value 1`] = `
+Array [
+  "XML_SVG_IMAGE",
+  "image/svg+xml",
+]
+`;
+
+exports[`MIME_TYPE should contain immutable XML_TEXT with correct value 1`] = `
+Array [
+  "XML_TEXT",
+  "text/xml",
+]
+`;
+
+exports[`MIME_TYPE should contain immutable XML_XHTML_APPLICATION with correct value 1`] = `
+Array [
+  "XML_XHTML_APPLICATION",
+  "application/xhtml+xml",
+]
+`;

--- a/test/conventions/__snapshots__/namespace.test.js.snap
+++ b/test/conventions/__snapshots__/namespace.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NAMESPACE should contain immutable HTML with correct value 1`] = `
+Array [
+  "HTML",
+  "http://www.w3.org/1999/xhtml",
+]
+`;
+
+exports[`NAMESPACE should contain immutable SVG with correct value 1`] = `
+Array [
+  "SVG",
+  "http://www.w3.org/2000/svg",
+]
+`;
+
+exports[`NAMESPACE should contain immutable XML with correct value 1`] = `
+Array [
+  "XML",
+  "http://www.w3.org/XML/1998/namespace",
+]
+`;
+
+exports[`NAMESPACE should contain immutable XMLNS with correct value 1`] = `
+Array [
+  "XMLNS",
+  "http://www.w3.org/2000/xmlns/",
+]
+`;

--- a/test/conventions/freeze.test.js
+++ b/test/conventions/freeze.test.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { freeze } = require('../../lib/conventions')
+
+describe('freeze', () => {
+	it('should return the frozen object (works in node)', () => {
+		const input = { k: 'v' }
+		const actual = freeze(input)
+		expect(actual).toBe(input)
+
+		try {
+			actual.k = 0
+			actual.a = 'b'
+			delete actual.k
+		} catch {
+			// Nothing can be added to or removed from the properties set of a frozen object.
+			// Any attempt to do so will fail, either silently or by throwing a TypeError exception
+			// (most commonly, but not exclusively, when in strict mode).
+		}
+		expect(actual).toEqual(input)
+	})
+	it('should return `input` if `Object.freeze` is not available', () => {
+		const input = { k: 'v' }
+		const actual = freeze(input, {})
+		expect(actual).toBe(input)
+	})
+	it('should return input if Object is not available', () => {
+		const input = { k: 'v' }
+		const actual = freeze(input, null)
+		expect(actual).toBe(input)
+	})
+	it('should use the custom ObjectConstructor correctly', () => {
+		const input = { k: 'v' }
+		const frozen = { ...input }
+		const freezeStub = jest.fn(() => frozen)
+		const actual = freeze(input, { freeze: freezeStub })
+		expect(freezeStub).toHaveBeenCalledWith(input)
+		expect(actual).toBe(frozen)
+	})
+})

--- a/test/conventions/mime-type.test.js
+++ b/test/conventions/mime-type.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const { MIME_TYPE } = require('../../lib/conventions')
+
+describe('MIME_TYPE', () => {
+	Object.keys(MIME_TYPE).forEach((key) => {
+		if (key === 'isHTML') {
+			describe('isHTML', () => {
+				it("should return true for 'text/html'", () => {
+					expect(MIME_TYPE.isHTML('text/html')).toBe(true)
+				})
+				it('should return true for MIME_TYPE.HTML', () => {
+					expect(MIME_TYPE.isHTML(MIME_TYPE.HTML)).toBe(true)
+				})
+				it.each([
+					undefined,
+					null,
+					0,
+					1,
+					false,
+					true,
+					'',
+					MIME_TYPE.XML_XHTML_APPLICATION,
+				])("should return false for '%s'", (value) => {
+					expect(MIME_TYPE.isHTML(value)).toBe(false)
+				})
+			})
+		} else {
+			const value = MIME_TYPE[key]
+			it(`should contain immutable ${key} with correct value`, () => {
+				expect([key, value]).toMatchSnapshot()
+				try {
+					MIME_TYPE[key] = 'boo'
+				} catch {}
+				expect(MIME_TYPE[key]).toBe(value)
+			})
+		}
+	})
+})

--- a/test/conventions/namespace.test.js
+++ b/test/conventions/namespace.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { NAMESPACE } = require('../../lib/conventions')
+
+describe('NAMESPACE', () => {
+	Object.keys(NAMESPACE).forEach((key) => {
+		if (key === 'isHTML') {
+			describe('isHTML', () => {
+				it('should return true for NAMESPACE.HTML', () => {
+					expect(NAMESPACE.isHTML(NAMESPACE.HTML)).toBe(true)
+				})
+				it("should return true for 'http://www.w3.org/1999/xhtml'", () => {
+					expect(NAMESPACE.isHTML('http://www.w3.org/1999/xhtml')).toBe(true)
+				})
+				it.each([undefined, null, 0, 1, false, true, '', NAMESPACE.XML])(
+					"should return false for '%s'",
+					(value) => {
+						expect(NAMESPACE.isHTML(value)).toBe(false)
+					}
+				)
+			})
+		} else {
+			const value = NAMESPACE[key]
+			it(`should contain immutable ${key} with correct value`, () => {
+				expect([key, value]).toMatchSnapshot()
+				try {
+					NAMESPACE[key] = 'boo'
+				} catch {}
+				expect(NAMESPACE[key]).toBe(value)
+			})
+		}
+	})
+})


### PR DESCRIPTION
Before starting to work on fixing #203, where namespaces and mime types are going to be used in multiple places, I decided to gather them in a separate module.

**conventions.js**
- `freeze`: is a small wrapper around `Object.freeze`, that gives type hints
  and also "works" if `Object.freeze` should not be available at runtime
- `MIME_TYPE`: has all mime types that are supported by `DOMParser.parseFromString` (second argument)
- `MIME_TYPE.isHTML`: short way to check if a mime type is the only one that enables HTML parsing
- `NAMESPACE`: has all namespaces that we are currently using in the code base
- `NAMESPACE.isHTML`: to check if a given value is the XHTML namespace

**entities.js**
- deprecated `entityMap` (but it's still available as an alias to `HTML_ENTITIES`)
- `HTML_ENTITIES`: new name for `entityMap`, is now immutable
- `XML_ENTITIES`: immutable map for the predefined XML entities