### PR TITLE
fix(XMLSerializer): Preserve whitespace character references

### DIFF
--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -13,15 +13,15 @@ var XMLReader = sax.XMLReader;
 /**
  * Normalizes line ending according to https://www.w3.org/TR/xml11/#sec-line-ends:
  *
- * XML parsed entities are often stored in computer files which, 
- * for editing convenience, are organized into lines. 
- * These lines are typically separated by some combination 
+ * XML parsed entities are often stored in computer files which,
+ * for editing convenience, are organized into lines.
+ * These lines are typically separated by some combination
  * of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
- * 
- * To simplify the tasks of applications, the XML processor must behave 
- * as if it normalized all line breaks in external parsed entities (including the document entity) 
+ *
+ * To simplify the tasks of applications, the XML processor must behave
+ * as if it normalized all line breaks in external parsed entities (including the document entity)
  * on input, before parsing, by translating all of the following to a single #xA character:
- * 
+ *
  * 1. the two-character sequence #xD #xA
  * 2. the two-character sequence #xD #x85
  * 3. the single character #x85

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -13,20 +13,20 @@ var XMLReader = sax.XMLReader;
 /**
  * Normalizes line ending according to https://www.w3.org/TR/xml11/#sec-line-ends:
  *
- * XML parsed entities are often stored in computer files which,
- * for editing convenience, are organized into lines.
- * These lines are typically separated by some combination
- * of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
- *
- * To simplify the tasks of applications, the XML processor must behave
- * as if it normalized all line breaks in external parsed entities (including the document entity)
- * on input, before parsing, by translating all of the following to a single #xA character:
- *
- * 1. the two-character sequence #xD #xA
- * 2. the two-character sequence #xD #x85
- * 3. the single character #x85
- * 4. the single character #x2028
- * 5. any #xD character that is not immediately followed by #xA or #x85.
+ * > XML parsed entities are often stored in computer files which,
+ * > for editing convenience, are organized into lines.
+ * > These lines are typically separated by some combination
+ * > of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
+ * >
+ * > To simplify the tasks of applications, the XML processor must behave
+ * > as if it normalized all line breaks in external parsed entities (including the document entity)
+ * > on input, before parsing, by translating all of the following to a single #xA character:
+ * >
+ * > 1. the two-character sequence #xD #xA
+ * > 2. the two-character sequence #xD #x85
+ * > 3. the single character #x85
+ * > 4. the single character #x2028
+ * > 5. any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}
@@ -59,8 +59,8 @@ function normalizeLineEndings(input) {
  * The DOMParser interface provides the ability to parse XML or HTML source code
  * from a string into a DOM `Document`.
  *
- * xmldom is different from the spec in that it allows an `options` parameter,
- * to override the default behavior.
+ * _xmldom is different from the spec in that it allows an `options` parameter,
+ * to override the default behavior._
  *
  * @param {DOMParserOptions} [options]
  * @constructor

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1139,11 +1139,11 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
  * Well-formed constraint: No < in Attribute Values
  * The replacement text of any entity referred to directly or indirectly in an attribute value must not contain a <.
  * @see https://www.w3.org/TR/xml/#CleanAttrVals
-  * @see https://www.w3.org/TR/xml/#NT-AttValue
-  * @see https://www.w3.org/TR/xml/#AVNormalize
+ * @see https://www.w3.org/TR/xml/#NT-AttValue
+ * @see https://www.w3.org/TR/xml/#AVNormalize
  */
 function addSerializedAttribute(buf, qualifiedName, value) {
-	buf.push(' ', qualifiedName, '="', value.replace(/[<&"\t\n\r]/g,_xmlEncoder), '"')
+	buf.push(' ', qualifiedName, '="', value.replace(/[<&"\t\n\r]/g, _xmlEncoder), '"')
 }
 
 function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1139,7 +1139,8 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
  * Well-formed constraint: No < in Attribute Values
  * The replacement text of any entity referred to directly or indirectly in an attribute value must not contain a <.
  * @see https://www.w3.org/TR/xml/#CleanAttrVals
- * @see https://www.w3.org/TR/xml/#NT-AttValue
+  * @see https://www.w3.org/TR/xml/#NT-AttValue
+  * @see https://www.w3.org/TR/xml/#AVNormalize
  */
 function addSerializedAttribute(buf, qualifiedName, value) {
 	buf.push(' ', qualifiedName, '="', value.replace(/[<&"\t\n\r]/g,_xmlEncoder), '"')

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1137,10 +1137,15 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
 }
 /**
  * Well-formed constraint: No < in Attribute Values
- * The replacement text of any entity referred to directly or indirectly in an attribute value must not contain a <.
- * @see https://www.w3.org/TR/xml/#CleanAttrVals
- * @see https://www.w3.org/TR/xml/#NT-AttValue
- * @see https://www.w3.org/TR/xml/#AVNormalize
+ * > The replacement text of any entity referred to directly or indirectly
+ * > in an attribute value must not contain a <.
+ * @see https://www.w3.org/TR/xml11/#CleanAttrVals
+ * @see https://www.w3.org/TR/xml11/#NT-AttValue
+ *
+ * Literal whitespace other than space that appear in attribute values
+ * are serialized as their entity references, so they will be preserved.
+ * (In contrast to whitespace literals in the input which are normalized to spaces)
+ * @see https://www.w3.org/TR/xml11/#AVNormalize
  */
 function addSerializedAttribute(buf, qualifiedName, value) {
 	buf.push(' ', qualifiedName, '="', value.replace(/[<&"\t\n\r]/g, _xmlEncoder), '"')

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1142,7 +1142,7 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
  * @see https://www.w3.org/TR/xml/#NT-AttValue
  */
 function addSerializedAttribute(buf, qualifiedName, value) {
-	buf.push(' ', qualifiedName, '="', value.replace(/[<&"]/g,_xmlEncoder), '"')
+	buf.push(' ', qualifiedName, '="', value.replace(/[<&"\t\n\r]/g,_xmlEncoder), '"')
 }
 
 function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -233,7 +233,15 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 		if (el.attributeNames.hasOwnProperty(qname)) {
 			errorHandler.fatalError('Attribute ' + qname + ' redefined')
 		}
-		el.addValue(qname, value, startIndex)
+		el.addValue(
+			qname,
+			// @see https://www.w3.org/TR/xml/#AVNormalize
+			// since the xmldom sax parser does not "interpret" DTD the following is not implemented:
+			// - recursive replacement of (DTD) entity references
+			// - trimming and collapsing multiple spaces into a single one for attributes that are not of type CDATA
+			value.replace(/[\t\n\r]/g, ' ').replace(/&#?\w+;/g, entityReplacer),
+			startIndex
+		)
 	}
 	var attrName;
 	var value;
@@ -264,7 +272,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 				start = p+1;
 				p = source.indexOf(c,start)
 				if(p>0){
-					value = source.slice(start,p).replace(/&#?\w+;/g,entityReplacer);
+					value = source.slice(start,p);
 					addAttribute(attrName, value, start-1);
 					s = S_ATTR_END;
 				}else{
@@ -272,10 +280,8 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 					throw new Error('attribute value no end \''+c+'\' match');
 				}
 			}else if(s == S_ATTR_NOQUOT_VALUE){
-				value = source.slice(start,p).replace(/&#?\w+;/g,entityReplacer);
-				//console.log(attrName,value,start,p)
+				value = source.slice(start,p);
 				addAttribute(attrName, value, start);
-				//console.dir(el)
 				errorHandler.warning('attribute "'+attrName+'" missed start quot('+c+')!!');
 				start = p+1;
 				s = S_ATTR_END
@@ -329,7 +335,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 				}
 				if(s == S_ATTR_NOQUOT_VALUE){
 					errorHandler.warning('attribute "'+value+'" missed quot(")!');
-					addAttribute(attrName, value.replace(/&#?\w+;/g,entityReplacer), start)
+					addAttribute(attrName, value, start)
 				}else{
 					if(!NAMESPACE.isHTML(currentNSMap['']) || !value.match(/^(?:disabled|checked|selected)$/i)){
 						errorHandler.warning('attribute "'+value+'" missed value!! "'+value+'" instead!!')
@@ -357,7 +363,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 					s = S_ATTR_SPACE;
 					break;
 				case S_ATTR_NOQUOT_VALUE:
-					var value = source.slice(start,p).replace(/&#?\w+;/g,entityReplacer);
+					var value = source.slice(start,p);
 					errorHandler.warning('attribute "'+value+'" missed quot(")!!');
 					addAttribute(attrName, value, start)
 				case S_ATTR_END:

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -272,7 +272,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 				start = p+1;
 				p = source.indexOf(c,start)
 				if(p>0){
-					value = source.slice(start,p);
+					value = source.slice(start, p);
 					addAttribute(attrName, value, start-1);
 					s = S_ATTR_END;
 				}else{
@@ -280,7 +280,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 					throw new Error('attribute value no end \''+c+'\' match');
 				}
 			}else if(s == S_ATTR_NOQUOT_VALUE){
-				value = source.slice(start,p);
+				value = source.slice(start, p);
 				addAttribute(attrName, value, start);
 				errorHandler.warning('attribute "'+attrName+'" missed start quot('+c+')!!');
 				start = p+1;
@@ -363,7 +363,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 					s = S_ATTR_SPACE;
 					break;
 				case S_ATTR_NOQUOT_VALUE:
-					var value = source.slice(start,p);
+					var value = source.slice(start, p);
 					errorHandler.warning('attribute "'+value+'" missed quot(")!!');
 					addAttribute(attrName, value, start)
 				case S_ATTR_END:

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -120,15 +120,11 @@ describe('XML Serializer', () => {
 		})
 	})
 	describe('properly escapes attribute values', () => {
-		it.only('should properly convert whitespace literals back to character references', () => {
+		it('should properly convert whitespace literals back to character references', () => {
 			const input = '<xml attr="&#9;&#10;&#13;"/>'
 			const dom = new DOMParser().parseFromString(input, MIME_TYPE.XML_TEXT)
 			const attr = dom.documentElement.attributes[0]
 
-			// are transferred to literal values in the DOM
-			expect(attr.value).toBe('\t\n\r')
-
-			// and back to character references when serializing
 			expect(new XMLSerializer().serializeToString(dom)).toBe(input)
 		})
 		it('should escape special characters in namespace attributes', () => {

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -127,6 +127,7 @@ describe('XML Serializer', () => {
 
 			expect(new XMLSerializer().serializeToString(dom)).toBe(input)
 		})
+
 		it('should escape special characters in namespace attributes', () => {
 			const input = `<xml xmlns='<&"' xmlns:attr='"&<'><test attr:test=""/></xml>`
 			const doc = new DOMParser().parseFromString(input, MIME_TYPE.XML_TEXT)

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -120,6 +120,17 @@ describe('XML Serializer', () => {
 		})
 	})
 	describe('properly escapes attribute values', () => {
+		it.only('should properly convert whitespace literals back to character references', () => {
+			const input = '<xml attr="&#9;&#10;&#13;"/>'
+			const dom = new DOMParser().parseFromString(input, MIME_TYPE.XML_TEXT)
+			const attr = dom.documentElement.attributes[0]
+
+			// are transferred to literal values in the DOM
+			expect(attr.value).toBe('\t\n\r')
+
+			// and back to character references when serializing
+			expect(new XMLSerializer().serializeToString(dom)).toBe(input)
+		})
 		it('should escape special characters in namespace attributes', () => {
 			const input = `<xml xmlns='<&"' xmlns:attr='"&<'><test attr:test=""/></xml>`
 			const doc = new DOMParser().parseFromString(input, MIME_TYPE.XML_TEXT)

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -73,6 +73,7 @@ describe('XML Node Parse', () => {
 			})
 		})
 
+		// https://www.w3.org/TR/xml/#AVNormalize
 		describe('containing whitespace', () => {
 			it('should transform whitespace literals into spaces', () => {
 				const { parser } = getTestParser()

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -72,6 +72,7 @@ describe('XML Node Parse', () => {
 				).toBe('<xml a="1" b=""/>')
 			})
 		})
+
 		describe('containing whitespace', () => {
 			it('should transform whitespace literals into spaces', () => {
 				const { parser } = getTestParser()
@@ -84,6 +85,7 @@ describe('XML Node Parse', () => {
 
 				expect(attr.value).toBe('    ')
 			})
+
 			it.each([
 				['&#x9;', '\t'],
 				['&#9;', '\t'],
@@ -105,11 +107,11 @@ describe('XML Node Parse', () => {
 					)
 
 					const attr = dom.documentElement.attributes.getNamedItem('attr')
-
 					expect(attr.value).toBe(literal)
 				}
 			)
 		})
+
 		it('unclosed root tag will be closed', () => {
 			const { errors, parser } = getTestParser()
 

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -77,6 +77,7 @@ describe('XML Node Parse', () => {
 			it('should transform whitespace literals into spaces', () => {
 				const { parser } = getTestParser()
 				const dom = parser.parseFromString(
+					// `\r\n` would be replaced by `\n` due to https://www.w3.org/TR/xml/#sec-line-ends
 					'<xml attr=" \t\n\r"/>',
 					MIME_TYPE.XML_TEXT
 				)

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -2,6 +2,7 @@
 
 const { getTestParser } = require('../get-test-parser')
 const { DOMParser } = require('../../lib')
+const { MIME_TYPE } = require('../../lib/conventions')
 
 describe('XML Node Parse', () => {
 	describe('no attribute', () => {
@@ -38,7 +39,7 @@ describe('XML Node Parse', () => {
 </bookstore>`)
 	})
 
-	it('nested closing tag with whitespace', () => {
+	it('sibling closing tag with whitespace', () => {
 		const actual = new DOMParser()
 			.parseFromString(`<book></book ><title>Harry Potter</title>`, 'text/xml')
 			.toString()
@@ -71,7 +72,44 @@ describe('XML Node Parse', () => {
 				).toBe('<xml a="1" b=""/>')
 			})
 		})
+		describe('containing whitespace', () => {
+			it('should transform whitespace literals into spaces', () => {
+				const { parser } = getTestParser()
+				const dom = parser.parseFromString(
+					'<xml attr=" \t\n\r"/>',
+					MIME_TYPE.XML_TEXT
+				)
 
+				const attr = dom.documentElement.attributes.getNamedItem('attr')
+
+				expect(attr.value).toBe('    ')
+			})
+			it.each([
+				['&#x9;', '\t'],
+				['&#9;', '\t'],
+				['&#xA;', '\n'],
+				['&#xa;', '\n'],
+				['&#10;', '\n'],
+				['&#xD;', '\r'],
+				['&#xd;', '\r'],
+				['&#13;', '\r'],
+				['&#x20;', ' '],
+				['&#32;', ' '],
+			])(
+				'should transform whitespace character reference %s to literal',
+				(reference, literal) => {
+					const { parser } = getTestParser()
+					const dom = parser.parseFromString(
+						`<xml attr="${reference}"/>`,
+						MIME_TYPE.XML_TEXT
+					)
+
+					const attr = dom.documentElement.attributes.getNamedItem('attr')
+
+					expect(attr.value).toBe(literal)
+				}
+			)
+		})
 		it('unclosed root tag will be closed', () => {
 			const { errors, parser } = getTestParser()
 

--- a/test/xmltest/__snapshots__/not-wf.test.js.snap
+++ b/test/xmltest/__snapshots__/not-wf.test.js.snap
@@ -858,6 +858,8 @@ exports[`xmltest/not-wellformed standalone should match 111.xml with snapshot 1`
 Object {
   "actual": "",
   "error": Array [
+    "[xmldom error]	entity not found:&e;
+@#[line:1,col:1]",
     "[xmldom error]	element parse error: Error: invalid attribute:&e;
 @#[line:1,col:1]",
     "[xmldom error]	entity not found:&e;

--- a/test/xmltest/__snapshots__/valid.test.js.snap
+++ b/test/xmltest/__snapshots__/valid.test.js.snap
@@ -313,8 +313,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 043.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"foo
-bar\\"/>",
+  "actual": "<doc a1=\\"foo&#13;&#10;bar\\"/>",
   "expected": "<doc a1=\\"foo bar\\"></doc>",
 }
 `;
@@ -462,7 +461,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 058.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\" 1  	2 	\\"/>",
+  "actual": "<doc a1=\\" 1  &#9;2 &#9;\\"/>",
   "expected": "<doc a1=\\"1 2\\"></doc>",
 }
 `;
@@ -824,30 +823,28 @@ Object {
 
 exports[`xmltest/valid standalone should match 104.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x	y\\"/>",
+  "actual": "<doc a=\\"x&#9;y\\"/>",
   "expected": "<doc a=\\"x y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 105.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x	y\\"/>",
+  "actual": "<doc a=\\"x&#9;y\\"/>",
   "expected": "<doc a=\\"x&#9;y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 106.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x
-y\\"/>",
+  "actual": "<doc a=\\"x&#10;y\\"/>",
   "expected": "<doc a=\\"x&#10;y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 107.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x
-y\\"/>",
+  "actual": "<doc a=\\"x&#13;y\\"/>",
   "expected": "<doc a=\\"x&#13;y\\"></doc>",
 }
 `;

--- a/test/xmltest/__snapshots__/valid.test.js.snap
+++ b/test/xmltest/__snapshots__/valid.test.js.snap
@@ -313,7 +313,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 043.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"foo  bar\\"/>",
+  "actual": "<doc a1=\\"foo bar\\"/>",
   "expected": "<doc a1=\\"foo bar\\"></doc>",
 }
 `;

--- a/test/xmltest/__snapshots__/valid.test.js.snap
+++ b/test/xmltest/__snapshots__/valid.test.js.snap
@@ -313,7 +313,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 043.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"foo&#13;&#10;bar\\"/>",
+  "actual": "<doc a1=\\"foo  bar\\"/>",
   "expected": "<doc a1=\\"foo bar\\"></doc>",
 }
 `;
@@ -461,7 +461,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 058.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\" 1  &#9;2 &#9;\\"/>",
+  "actual": "<doc a1=\\" 1   2  \\"/>",
   "expected": "<doc a1=\\"1 2\\"></doc>",
 }
 `;
@@ -823,7 +823,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 104.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x&#9;y\\"/>",
+  "actual": "<doc a=\\"x y\\"/>",
   "expected": "<doc a=\\"x y\\"></doc>",
 }
 `;


### PR DESCRIPTION
- Added normalization of white space literal characters as specified in https://www.w3.org/TR/xml/#AVNormalize, they now appear as space(s) in the attribute values when accessed from the DOM (and are also serialized as space)
- Added serialization of white space literal values to to the correct numerical character references as described in https://github.com/w3c/DOM-Parsing/issues/59 to fix #284 

BREAKING CHANGE: If you relied on the not spec compliant preservation of `\t`, `\n` or `\r` in **attribute values**. To preserve those you will have to create XML that instead contains the correct numerical (or hexadecimal) equivalent (`&#x9;`, `&#xA;`, `&#xD;`).