### PR TITLE
ci(test): Restore latest node version to 16.x

### DIFF
--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -20,7 +20,7 @@ jobs:
         - 10.x
         - 12.x
         - 14.x
-        - 16.8
+        - 16.x
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
since 16.9.1 was released which fixed the regression in 16.9.0