### PR TITLE
chore: Drop deprecated exports from `lib/dom-parser.js`

### DIFF
--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -256,13 +256,3 @@ function appendElement (hander,node) {
 
 exports.__DOMHandler = DOMHandler;
 exports.DOMParser = DOMParser;
-
-/**
- * @deprecated Import/require from main entry point instead
- */
-exports.DOMImplementation = dom.DOMImplementation;
-
-/**
- * @deprecated Import/require from main entry point instead
- */
-exports.XMLSerializer = dom.XMLSerializer;


### PR DESCRIPTION
BREAKING CHANGE: But they are still available from the `@xmldom/xmldom` main package.

closes https://github.com/xmldom/xmldom/issues/53