### PR TITLE
fix: Handle whitespace in closing tags

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -117,7 +117,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 			switch(source.charAt(tagStart+1)){
 			case '/':
 				var end = source.indexOf('>',tagStart+3);
-				var tagName = source.substring(tagStart+2,end).replace(/[ \t\n\r]+$/g, '');
+				var tagName = source.substring(tagStart + 2, end).replace(/[ \t\n\r]+$/g, '');
 				var config = parseStack.pop();
 				if(end<0){
 					

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -117,7 +117,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 			switch(source.charAt(tagStart+1)){
 			case '/':
 				var end = source.indexOf('>',tagStart+3);
-				var tagName = source.substring(tagStart+2,end);
+				var tagName = source.substring(tagStart+2,end).replace(/[ \t\n\r]+$/g, '');
 				var config = parseStack.pop();
 				if(end<0){
 					

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -5,12 +5,44 @@ const { DOMParser } = require('../../lib/dom-parser')
 
 describe('XML Node Parse', () => {
 	describe('no attribute', () => {
-		it.each(['<xml ></xml>', '<xml></xml>', '<xml />'])('%s', (input) => {
-			const actual = new DOMParser()
-				.parseFromString(input, 'text/xml')
-				.toString()
-			expect(actual).toBe('<xml/>')
-		})
+		it.each(['<xml ></xml>', '<xml></xml>', '<xml></xml \r\n>', '<xml />'])(
+			'%s',
+			(input) => {
+				const actual = new DOMParser()
+					.parseFromString(input, 'text/xml')
+					.toString()
+				expect(actual).toBe('<xml/>')
+			}
+		)
+	})
+	it('nested closing tag with whitespace', () => {
+		const actual = new DOMParser()
+			.parseFromString(
+				`<?xml version="1.0" encoding="UTF-8"?>
+<bookstore>
+  <book category="cooking">
+    <author>Giada De Laurentiis</author
+    >
+    <title lang="en">Everyday Italian</title>
+  </book>
+</bookstore>`,
+				'text/xml'
+			)
+			.toString()
+		expect(actual).toBe(`<?xml version="1.0" encoding="UTF-8"?>
+<bookstore>
+  <book category="cooking">
+    <author>Giada De Laurentiis</author>
+    <title lang="en">Everyday Italian</title>
+  </book>
+</bookstore>`)
+	})
+
+	it('nested closing tag with whitespace', () => {
+		const actual = new DOMParser()
+			.parseFromString(`<book></book ><title>Harry Potter</title>`, 'text/xml')
+			.toString()
+		expect(actual).toBe(`<book/><title>Harry Potter</title>`)
 	})
 
 	describe('simple attributes', () => {


### PR DESCRIPTION
by not treating them as part of the tag name.
We drop the additional whitespace as part of parsing.
xmldom was already automatically closing tags that it couldn't find a matching end,
but the whitespace was no longer present.
Strange things started to happen if there were elements after the one with the additional white space.

Fixes #69