### PR TITLE
fix(dom): Implement `getElementsByClassName` as specified

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -675,6 +675,19 @@ Document.prototype = {
 		return rtv;
 	},
 	
+	/**
+	 * The `getElementsByClassName` method of `Document` interface returns an array-like object 
+	 * of all child elements which have **all** of the given class name(s).
+	 * 
+	 * Warning: This is a live LiveNodeList.
+	 * Changes in the DOM will reflect in the array as the changes occur.
+	 * If an element selected by this array no longer qualifies for the selector,
+	 * it will automatically be removed. Be aware of this for iteration purposes.
+	 *
+	 * @param {string} classNames is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
+	 */
 	getElementsByClassName: function(classNames) {
 		var spaceSeparatedTokens = function(string) {
 			// 5 space characters, as defined in html spec

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -22,6 +22,19 @@ function splitOnASCIIWhitespace(input) {
 	return input.split(/[\t\n\f\r ]+/).filter(notEmptyString)
 }
 
+/**
+ * Uses `list.indexOf` to implement something like `Array.prototype.includes`,
+ * which we can not rely on being available.
+ *
+ * @param {any[]} list
+ * @returns {function(any): boolean}
+ */
+function arrayIncludes (list) {
+	return function(element) {
+		return list && list.indexOf(element) !== -1;
+	}
+}
+
 function copy(src,dest){
 	for(var p in src){
 		dest[p] = src[p];
@@ -726,9 +739,7 @@ Document.prototype = {
 							var matches = classNames === classActual;
 							if (!matches) {
 								var namesActual = splitOnASCIIWhitespace(classActual)
-								matches = namesTarget.every(function(name) {
-									return namesActual.indexOf(name) !== -1
-								})
+								matches = namesTarget.every(arrayIncludes(namesActual))
 							}
 							if(matches) {
 								ls.push(node);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -706,13 +706,19 @@ Document.prototype = {
 				_visitNode(base.documentElement, function(node) {
 					if(node !== base && node.nodeType == ELEMENT_NODE) {
 						var classActual = node.getAttribute('class')
-						if (classActual) { // don't match '' for ''
-							var namesActual = spaceSeparatedTokens(classActual)
-							var matches = namesTarget.every(function(name) {
-								return namesActual.indexOf(name) !== -1
-							})
-							if(matches) {
+						// can be null if the attribute does not exist
+						if (classActual) {
+							// before splitting and iterating just compare them for the most common case
+							if (classNames === classActual) {
 								ls.push(node);
+							} else {
+								var namesActual = spaceSeparatedTokens(classActual)
+								var matches = namesTarget.every(function(name) {
+									return namesActual.indexOf(name) !== -1
+								})
+								if(matches) {
+									ls.push(node);
+								}
 							}
 						}
 					}

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -675,14 +675,27 @@ Document.prototype = {
 		return rtv;
 	},
 	
-	getElementsByClassName: function(className) {
-		var pattern = new RegExp("(^|\\s)" + className + "(\\s|$)");
+	getElementsByClassName: function(classNames) {
+		var spaceSeparatedTokens = function(string) {
+			// 5 space characters, as defined in html spec
+			return string.split(/[ \t\n\f\r]+/).filter(function(name) {
+				return name !== ''
+			})
+		}
+		var namesTarget = spaceSeparatedTokens(classNames)
 		return new LiveNodeList(this, function(base) {
 			var ls = [];
 			_visitNode(base.documentElement, function(node) {
 				if(node !== base && node.nodeType == ELEMENT_NODE) {
-					if(pattern.test(node.getAttribute('class'))) {
-						ls.push(node);
+					var classActual = node.getAttribute('class')
+					if (classActual && namesTarget.length > 0) { // don't match '' for ''
+						var namesActual = spaceSeparatedTokens(classActual)
+						var matches = namesTarget.every(function(name) {
+							return namesActual.indexOf(name) !== -1
+						})
+						if(matches) {
+							ls.push(node);
+						}
 					}
 				}
 			});

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2,6 +2,26 @@ var conventions = require("./conventions");
 
 var NAMESPACE = conventions.NAMESPACE;
 
+/**
+ * A prerequisite for `[].filter`, to drop elements that are empty
+ * @param {string} input
+ * @returns {boolean}
+ */
+function notEmptyString (input) {
+	return input !== ''
+}
+/**
+ * @see https://infra.spec.whatwg.org/#split-on-ascii-whitespace
+ * @see https://infra.spec.whatwg.org/#ascii-whitespace
+ *
+ * @param {string} input
+ * @returns {string[]} (can be empty)
+ */
+function splitOnASCIIWhitespace(input) {
+	// U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, U+0020 SPACE
+	return input.split(/[\t\n\f\r ]+/).filter(notEmptyString)
+}
+
 function copy(src,dest){
 	for(var p in src){
 		dest[p] = src[p];
@@ -693,25 +713,19 @@ Document.prototype = {
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */
 	getElementsByClassName: function(classNames) {
-		var spaceSeparatedTokens = function(string) {
-			// 5 space characters, as defined in html spec
-			return string.split(/[ \f\n\r\t]+/).filter(function(name) {
-				return name !== ''
-			})
-		}
-		var namesTarget = spaceSeparatedTokens(classNames)
+		var namesTarget = splitOnASCIIWhitespace(classNames)
 		return new LiveNodeList(this, function(base) {
 			var ls = [];
 			if (namesTarget.length > 0) {
 				_visitNode(base.documentElement, function(node) {
-					if(node !== base && node.nodeType == ELEMENT_NODE) {
+					if(node !== base && node.nodeType === ELEMENT_NODE) {
 						var classActual = node.getAttribute('class')
 						// can be null if the attribute does not exist
 						if (classActual) {
 							// before splitting and iterating just compare them for the most common case
 							var matches = classNames === classActual;
 							if (!matches) {
-								var namesActual = spaceSeparatedTokens(classActual)
+								var namesActual = splitOnASCIIWhitespace(classActual)
 								matches = namesTarget.every(function(name) {
 									return namesActual.indexOf(name) !== -1
 								})

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -709,16 +709,15 @@ Document.prototype = {
 						// can be null if the attribute does not exist
 						if (classActual) {
 							// before splitting and iterating just compare them for the most common case
-							if (classNames === classActual) {
-								ls.push(node);
-							} else {
+							var matches = classNames === classActual;
+							if (!matches) {
 								var namesActual = spaceSeparatedTokens(classActual)
-								var matches = namesTarget.every(function(name) {
+								matches = namesTarget.every(function(name) {
 									return namesActual.indexOf(name) !== -1
 								})
-								if(matches) {
-									ls.push(node);
-								}
+							}
+							if(matches) {
+								ls.push(node);
 							}
 						}
 					}

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -634,8 +634,8 @@ Document.prototype = {
 	doctype :  null,
 	documentElement :  null,
 	_inc : 1,
-	
-	insertBefore :  function(newChild, refChild){//raises 
+
+	insertBefore :  function(newChild, refChild){//raises
 		if(newChild.nodeType == DOCUMENT_FRAGMENT_NODE){
 			var child = newChild.firstChild;
 			while(child){
@@ -648,7 +648,7 @@ Document.prototype = {
 		if(this.documentElement == null && newChild.nodeType == ELEMENT_NODE){
 			this.documentElement = newChild;
 		}
-		
+
 		return _insertBefore(this,newChild,refChild),(newChild.ownerDocument = this),newChild;
 	},
 	removeChild :  function(oldChild){
@@ -674,11 +674,14 @@ Document.prototype = {
 		})
 		return rtv;
 	},
-	
+
 	/**
-	 * The `getElementsByClassName` method of `Document` interface returns an array-like object 
+	 * The `getElementsByClassName` method of `Document` interface returns an array-like object
 	 * of all child elements which have **all** of the given class name(s).
-	 * 
+	 *
+	 * Returns an empty list if `classeNames` is an empty string or only contains HTML white space characters.
+	 *
+	 *
 	 * Warning: This is a live LiveNodeList.
 	 * Changes in the DOM will reflect in the array as the changes occur.
 	 * If an element selected by this array no longer qualifies for the selector,
@@ -687,35 +690,38 @@ Document.prototype = {
 	 * @param {string} classNames is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
+	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */
 	getElementsByClassName: function(classNames) {
 		var spaceSeparatedTokens = function(string) {
 			// 5 space characters, as defined in html spec
-			return string.split(/[ \t\n\f\r]+/).filter(function(name) {
+			return string.split(/[ \f\n\r\t]+/).filter(function(name) {
 				return name !== ''
 			})
 		}
 		var namesTarget = spaceSeparatedTokens(classNames)
 		return new LiveNodeList(this, function(base) {
 			var ls = [];
-			_visitNode(base.documentElement, function(node) {
-				if(node !== base && node.nodeType == ELEMENT_NODE) {
-					var classActual = node.getAttribute('class')
-					if (classActual && namesTarget.length > 0) { // don't match '' for ''
-						var namesActual = spaceSeparatedTokens(classActual)
-						var matches = namesTarget.every(function(name) {
-							return namesActual.indexOf(name) !== -1
-						})
-						if(matches) {
-							ls.push(node);
+			if (namesTarget.length > 0) {
+				_visitNode(base.documentElement, function(node) {
+					if(node !== base && node.nodeType == ELEMENT_NODE) {
+						var classActual = node.getAttribute('class')
+						if (classActual) { // don't match '' for ''
+							var namesActual = spaceSeparatedTokens(classActual)
+							var matches = namesTarget.every(function(name) {
+								return namesActual.indexOf(name) !== -1
+							})
+							if(matches) {
+								ls.push(node);
+							}
 						}
 					}
-				}
-			});
+				});
+			}
 			return ls;
 		});
 	},
-	
+
 	//document factory method:
 	createElement :	function(tagName){
 		var node = new Element();

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -19,7 +19,32 @@ function notEmptyString (input) {
  */
 function splitOnASCIIWhitespace(input) {
 	// U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, U+0020 SPACE
-	return input.split(/[\t\n\f\r ]+/).filter(notEmptyString)
+	return input ? input.split(/[\t\n\f\r ]+/).filter(notEmptyString) : []
+}
+
+/**
+ * Adds element as a key to current if it is not already present.
+ *
+ * @param {Record<string, boolean | undefined>} current
+ * @param {string} element
+ * @returns {Record<string, boolean | undefined>}
+ */
+function orderedSetReducer (current, element) {
+	if (!current.hasOwnProperty(element)) {
+		current[element] = true;
+	}
+	return current;
+}
+
+/**
+ * @see https://infra.spec.whatwg.org/#ordered-set
+ * @param {string} input
+ * @returns {string[]}
+ */
+function toOrderedSet(input) {
+	if (!input) return [];
+	var list = splitOnASCIIWhitespace(input);
+	return Object.keys(list.reduce(orderedSetReducer, {}))
 }
 
 /**
@@ -726,20 +751,20 @@ Document.prototype = {
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */
 	getElementsByClassName: function(classNames) {
-		var namesTarget = splitOnASCIIWhitespace(classNames)
+		var classNamesSet = toOrderedSet(classNames)
 		return new LiveNodeList(this, function(base) {
 			var ls = [];
-			if (namesTarget.length > 0) {
+			if (classNamesSet.length > 0) {
 				_visitNode(base.documentElement, function(node) {
 					if(node !== base && node.nodeType === ELEMENT_NODE) {
-						var classActual = node.getAttribute('class')
+						var nodeClassNames = node.getAttribute('class')
 						// can be null if the attribute does not exist
-						if (classActual) {
+						if (nodeClassNames) {
 							// before splitting and iterating just compare them for the most common case
-							var matches = classNames === classActual;
+							var matches = classNames === nodeClassNames;
 							if (!matches) {
-								var namesActual = splitOnASCIIWhitespace(classActual)
-								matches = namesTarget.every(arrayIncludes(namesActual))
+								var nodeClassNamesSet = toOrderedSet(nodeClassNames)
+								matches = classNamesSet.every(arrayIncludes(nodeClassNamesSet))
 							}
 							if(matches) {
 								ls.push(node);

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -66,7 +66,7 @@ describe('Document.prototype', () => {
 			const MIXED_CASES = ['AAA', 'AAa', 'AaA', 'aAA']
 			const doc = getTestParser().parser.parseFromString(INPUT(...MIXED_CASES))
 
-			MIXED_CASES.forEach(className => {
+			MIXED_CASES.forEach((className) => {
 				expect(doc.getElementsByClassName(className)).toHaveLength(1)
 			})
 		})

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const { getTestParser } = require('../get-test-parser')
+
+const INPUT = (first = '', second = '', third = '', fourth = '') => `
+<html >
+	<body id="body">
+		<p id="p1" class=" quote first   odd ${first} ">Lorem ipsum</p>
+		<p id="p2" class=" quote second  even ${second} ">Lorem ipsum</p>
+		<p id="p3" class=" quote third   odd ${third} ">Lorem ipsum</p>
+		<p id="p4" class=" quote fourth  even ${fourth} ">Lorem ipsum</p>
+	</body>
+</html>
+`
+
+const NON_HTML_WHITESPACE =
+	'\v\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000\ufeff'
+
+describe('Document.prototype', () => {
+	describe('getElementsByClassName', () => {
+		it('should be able to resolve [] as a class name', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT('[]'))
+			expect(doc.getElementsByClassName('[]')).toHaveLength(1)
+		})
+		it('should be able to resolve [ as a class name', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT('['))
+			expect(doc.getElementsByClassName('[')).toHaveLength(1)
+		})
+		it('should be able to resolve multiple class names in a different order', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT())
+			expect(doc.getElementsByClassName('odd quote')).toHaveLength(2)
+		})
+		it('should be able to resolve non html whitespace as classname', () => {
+			const doc = getTestParser().parser.parseFromString(
+				INPUT(NON_HTML_WHITESPACE)
+			)
+
+			expect(
+				doc.getElementsByClassName(`quote ${NON_HTML_WHITESPACE}`)
+			).toHaveLength(1)
+		})
+		it('should not allow regular expression in argument', () => {
+			const search = '(((a||||)+)+)+'
+			const matching = 'aaaaa'
+			expect(new RegExp(search).test(matching)).toBe(true)
+
+			const doc = getTestParser().parser.parseFromString(
+				INPUT(search, matching, search)
+			)
+
+			expect(doc.getElementsByClassName(search)).toHaveLength(2)
+		})
+		it('should return an empty collection when no class names or are passed', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT())
+
+			expect(doc.getElementsByClassName('')).toHaveLength(0)
+		})
+		it('should return an empty collection when only spaces are passed', () => {
+			const doc = getTestParser().parser.parseFromString(
+				INPUT(' \f\n\r\t', ' \f\n\r\t', ' \f\n\r\t', ' \f\n\r\t')
+			)
+
+			expect(doc.getElementsByClassName(' \f\n\r\t')).toHaveLength(0)
+		})
+		it('should return only the case insensitive matching names', () => {
+			const MIXED_CASES = ['AAA', 'AAa', 'AaA', 'aAA']
+			const doc = getTestParser().parser.parseFromString(INPUT(...MIXED_CASES))
+
+			MIXED_CASES.forEach(className => {
+				expect(doc.getElementsByClassName(className)).toHaveLength(1)
+			})
+		})
+	})
+})


### PR DESCRIPTION
Reimplements `Document.getElementsByClassName` without using a dynamically generated regex.

1. Unlike _CSS grammar_, there seems to be no limitation on which classnames are valid in HTML/DOM (given that they don't contain space chars). That is, `[` seems to be a valid classname, which was broken in this impl as it was fed into a regexp unescaped and caused `xmldom` to throw.
2. Whitespace processing should be now correct. `\s` in JS regexps includes more chars than [space-separated tokens](https://www.w3.org/TR/html52/infrastructure.html#set-of-space-separated-tokens) of html.
3. This now should support a list of space-separated classnames as an argument. Previously, that was broken and order-dependent.
4. This prevents causing a ReDoS by passing in exponential regexps as strings to `getElementsByClassName()` method,
    e.g. `new RegExp("(^|\\s)" + '(((a||||)+)+)+' + "(\\s|$)").test('aaaaab')`.

Refs:
1. https://dom.spec.whatwg.org/#dom-document-getelementsbyclassname
2. https://dom.spec.whatwg.org/#dom-element-getelementsbyclassname
3. https://dom.spec.whatwg.org/#concept-getelementsbyclassname
4. https://www.w3.org/TR/html52/dom.html#element-attrdef-global-class
5. https://www.w3.org/TR/html52/infrastructure.html#set-of-space-separated-tokens
6. https://github.com/xmldom/xmldom/issues/24
7. https://github.com/xmldom/xmldom/pull/25

Note: I couldn't find the tests for this and am unsure how to test this. cc @codler perhaps — could you confirm this would work?
Seems to work for me with simple playground tests.