### PR TITLE
chore(npm): Drop unused devDependency dom-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,15 +2087,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-js": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/dom-js/-/dom-js-0.0.9.tgz",
-      "integrity": "sha1-LW3WwhGvAY8APzDt9WiPHvhvFac=",
-      "dev": true,
-      "requires": {
-        "sax": ">=0.1.5"
-      }
-    },
     "domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -5915,12 +5906,6 @@
           }
         }
       }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
     },
     "saxes": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "dependencies": {},
   "devDependencies": {
     "@stryker-mutator/core": "^4.5.1",
-    "dom-js": "0.0.9",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-es5": "^1.5.0",


### PR DESCRIPTION
it has been [deprecated and recommends this library](https://gitlab.com/teknopaul/dom-js/-/blob/master/README.md), so I don't think we still need to have it as a devDependency.

(I think it was originally there to compare performance.)