### PR TITLE
test: Fix stryker config

### DIFF
--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -14,7 +14,7 @@
   },
   "coverageAnalysis": "off",
   "commandRunner": {
-    "command": "npm run test:jest -- --bail --no-cache --ci --maxWorkers=1"
+    "command": "npm run test -- --bail --no-cache --ci --maxWorkers=1"
   },
   "timeoutMS_comment": "When all tests pass (mutant survives) our tests need some time. So this is configured to prevent 'timeout's",
   "timeoutMS": 15000

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -14,7 +14,7 @@
   },
   "coverageAnalysis": "off",
   "commandRunner": {
-    "command": "npm run test -- --bail --no-cache --ci --maxWorkers=1"
+    "command": "npm test -- --bail --no-cache --ci --maxWorkers=1"
   },
   "timeoutMS_comment": "When all tests pass (mutant survives) our tests need some time. So this is configured to prevent 'timeout's",
   "timeoutMS": 15000


### PR DESCRIPTION
by pointing it to the existing `test` script instead of the missing `test:jest` srcipt that has been removed in #297