### PR TITLE
fix: Set `localName` as part of `Document.createElement`

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -627,6 +627,7 @@ Document.prototype = {
 		node.ownerDocument = this;
 		node.nodeName = tagName;
 		node.tagName = tagName;
+		node.localName = tagName;
 		node.childNodes = new NodeList();
 		var attrs	= node.attributes = new NamedNodeMap();
 		attrs._ownerElement = node;

--- a/test/dom/element.test.js
+++ b/test/dom/element.test.js
@@ -6,49 +6,50 @@ const {
 	XMLSerializer,
 } = require('../../lib/dom-parser')
 
-// Create a Test Suite
-describe('XML Namespace Parse', () => {
+describe('Document', () => {
 	// See: http://jsfiddle.net/bigeasy/ShcXP/1/
-	it('supports Document_getElementsByTagName', () => {
-		const doc = new DOMParser().parseFromString('<a><b/></a>')
-		expect(doc.getElementsByTagName('*')).toHaveLength(2)
-		expect(doc.documentElement.getElementsByTagName('*')).toHaveLength(1)
-	})
+	describe('getElementsByTagName', () => {
+		it('should return the correct number of elements', () => {
+			const doc = new DOMParser().parseFromString('<a><b/></a>')
+			expect(doc.getElementsByTagName('*')).toHaveLength(2)
+			expect(doc.documentElement.getElementsByTagName('*')).toHaveLength(1)
+		})
 
-	it('supports getElementsByTagName', () => {
-		const doc = new DOMParser().parseFromString(
-			'<xml xmlns="http://test.com" xmlns:t="http://test.com" xmlns:t2="http://test2.com">' +
-				'<t:test/><test/><t2:test/>' +
-				'<child attr="1"><test><child attr="2"/></test></child>' +
-				'<child attr="3"/></xml>',
-			'text/xml'
-		)
+		it('should support API on element (this test needs to be split)', () => {
+			const doc = new DOMParser().parseFromString(
+				'<xml xmlns="http://test.com" xmlns:t="http://test.com" xmlns:t2="http://test2.com">' +
+					'<t:test/><test/><t2:test/>' +
+					'<child attr="1"><test><child attr="2"/></test></child>' +
+					'<child attr="3"/></xml>',
+				'text/xml'
+			)
 
-		const childs1 = doc.documentElement.getElementsByTagName('child')
-		expect(childs1.item(0).getAttribute('attr')).toBe('1')
-		expect(childs1.item(1).getAttribute('attr')).toBe('2')
-		expect(childs1.item(2).getAttribute('attr')).toBe('3')
-		expect(childs1).toHaveLength(3)
+			const childs1 = doc.documentElement.getElementsByTagName('child')
+			expect(childs1.item(0).getAttribute('attr')).toBe('1')
+			expect(childs1.item(1).getAttribute('attr')).toBe('2')
+			expect(childs1.item(2).getAttribute('attr')).toBe('3')
+			expect(childs1).toHaveLength(3)
 
-		const childs2 = doc.getElementsByTagName('child')
-		expect(childs2.item(0).getAttribute('attr')).toBe('1')
-		expect(childs2.item(1).getAttribute('attr')).toBe('2')
-		expect(childs2.item(2).getAttribute('attr')).toBe('3')
-		expect(childs2).toHaveLength(3)
+			const childs2 = doc.getElementsByTagName('child')
+			expect(childs2.item(0).getAttribute('attr')).toBe('1')
+			expect(childs2.item(1).getAttribute('attr')).toBe('2')
+			expect(childs2.item(2).getAttribute('attr')).toBe('3')
+			expect(childs2).toHaveLength(3)
 
-		const childs3 = doc.documentElement.getElementsByTagName('*')
-		for (let i = 0, buf = []; i < childs3.length; i++) {
-			buf.push(childs3[i].tagName)
-		}
-		expect(childs3).toHaveLength(7)
+			const childs3 = doc.documentElement.getElementsByTagName('*')
+			for (let i = 0, buf = []; i < childs3.length; i++) {
+				buf.push(childs3[i].tagName)
+			}
+			expect(childs3).toHaveLength(7)
 
-		const feed = new DOMParser().parseFromString(
-			'<feed><entry>foo</entry></feed>'
-		)
-		const entries = feed.documentElement.getElementsByTagName('entry')
-		expect(entries).toHaveLength(1)
-		expect(entries[0].nodeName).toBe('entry')
-		expect(feed.documentElement.childNodes.item(0).nodeName).toBe('entry')
+			const feed = new DOMParser().parseFromString(
+				'<feed><entry>foo</entry></feed>'
+			)
+			const entries = feed.documentElement.getElementsByTagName('entry')
+			expect(entries).toHaveLength(1)
+			expect(entries[0].nodeName).toBe('entry')
+			expect(feed.documentElement.childNodes.item(0).nodeName).toBe('entry')
+		})
 	})
 
 	it('supports getElementsByTagNameNS', () => {
@@ -168,10 +169,14 @@ describe('XML Namespace Parse', () => {
 		expect(doc.documentElement.toString()).toBe('<test>bye</test>')
 	})
 
-	it('creates elements with a localName', () => {
-		const doc = new DOMImplementation().createDocument(null, 'test', null)
-		const elem = doc.createElement('foo')
-		expect(elem.localName === 'foo')
+	describe('createElement', () => {
+		it('should set localName', () => {
+			const doc = new DOMImplementation().createDocument(null, 'test', null)
+
+			const elem = doc.createElement('foo')
+
+			expect(elem.localName === 'foo')
+		})
 	})
 
 	xit('nested append failed', () => {})

--- a/test/dom/element.test.js
+++ b/test/dom/element.test.js
@@ -1,6 +1,10 @@
 'use strict'
 
-const { DOMParser, XMLSerializer } = require('../../lib/dom-parser')
+const {
+	DOMParser,
+	DOMImplementation,
+	XMLSerializer,
+} = require('../../lib/dom-parser')
 
 // Create a Test Suite
 describe('XML Namespace Parse', () => {
@@ -162,6 +166,12 @@ describe('XML Namespace Parse', () => {
 		expect(doc.documentElement.toString()).toBe('<test><a>hello</a><b/></test>')
 		doc.documentElement.textContent = 'bye'
 		expect(doc.documentElement.toString()).toBe('<test>bye</test>')
+	})
+
+	it('creates elements with a localName', () => {
+		const doc = new DOMImplementation().createDocument(null, 'test', null)
+		const elem = doc.createElement('foo')
+		expect(elem.localName === 'foo')
 	})
 
 	xit('nested append failed', () => {})


### PR DESCRIPTION
This seemed to be missing. Without it, xpath (XPath 1.0) works, but
xpath2 (XPath 2.0) and fontoxpath (XPath 3.x) do not match elements.