### PR TITLE
chore(renovate): Disable for (minimum) node version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,12 @@
   "commitMessageExtra": "-> {{#if isMajor}}{{{newMajor}}}{{else}}{{#if isSingleVersion}}{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}} - {{depType}}",
   "commitMessageTopic": "{{depName}}",
   "prHourlyLimit": 0,
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "packageRules": [
+    {
+      "$comment": "We will only ever update the major version of node when we can no longer support it. Which will be a breaking change.",
+      "packageNames": ["node"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
As discussed in #212:

> I would favor that we turn these Node.js updates off, as I would consider this kind of an update to be a BREAKING CHANGE. I have not found the documentation how to turn these Node.js updates off.

After this lands I want to verify the configuration by checking the "Retry/rebase" checkbox in #212 and expect that that PR will be auto-closed by renovate.