### PR TITLE
chore(npm): Scope package to @xmldom org

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# make sure to publish the scoped package as a public one
+# https://docs.npmjs.com/cli/v6/using-npm/config#access
+access=public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 [Commits](https://github.com/xmldom/xmldom/compare/0.6.0...0.7.0)
 
+First version published as `@xmldom/xmldom` due to [`#271`](https://github.com/xmldom/xmldom/pull/271).
+
 ### Fixes:
 
 - Security: Misinterpretation of malicious XML input [`CVE-2021-32796`](https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 [Commits](https://github.com/xmldom/xmldom/compare/0.6.0...0.7.0)
 
-First version published as `@xmldom/xmldom` due to [`#271`](https://github.com/xmldom/xmldom/pull/271).
+Due to [`#271`](https://github.com/xmldom/xmldom/issue/271) this version was published as
+- unscoped `xmldom` package to github (git tags [`0.7.0`](https://github.com/xmldom/xmldom/tree/0.7.0) and [`0.7.0+unscoped`](https://github.com/xmldom/xmldom/tree/0.7.0%2Bunscoped))
+- scoped `@xmldom/xmldom` package to npm (git tag `0.7.0+scoped`)
+For more details look at [`#278`](https://github.com/xmldom/xmldom/pull/278#issuecomment-902172483)
 
 ### Fixes:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "xmldom",
+  "name": "@xmldom/xmldom",
   "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -57,11 +57,6 @@
       "name": "brodybits",
       "email": "chris@brody.consulting",
       "url": "https://github.com/brodybits"
-    },
-    {
-      "name": "Christian Bewernitz",
-      "email": "coder@karfau.de",
-      "web": "https://github.com/karfau"
     }
   ],
   "contributors": [
@@ -89,6 +84,11 @@
       "name": "Eric Newport",
       "email": "kethinov@gmail.com",
       "web": "https://github.com/kethinov"
+    },
+    {
+      "name": "Christian Bewernitz",
+      "email": "coder@karfau.de",
+      "web": "https://github.com/karfau"
     }
   ],
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xmldom",
+  "name": "@xmldom/xmldom",
   "version": "0.7.0",
   "description": "A pure JavaScript W3C standard-based (XML DOM Level 2 Core) DOMParser and XMLSerializer module.",
   "keywords": [
@@ -57,6 +57,11 @@
       "name": "brodybits",
       "email": "chris@brody.consulting",
       "url": "https://github.com/brodybits"
+    },
+    {
+      "name": "Christian Bewernitz",
+      "email": "coder@karfau.de",
+      "web": "https://github.com/karfau"
     }
   ],
   "contributors": [
@@ -84,11 +89,6 @@
       "name": "Eric Newport",
       "email": "kethinov@gmail.com",
       "web": "https://github.com/kethinov"
-    },
-    {
-      "name": "Christian Bewernitz",
-      "email": "coder@karfau.de",
-      "web": "https://github.com/karfau"
     }
   ],
   "bugs": {

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,14 @@
-# XMLDOM
+# @xmldom/xmldom
 
-[![license](https://img.shields.io/npm/l/xmldom?color=blue&style=flat-square)](LICENSE)
-[![npm](https://img.shields.io/npm/v/xmldom?style=flat-square)](https://www.npmjs.com/package/xmldom)
+[![license](https://img.shields.io/npm/l/@xmldom/xmldom?color=blue&style=flat-square)](LICENSE)
+[![npm](https://img.shields.io/npm/v/@xmldom/xmldom?style=flat-square)](https://www.npmjs.com/package/@xmldom/xmldom)
 [![bug issues](https://img.shields.io/github/issues/xmldom/xmldom/bug?color=red&style=flat-square)](https://github.com/xmldom/xmldom/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 [!["help wanted" issues](https://img.shields.io/github/issues/xmldom/xmldom/help%20wanted?color=darkgreen&style=flat-square)](https://github.com/xmldom/xmldom/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 [![Mutation report](https://camo.githubusercontent.com/ee312c4ebce7784ce9f785757eba5d6e33e6d950/68747470733a2f2f696d672e736869656c64732e696f2f656e64706f696e743f7374796c653d666c61742675726c3d687474707325334125324625324662616467652d6170692e737472796b65722d6d757461746f722e696f2532466769746875622e636f6d25324662726f647962697473253246786d6c646f6d2532466d6173746572)](https://dashboard.stryker-mutator.io/reports/github.com/brodybits/xmldom/master)
+
+**The currently active maintainers decided to publish this code as `@xmldom/xmldom` because [the npm library `xmldom` contains security issues but can currently not be published by us](https://github.com/xmldom/xmldom/issues/271).**
+
+*For better readability in the docs we will continue to talk about this library as "xmldom".*
 
 xmldom is a javascript [ponyfill](https://ponyfill.com/) for the following APIs supported in browsers:
 - convert an XML string into a DOM tree (`new DOMParser().parseFromString(xml, mimeType)` => `Document`)
@@ -81,12 +85,12 @@ More details about the transition can be found in the [CHANGELOG](CHANGELOG.md#m
 
 ### Install:
 
-> npm install xmldom
+> npm install @xmldom/xmldom
 
 ### Example:
 
 ```javascript
-const { DOMParser } = require('xmldom')
+const { DOMParser } = require('@xmldom/xmldom')
 
 const doc = new DOMParser().parseFromString(
     '<xml xmlns="a" xmlns:c="./lite">\n' +
@@ -107,7 +111,7 @@ console.info(nsAttr)
 Note: in Typescript and ES6 you can use the import approach, as follows:
 
 ```javascript
-import { DOMParser } from 'xmldom'
+import { DOMParser } from '@xmldom/xmldom'
 ```
 
 ## API Reference


### PR DESCRIPTION
As discussed in the recent days, this PR prepares the scoping of the package into the npm organisation `xmldom` so the new package name is `@xmldom/xmldom`.

See https://docs.npmjs.com/about-scopes
I also checked that the `@` has to be part of the shields/badges URL to work, by looking at https://shields.io/category/version and trying it with an existing scoped package.