### PR TITLE
fix(sax): Restore ability to parse `__prototype__` attributes

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -230,7 +230,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 	 * @param {number} startIndex
 	 */
 	function addAttribute(qname, value, startIndex) {
-		if (qname in el.attributeNames) errorHandler.fatalError('Attribute ' + qname + ' redefined')
+		if (el.attributeNames.hasOwnProperty(qname)) errorHandler.fatalError('Attribute ' + qname + ' redefined')
 		el.addValue(qname, value, startIndex)
 	}
 	var attrName;

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -230,7 +230,9 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 	 * @param {number} startIndex
 	 */
 	function addAttribute(qname, value, startIndex) {
-		if (el.attributeNames.hasOwnProperty(qname)) errorHandler.fatalError('Attribute ' + qname + ' redefined')
+		if (el.attributeNames.hasOwnProperty(qname)) {
+			errorHandler.fatalError('Attribute ' + qname + ' redefined')
+		}
 		el.addValue(qname, value, startIndex)
 	}
 	var attrName;

--- a/test/parse/__snapshots__/parse-element.test.js.snap
+++ b/test/parse/__snapshots__/parse-element.test.js.snap
@@ -10,6 +10,18 @@ Object {
 }
 `;
 
+exports[`XML Node Parse simple attributes should be able to have \`__prototype__\` attribute 1`] = `
+Object {
+  "actual": "<xml __prototype__=\\"\\"/>",
+}
+`;
+
+exports[`XML Node Parse simple attributes should be able to have \`constructor\` attribute 1`] = `
+Object {
+  "actual": "<xml constructor=\\"\\"/>",
+}
+`;
+
 exports[`XML Node Parse simple attributes unclosed root tag will be closed 1`] = `
 Object {
   "actual": "<xml a=\\"1\\" b=\\"2/\\"/>",

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -81,6 +81,26 @@ describe('XML Node Parse', () => {
 
 			expect({ actual, ...errors }).toMatchSnapshot()
 		})
+
+		it('should be able to have `constructor` attribute', () => {
+			const { errors, parser } = getTestParser()
+
+			const actual = parser
+				.parseFromString('<xml constructor=""/>', 'text/xml')
+				.toString()
+
+			expect({ actual, ...errors }).toMatchSnapshot()
+		})
+
+		it('should be able to have `__prototype__` attribute', () => {
+			const { errors, parser } = getTestParser()
+
+			const actual = parser
+				.parseFromString('<xml __prototype__=""/>', 'text/xml')
+				.toString()
+
+			expect({ actual, ...errors }).toMatchSnapshot()
+		})
 	})
 
 	describe('namespaced attributes', () => {


### PR DESCRIPTION
As noted in issue #252 some attributes conflict with prototype fields (such as an attribute `constructor`) thus we must remove the `in` operator and replace with `Object.prototype.hasOwnProperty()`.