### PR TITLE
ci(github): Split test and lint steps into jobs

### DIFF
--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -20,7 +20,7 @@ jobs:
         - 10.x
         - 12.x
         - 14.x
-        - 16.x
+        - 16.8
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: test - Node.js CI
+name: Node.js CI
 
 on:
   push:

--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
@@ -30,4 +30,21 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci --no-audit
     - run: npm run test
+
+  lint:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version:
+        - 14.x
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci --no-audit
     - run: npm run lint


### PR DESCRIPTION
to allow linting to be listed as a separately failing check in the PR.

Really fixes #111

Note: I don't think there is any benefit of splitting them into different files as of now.