### PR TITLE
docs(readme): Add downloads per week badges

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # @xmldom/xmldom
 
-***Since version 0.7.0 this package is published to npm as [`@xmldom/xmldom`](https://www.npmjs.com/package/@xmldom/xmldom) and no longer as [`xmldom`](https://www.npmjs.com/package/xmldom), because [we are no longer able to publish `xmldom`](https://github.com/xmldom/xmldom/issues/271).***  
+***Since version 0.7.0 this package is published to npm as [`@xmldom/xmldom` ![npm downloads per week](https://img.shields.io/npm/dw/@xmldom/xmldom?style=flat-square)](https://www.npmjs.com/package/@xmldom/xmldom) and no longer as [`xmldom` ![npm downloads per week](https://img.shields.io/npm/dw/xmldom?style=flat-square)](https://www.npmjs.com/package/xmldom) , because [we are no longer able to publish `xmldom`](https://github.com/xmldom/xmldom/issues/271).***  
 *For better readability in the docs we will continue to talk about this library as "xmldom".*
 
 [![license](https://img.shields.io/npm/l/@xmldom/xmldom?color=blue&style=flat-square)](LICENSE)


### PR DESCRIPTION
for both `xmldom` and `@xmldom/xmldom` since I keep opening both pages to check the progress of the transition:
- [`@xmldom/xmldom` ![npm downloads per week](https://img.shields.io/npm/dw/@xmldom/xmldom?style=flat-square)](https://www.npmjs.com/package/@xmldom/xmldom) 
- [`xmldom` ![npm downloads per week](https://img.shields.io/npm/dw/xmldom?style=flat-square)](https://www.npmjs.com/package/xmldom) 

I think having the badges at this spot will indicate when we will be able to remove this line from the readme.
It's worth mentioning that more than half of the downloads originates from deprecated versions of `xmldom` (this information is available under the versions tab):
![image](https://user-images.githubusercontent.com/135657/131242968-7633f6aa-1478-4911-8f51-df8f84dd62a0.png)
