### PR TITLE
chore(package.json): remove author, maintainers, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "XMLSerializer",
     "ponyfill"
   ],
-  "author": "jindw <jindw@xidea.org> (http://www.xidea.org)",
   "homepage": "https://github.com/xmldom/xmldom",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -52,45 +52,6 @@
     "xmltest": "^1.5.0",
     "yauzl": "^2.10.0"
   },
-  "maintainers": [
-    {
-      "name": "brodybits",
-      "email": "chris@brody.consulting",
-      "url": "https://github.com/brodybits"
-    }
-  ],
-  "contributors": [
-    {
-      "name": "jindw",
-      "email": "jindw@xidea.org",
-      "url": "http://www.xidea.org"
-    },
-    {
-      "name": "Yaron Naveh",
-      "email": "yaronn01@gmail.com",
-      "web": "http://webservices20.blogspot.com/"
-    },
-    {
-      "name": "Harutyun Amirjanyan",
-      "email": "amirjanyan@gmail.com",
-      "web": "https://github.com/nightwing"
-    },
-    {
-      "name": "Alan Gutierrez",
-      "email": "alan@prettyrobots.com",
-      "web": "http://www.prettyrobots.com/"
-    },
-    {
-      "name": "Eric Newport",
-      "email": "kethinov@gmail.com",
-      "web": "https://github.com/kethinov"
-    },
-    {
-      "name": "Christian Bewernitz",
-      "email": "coder@karfau.de",
-      "web": "https://github.com/karfau"
-    }
-  ],
   "bugs": {
     "url": "https://github.com/xmldom/xmldom/issues"
   },


### PR DESCRIPTION
since they are visible on github/npm level and don't need to additionally be synced/maintained inside `package.json`, as discussed for followup in PR #278.