### PR TITLE
fix(types): Copy types from DefinitelyTyped

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,43 @@
+/// <reference lib="dom" />
+
+declare module "@xmldom/xmldom" {
+  var DOMParser: DOMParserStatic;
+  var XMLSerializer: XMLSerializerStatic;
+  var DOMImplementation: DOMImplementationStatic;
+
+  interface DOMImplementationStatic {
+      new(): DOMImplementation;
+  }
+
+  interface DOMParserStatic {
+      new (): DOMParser;
+      new (options: Options): DOMParser;
+  }
+
+  interface XMLSerializerStatic {
+      new (): XMLSerializer;
+  }
+
+  interface DOMParser {
+      parseFromString(xmlsource: string, mimeType?: string): Document;
+  }
+
+  interface XMLSerializer {
+      serializeToString(node: Node): string;
+  }
+
+  interface Options {
+      locator?: any;
+      errorHandler?: ErrorHandlerFunction | ErrorHandlerObject | undefined;
+  }
+
+  interface ErrorHandlerFunction {
+      (level: string, msg: any): any;
+  }
+
+  interface ErrorHandlerObject {
+      warning?: ((msg: any) => any) | undefined;
+      error?: ((msg: any) => any) | undefined;
+      fatalError?: ((msg: any) => any) | undefined;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "git://github.com/xmldom/xmldom.git"
   },
   "main": "lib/dom-parser.js",
+  "types": "index.d.ts",
   "files": [
     "CHANGELOG.md",
     "LICENSE",


### PR DESCRIPTION
This PR partially addresses #191 (see https://github.com/xmldom/xmldom/issues/191#issuecomment-902225494 → step 1). The file was copied from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f378781417e2964083f492ac85bad985d0f47650/types/xmldom/index.d.ts).