### PR TITLE
fix(dom): Preserve default namespace when serializing

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -488,6 +488,20 @@ Node.prototype = {
     hasAttributes:function(){
     	return this.attributes.length>0;
     },
+	/**
+	 * Look up the prefix associated to the given namespace URI, starting from this node.
+	 * **The default namespace declarations are ignored by this method.**
+	 * See Namespace Prefix Lookup for details on the algorithm used by this method.
+	 *
+	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._
+	 *
+	 * @param {string | null} namespaceURI
+	 * @returns {string | null}
+	 * @see https://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-lookupNamespacePrefix
+	 * @see https://www.w3.org/TR/DOM-Level-3-Core/namespaces-algorithms.html#lookupNamespacePrefixAlgo
+	 * @see https://dom.spec.whatwg.org/#dom-node-lookupprefix
+	 * @see https://github.com/xmldom/xmldom/issues/322
+	 */
     lookupPrefix:function(namespaceURI){
     	var el = this;
     	while(el){

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1175,10 +1175,21 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		var prefixedNodeName = nodeName
 		if (!isHTML && !node.prefix && node.namespaceURI) {
 			var defaultNS
+			// lookup current default ns from `xmlns` attribute
 			for (var ai = 0; ai < attrs.length; ai++) {
 				if (attrs.item(ai).name === 'xmlns') {
 					defaultNS = attrs.item(ai).value
 					break
+				}
+			}
+			if (!defaultNS) {
+				// lookup current default ns in visibleNamespaces
+				for (var nsi = visibleNamespaces.length - 1; nsi >= 0; nsi--) {
+					var namespace = visibleNamespaces[nsi]
+					if (namespace.prefix === '' && namespace.namespace === node.namespaceURI) {
+						defaultNS = namespace.namespace
+						break
+					}
 				}
 			}
 			if (defaultNS !== node.namespaceURI) {

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -119,6 +119,33 @@ describe('XML Serializer', () => {
 			)
 		})
 	})
+	describe('is insensitive to namespace order', () => {
+		it('should produce unprefixed svg elements regardless of xmlns vs xmnls:svg order', () => {
+			const svgNamedIsFirst = [
+				'<svg version="1.1" width="153" height="144" ',
+				'  xmlns:svg="http://www.w3.org/2000/svg" ',
+				'  xmlns="http://www.w3.org/2000/svg" >',
+				'<g><circle cx="60" cy="60" r="50"/></g>',
+				'</svg>',
+			].join('\n')
+			const dom1 = new DOMParser().parseFromString(svgNamedIsFirst, 'text/xml')
+			const result1 = new XMLSerializer().serializeToString(dom1)
+			expect(result1).not.toContain('<svg:g')
+			const svgDefaultIsFirst = [
+				'<svg version="1.1" width="153" height="144" ',
+				'  xmlns="http://www.w3.org/2000/svg" ',
+				'  xmlns:svg="http://www.w3.org/2000/svg" >',
+				'<g><circle cx="60" cy="60" r="50"/></g>',
+				'</svg>',
+			].join('\n')
+			const dom2 = new DOMParser().parseFromString(
+				svgDefaultIsFirst,
+				'text/xml'
+			)
+			const result2 = new XMLSerializer().serializeToString(dom2)
+			expect(result2.toString()).not.toContain('<svg:g')
+		})
+	})
 	describe('properly escapes attribute values', () => {
 		it('should escape special characters in namespace attributes', () => {
 			const input = `<xml xmlns='<&"' xmlns:attr='"&<'><test attr:test=""/></xml>`

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -119,7 +119,7 @@ describe('XML Serializer', () => {
 			)
 		})
 	})
-	describe.only('is insensitive to namespace order', () => {
+	describe('is insensitive to namespace order', () => {
 		it('should preserve prefixes for inner elements and attributes', () => {
 			const NS = 'http://www.w3.org/test'
 			const xml = `

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -133,8 +133,8 @@ describe('XML Serializer', () => {
 `.trim()
 			const dom = new DOMParser().parseFromString(xml, 'text/xml')
 			const doc = dom.documentElement
-			const levelOne = doc.childNodes.item(1)
-			expect(levelOne).toMatchObject({
+			const one = doc.childNodes.item(1)
+			expect(one).toMatchObject({
 				localName: 'one',
 				nodeName: 'one',
 				prefix: null,
@@ -147,15 +147,15 @@ describe('XML Serializer', () => {
 				prefix: null,
 				namespaceURI: NS,
 			})
-			const levelTwo = group.childNodes.item(1)
-			expect(levelTwo).toMatchObject({
+			const two = group.childNodes.item(1)
+			expect(two).toMatchObject({
 				localName: 'two',
 				nodeName: 'two',
 				prefix: null,
 				namespaceURI: NS,
 			})
-			const innerLevelTow = group.childNodes.item(3)
-			expect(innerLevelTow).toMatchObject({
+			const three = group.childNodes.item(3)
+			expect(three).toMatchObject({
 				localName: 'three',
 				nodeName: 'inner:three',
 				prefix: 'inner',
@@ -176,8 +176,8 @@ describe('XML Serializer', () => {
 `.trim()
 			const dom = new DOMParser().parseFromString(xml, 'text/xml')
 			const doc = dom.documentElement
-			const levelOne = doc.childNodes.item(1)
-			expect(levelOne).toMatchObject({
+			const one = doc.childNodes.item(1)
+			expect(one).toMatchObject({
 				localName: 'one',
 				nodeName: 'inner:one',
 				prefix: 'inner',
@@ -190,15 +190,15 @@ describe('XML Serializer', () => {
 				prefix: 'inner',
 				namespaceURI: NS,
 			})
-			const levelTwo = group.childNodes.item(1)
-			expect(levelTwo).toMatchObject({
+			const two = group.childNodes.item(1)
+			expect(two).toMatchObject({
 				localName: 'two',
 				nodeName: 'inner:two',
 				prefix: 'inner',
 				namespaceURI: NS,
 			})
-			const innerLevelTow = group.childNodes.item(3)
-			expect(innerLevelTow).toMatchObject({
+			const three = group.childNodes.item(3)
+			expect(three).toMatchObject({
 				localName: 'three',
 				nodeName: 'three',
 				prefix: null,

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -121,15 +121,11 @@ describe('XML Serializer', () => {
 	})
 	describe.only('is insensitive to namespace order', () => {
 		//TODO fill in tests (think of an example as simple as possible that makes sense, doesn't have to be SVG related)
-		it('should preserve prefixes for inner elements and attributes')
-		it(
-			'should preserve missing prefixes for inner prefixed elements and attributes'
-		)
+		it('should preserve prefixes for inner elements and attributes', () => {})
+		it('should preserve missing prefixes for inner prefixed elements and attributes', () => {})
 		it('should produce unprefixed svg elements when prefixed namespace comes first', () => {
 			const svg = `
-<svg 
-	xmlns:svg="http://www.w3.org/2000/svg" 
-	xmlns="http://www.w3.org/2000/svg">
+<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg">
 	<g><circle/></g>
 </svg>`
 			const dom = new DOMParser().parseFromString(svg, 'text/xml')
@@ -138,10 +134,7 @@ describe('XML Serializer', () => {
 		})
 		it('should produce unprefixed svg elements when default namespace comes first', () => {
 			const svg = `
-<svg 
-	xmlns="http://www.w3.org/2000/svg"
-	xmlns:svg="http://www.w3.org/2000/svg" 
-	>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
 	<g><circle/></g>
 </svg>`
 			const dom = new DOMParser().parseFromString(svg, 'text/xml')

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -119,31 +119,34 @@ describe('XML Serializer', () => {
 			)
 		})
 	})
-	describe('is insensitive to namespace order', () => {
-		it('should produce unprefixed svg elements regardless of xmlns vs xmnls:svg order', () => {
-			const svgNamedIsFirst = [
-				'<svg version="1.1" width="153" height="144" ',
-				'  xmlns:svg="http://www.w3.org/2000/svg" ',
-				'  xmlns="http://www.w3.org/2000/svg" >',
-				'<g><circle cx="60" cy="60" r="50"/></g>',
-				'</svg>',
-			].join('\n')
-			const dom1 = new DOMParser().parseFromString(svgNamedIsFirst, 'text/xml')
-			const result1 = new XMLSerializer().serializeToString(dom1)
-			expect(result1).not.toContain('<svg:g')
-			const svgDefaultIsFirst = [
-				'<svg version="1.1" width="153" height="144" ',
-				'  xmlns="http://www.w3.org/2000/svg" ',
-				'  xmlns:svg="http://www.w3.org/2000/svg" >',
-				'<g><circle cx="60" cy="60" r="50"/></g>',
-				'</svg>',
-			].join('\n')
-			const dom2 = new DOMParser().parseFromString(
-				svgDefaultIsFirst,
-				'text/xml'
-			)
-			const result2 = new XMLSerializer().serializeToString(dom2)
-			expect(result2.toString()).not.toContain('<svg:g')
+	describe.only('is insensitive to namespace order', () => {
+		//TODO fill in tests (think of an example as simple as possible that makes sense, doesn't have to be SVG related)
+		it('should preserve prefixes for inner elements and attributes')
+		it(
+			'should preserve missing prefixes for inner prefixed elements and attributes'
+		)
+		it('should produce unprefixed svg elements when prefixed namespace comes first', () => {
+			const svg = `
+<svg 
+	xmlns:svg="http://www.w3.org/2000/svg" 
+	xmlns="http://www.w3.org/2000/svg">
+	<g><circle/></g>
+</svg>`
+			const dom = new DOMParser().parseFromString(svg, 'text/xml')
+
+			expect(new XMLSerializer().serializeToString(dom)).toEqual(svg)
+		})
+		it('should produce unprefixed svg elements when default namespace comes first', () => {
+			const svg = `
+<svg 
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:svg="http://www.w3.org/2000/svg" 
+	>
+	<g><circle/></g>
+</svg>`
+			const dom = new DOMParser().parseFromString(svg, 'text/xml')
+
+			expect(new XMLSerializer().serializeToString(dom)).toEqual(svg)
 		})
 	})
 	describe('properly escapes attribute values', () => {


### PR DESCRIPTION
The regression was introduced as part of #268 by not considering the visible default namespace for attributes without a prefix.

Fixes #319 