### PR TITLE
refactor: Improve exports & require statements

### DIFF
--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -254,7 +254,10 @@ function appendElement (hander,node) {
 }//appendChild and setAttributeNS are preformance key
 
 //if(typeof require == 'function'){
-exports.DOMImplementation = require('./dom').DOMImplementation;
+/**
+ * @deprecated Import/require from main entry point instead
+ */
+exports.DOMImplementation = dom.DOMImplementation;
 exports.XMLSerializer = require('./dom').XMLSerializer ;
 exports.DOMParser = DOMParser;
 exports.__DOMHandler = DOMHandler;

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -1,7 +1,13 @@
 var conventions = require("./conventions");
 var entities = require('./entities');
 
+var DOMImplementation = require('./dom').DOMImplementation;
+var sax = require('./sax');
+
 var NAMESPACE = conventions.NAMESPACE;
+
+var XMLReader = sax.XMLReader;
+var ParseError = sax.ParseError;
 
 function DOMParser(options){
 	this.options = options ||{locator:{}};
@@ -247,10 +253,6 @@ function appendElement (hander,node) {
 }//appendChild and setAttributeNS are preformance key
 
 //if(typeof require == 'function'){
-var sax = require('./sax');
-var XMLReader = sax.XMLReader;
-var ParseError = sax.ParseError;
-var DOMImplementation = require('./dom').DOMImplementation;
 exports.DOMParser = DOMParser;
 exports.__DOMHandler = DOMHandler;
 //}

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -252,5 +252,7 @@ function appendElement (hander,node) {
     }
 }//appendChild and setAttributeNS are preformance key
 
+//if(typeof require == 'function'){
 exports.DOMParser = DOMParser;
 exports.__DOMHandler = DOMHandler;
+//}

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -7,8 +7,8 @@ var DOMImplementation = dom.DOMImplementation;
 
 var NAMESPACE = conventions.NAMESPACE;
 
-var XMLReader = sax.XMLReader;
 var ParseError = sax.ParseError;
+var XMLReader = sax.XMLReader;
 
 function DOMParser(options){
 	this.options = options ||{locator:{}};

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -253,15 +253,15 @@ function appendElement (hander,node) {
     }
 }//appendChild and setAttributeNS are preformance key
 
-//if(typeof require == 'function'){
+exports.__DOMHandler = DOMHandler;
+exports.DOMParser = DOMParser;
+
 /**
  * @deprecated Import/require from main entry point instead
  */
 exports.DOMImplementation = dom.DOMImplementation;
+
 /**
  * @deprecated Import/require from main entry point instead
  */
 exports.XMLSerializer = dom.XMLSerializer;
-exports.DOMParser = DOMParser;
-exports.__DOMHandler = DOMHandler;
-//}

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -250,8 +250,7 @@ function appendElement (hander,node) {
 var sax = require('./sax');
 var XMLReader = sax.XMLReader;
 var ParseError = sax.ParseError;
-var DOMImplementation = exports.DOMImplementation = require('./dom').DOMImplementation;
-exports.XMLSerializer = require('./dom').XMLSerializer ;
+var DOMImplementation = require('./dom').DOMImplementation;
 exports.DOMParser = DOMParser;
 exports.__DOMHandler = DOMHandler;
 //}

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -1,8 +1,9 @@
 var conventions = require("./conventions");
+var dom = require('./dom')
 var entities = require('./entities');
-
-var DOMImplementation = require('./dom').DOMImplementation;
 var sax = require('./sax');
+
+var DOMImplementation = dom.DOMImplementation;
 
 var NAMESPACE = conventions.NAMESPACE;
 

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -1,13 +1,7 @@
 var conventions = require("./conventions");
 var entities = require('./entities');
 
-var DOMImplementation = require('./dom').DOMImplementation;
-var sax = require('./sax');
-
 var NAMESPACE = conventions.NAMESPACE;
-
-var XMLReader = sax.XMLReader;
-var ParseError = sax.ParseError;
 
 function DOMParser(options){
 	this.options = options ||{locator:{}};
@@ -253,6 +247,10 @@ function appendElement (hander,node) {
 }//appendChild and setAttributeNS are preformance key
 
 //if(typeof require == 'function'){
+var sax = require('./sax');
+var XMLReader = sax.XMLReader;
+var ParseError = sax.ParseError;
+var DOMImplementation = require('./dom').DOMImplementation;
 exports.DOMParser = DOMParser;
 exports.__DOMHandler = DOMHandler;
 //}

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -1,7 +1,13 @@
 var conventions = require("./conventions");
 var entities = require('./entities');
 
+var DOMImplementation = require('./dom').DOMImplementation;
+var sax = require('./sax');
+
 var NAMESPACE = conventions.NAMESPACE;
+
+var XMLReader = sax.XMLReader;
+var ParseError = sax.ParseError;
 
 function DOMParser(options){
 	this.options = options ||{locator:{}};
@@ -247,10 +253,7 @@ function appendElement (hander,node) {
 }//appendChild and setAttributeNS are preformance key
 
 //if(typeof require == 'function'){
-var sax = require('./sax');
-var XMLReader = sax.XMLReader;
-var ParseError = sax.ParseError;
-var DOMImplementation = exports.DOMImplementation = require('./dom').DOMImplementation;
+exports.DOMImplementation = require('./dom').DOMImplementation;
 exports.XMLSerializer = require('./dom').XMLSerializer ;
 exports.DOMParser = DOMParser;
 exports.__DOMHandler = DOMHandler;

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -252,7 +252,5 @@ function appendElement (hander,node) {
     }
 }//appendChild and setAttributeNS are preformance key
 
-//if(typeof require == 'function'){
 exports.DOMParser = DOMParser;
 exports.__DOMHandler = DOMHandler;
-//}

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -250,7 +250,8 @@ function appendElement (hander,node) {
 var sax = require('./sax');
 var XMLReader = sax.XMLReader;
 var ParseError = sax.ParseError;
-var DOMImplementation = require('./dom').DOMImplementation;
+var DOMImplementation = exports.DOMImplementation = require('./dom').DOMImplementation;
+exports.XMLSerializer = require('./dom').XMLSerializer ;
 exports.DOMParser = DOMParser;
 exports.__DOMHandler = DOMHandler;
 //}

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -258,7 +258,10 @@ function appendElement (hander,node) {
  * @deprecated Import/require from main entry point instead
  */
 exports.DOMImplementation = dom.DOMImplementation;
-exports.XMLSerializer = require('./dom').XMLSerializer ;
+/**
+ * @deprecated Import/require from main entry point instead
+ */
+exports.XMLSerializer = dom.XMLSerializer;
 exports.DOMParser = DOMParser;
 exports.__DOMHandler = DOMHandler;
 //}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,3 @@
+exports.DOMImplementation = require('./dom').DOMImplementation
+exports.XMLSerializer = require('./dom').XMLSerializer
+exports.DOMParser = require('./dom-parser').DOMParser

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
-exports.DOMImplementation = require('./dom').DOMImplementation
-exports.XMLSerializer = require('./dom').XMLSerializer
+var dom = require('./dom')
+exports.DOMImplementation = dom.DOMImplementation
+exports.XMLSerializer = dom.XMLSerializer
 exports.DOMParser = require('./dom-parser').DOMParser

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "type": "git",
     "url": "git://github.com/xmldom/xmldom.git"
   },
-  "main": "lib/dom-parser.js",
+  "main": "lib/index.js",
   "types": "index.d.ts",
   "files": [
     "CHANGELOG.md",

--- a/test/dom-parser.test.js
+++ b/test/dom-parser.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../lib/dom-parser')
+const { DOMParser } = require('../lib')
 
 describe('DOMParser', () => {
 	describe('constructor', () => {

--- a/test/dom/attr.test.js
+++ b/test/dom/attr.test.js
@@ -1,5 +1,5 @@
 'use strict'
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 const { DOMException } = require('../../lib/dom')
 
 describe('XML attrs', () => {

--- a/test/dom/clone.test.js
+++ b/test/dom/clone.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser, XMLSerializer } = require('../../lib/dom-parser')
+const { DOMParser, XMLSerializer } = require('../../lib')
 
 describe('XML Namespace Parse', () => {
 	it('can properly set clone', () => {

--- a/test/dom/element.test.js
+++ b/test/dom/element.test.js
@@ -1,10 +1,6 @@
 'use strict'
 
-const {
-	DOMParser,
-	DOMImplementation,
-	XMLSerializer,
-} = require('../../lib/dom-parser')
+const { DOMParser, DOMImplementation, XMLSerializer } = require('../../lib')
 
 describe('Document', () => {
 	// See: http://jsfiddle.net/bigeasy/ShcXP/1/

--- a/test/dom/fragment.test.js
+++ b/test/dom/fragment.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 
 describe('DOM DocumentFragment', () => {
 	// see: http://jsfiddle.net/9Wmh2/1/

--- a/test/dom/ns-test.test.js
+++ b/test/dom/ns-test.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 
 // Create a Test Suite
 describe('XML Namespace Parse', () => {

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../../lib')
-const { XMLSerializer } = require('../../lib/dom')
+const { DOMParser, XMLSerializer } = require('../../lib')
 const { MIME_TYPE } = require('../../lib/conventions')
 
 describe('XML Serializer', () => {

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 const { XMLSerializer } = require('../../lib/dom')
 const { MIME_TYPE } = require('../../lib/conventions')
 

--- a/test/error/error-handler.test.js
+++ b/test/error/error-handler.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 const { REPORTED } = require('./reported')
 
 describe('custom errorHandler', () => {

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -3,7 +3,7 @@
 const { LINE_TO_ERROR_INDEX, REPORTED } = require('./reported')
 const { getTestParser } = require('../get-test-parser')
 const { ParseError } = require('../../lib/sax')
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 
 describe.each(Object.entries(REPORTED))(
 	'%s',

--- a/test/parse/big-file-performance.test.js
+++ b/test/parse/big-file-performance.test.js
@@ -1,6 +1,6 @@
 /* eslint strict: off */
 
-const { XMLSerializer, DOMParser } = require('../../lib/dom-parser')
+const { XMLSerializer, DOMParser } = require('../../lib')
 /*
 var DomJS = require('dom-js').DomJS
 try {

--- a/test/parse/file.test.js
+++ b/test/parse/file.test.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs')
 
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 
 describe('from file', () => {
 	it('file-test1.xml', () => {

--- a/test/parse/locator.test.js
+++ b/test/parse/locator.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 const { getTestParser } = require('../get-test-parser')
 
 describe('DOMLocator', () => {

--- a/test/parse/namespace.test.js
+++ b/test/parse/namespace.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 
 /**
  * Returns an array containing only one occurrence of every sting in `values` (like in a Set).

--- a/test/parse/node.test.js
+++ b/test/parse/node.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Node } = require('../../lib/dom')
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 
 const expectNeighbours = (first, second, ...nodes) => {
 	expect(first.nextSibling).toStrictEqual(second)

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { getTestParser } = require('../get-test-parser')
-const { DOMParser } = require('../../lib/dom-parser')
+const { DOMParser } = require('../../lib')
 
 describe('XML Node Parse', () => {
 	describe('no attribute', () => {

--- a/test/xss.test.js
+++ b/test/xss.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../lib/dom-parser')
+const { DOMParser } = require('../lib')
 
 const excludeTags = new RegExp(
 	'^(?:' +


### PR DESCRIPTION
by creating a proper main entry file `lib/index.js`.
NOTE that the following exports have been deprecated in `lib/dom-parser.js` and will be removed in the next minor release:
- `DOMImplementation`
- `XMLSerializer`

