### PR TITLE
fix: Only use HTML rules if mimeType matches

### DIFF
--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -7,6 +7,8 @@ const source = `<xml xmlns="a">
 
 const doc = new DOMParser().parseFromString(source, 'text/xml')
 
+if (!doc) throw 'expected Document but was undefined'
+
 const serialized = new XMLSerializer().serializeToString(doc)
 
 if (source !== serialized) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,43 +1,45 @@
 /// <reference lib="dom" />
 
-declare module "@xmldom/xmldom" {
-  var DOMParser: DOMParserStatic;
-  var XMLSerializer: XMLSerializerStatic;
-  var DOMImplementation: DOMImplementationStatic;
+declare module '@xmldom/xmldom' {
+	var DOMParser: DOMParserStatic
+	var XMLSerializer: XMLSerializerStatic
+	var DOMImplementation: DOMImplementationStatic
 
-  interface DOMImplementationStatic {
-      new(): DOMImplementation;
-  }
+	interface DOMImplementationStatic {
+		new (): DOMImplementation
+	}
 
-  interface DOMParserStatic {
-      new (): DOMParser;
-      new (options: Options): DOMParser;
-  }
+	interface DOMParserStatic {
+		new (): DOMParser
+		new (options: DOMParserOptions): DOMParser
+	}
 
-  interface XMLSerializerStatic {
-      new (): XMLSerializer;
-  }
+	interface XMLSerializerStatic {
+		new (): XMLSerializer
+	}
 
-  interface DOMParser {
-      parseFromString(xmlsource: string, mimeType?: string): Document;
-  }
+	interface DOMParser {
+		parseFromString(source: string, mimeType?: string): Document | undefined
+	}
 
-  interface XMLSerializer {
-      serializeToString(node: Node): string;
-  }
+	interface XMLSerializer {
+		serializeToString(node: Node): string
+	}
 
-  interface Options {
-      locator?: any;
-      errorHandler?: ErrorHandlerFunction | ErrorHandlerObject | undefined;
-  }
+	interface DOMParserOptions {
+		errorHandler?: ErrorHandlerFunction | ErrorHandlerObject
+		locator?: { columnNumber?: number; lineNumber?: number }
+		normalizeLineEndings?: (source: string) => string
+		xmlns?: Record<string, string | null | undefined>
+	}
 
-  interface ErrorHandlerFunction {
-      (level: string, msg: any): any;
-  }
+	interface ErrorHandlerFunction {
+		(level: 'warn' | 'error' | 'fatalError', msg: string): void
+	}
 
-  interface ErrorHandlerObject {
-      warning?: ((msg: any) => any) | undefined;
-      error?: ((msg: any) => any) | undefined;
-      fatalError?: ((msg: any) => any) | undefined;
-  }
+	interface ErrorHandlerObject {
+		warning?: (msg: string) => void
+		error?: (msg: string) => void
+		fatalError?: (msg: string) => void
+	}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ declare module '@xmldom/xmldom' {
 
 	interface DOMParserOptions {
 		errorHandler?: ErrorHandlerFunction | ErrorHandlerObject
-		locator?: { columnNumber?: number; lineNumber?: number }
+		locator?: boolean
 		normalizeLineEndings?: (source: string) => string
 		xmlns?: Record<string, string | null | undefined>
 	}

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -48,6 +48,103 @@ function assign(target, source) {
 }
 
 /**
+ * A number of attributes are boolean attributes.
+ * The presence of a boolean attribute on an element represents the `true` value,
+ * and the absence of the attribute represents the `false` value.
+ *
+ * If the attribute is present, its value must either be the empty string
+ * or a value that is an ASCII case-insensitive match for the attribute's canonical name,
+ * with no leading or trailing whitespace.
+ *
+ * Note: The values `"true"` and `"false"` are not allowed on boolean attributes.
+ * To represent a `false` value, the attribute has to be omitted altogether.
+ *
+ * @see https://html.spec.whatwg.org/#boolean-attributes
+ * @see https://html.spec.whatwg.org/#attributes-3
+ */
+var HTML_BOOLEAN_ATTRIBUTES = freeze({
+	allowfullscreen: true,
+	async: true,
+	autofocus: true,
+	autoplay: true,
+	checked: true,
+	controls: true,
+	default: true,
+	defer: true,
+	disabled: true,
+	formnovalidate: true,
+	hidden: true,
+	ismap: true,
+	itemscope: true,
+	loop: true,
+	multiple: true,
+	muted: true,
+	nomodule: true,
+	novalidate: true,
+	open: true,
+	playsinline: true,
+	readonly: true,
+	required: true,
+	reversed: true,
+	selected: true,
+})
+
+/**
+ * Check if `name` is matching one of the HTML boolean attribute names.
+ * This method doesn't check if such attributes are allowed in the context of the current document/parsing.
+ *
+ * @param {string} name
+ * @return {boolean}
+ * @see HTML_BOOLEAN_ATTRIBUTES
+ * @see https://html.spec.whatwg.org/#boolean-attributes
+ * @see https://html.spec.whatwg.org/#attributes-3
+ */
+function isHTMLBooleanAttribute(name) {
+	return HTML_BOOLEAN_ATTRIBUTES.hasOwnProperty(name.toLowerCase())
+}
+
+/**
+ * Void elements only have a start tag; end tags must not be specified for void elements.
+ * These elements should be written as self closing like this: `<area />`.
+ * This should not be confused with tags that HTML allows to omit the end tag for
+ * (like `li`, `tr` and others), which have content after them,
+ * so they can not be written as self closing.
+ * (xmldom does not have any logic for ommitable cases and will report them as a warning.)
+ *
+ * @type {Readonly<{area: boolean, col: boolean, img: boolean, wbr: boolean, link: boolean, hr: boolean, source: boolean, br: boolean, input: boolean, param: boolean, meta: boolean, embed: boolean, track: boolean, base: boolean}>}
+ * @see https://html.spec.whatwg.org/#void-elements
+ */
+var HTML_VOID_ELEMENTS = freeze({
+	area: true,
+	base: true,
+	br: true,
+	col: true,
+	embed: true,
+	hr: true,
+	img: true,
+	input: true,
+	link: true,
+	meta: true,
+	param: true,
+	source: true,
+	track: true,
+	wbr: true,
+})
+
+/**
+ * Check if `tagName` is matching one of the HTML void element names.
+ * This method doesn't check if such tags are allowed
+ * in the context of the current document/parsing.
+ *
+ * @param {string} tagName
+ * @return {boolean}
+ * @see HTML_VOID_ELEMENTS
+ */
+function isHTMLVoidElement(tagName) {
+	return HTML_VOID_ELEMENTS.hasOwnProperty(tagName.toLowerCase())
+}
+
+/**
  * All mime types that are allowed as input to `DOMParser.parseFromString`
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02 MDN
@@ -93,7 +190,9 @@ var MIME_TYPE = freeze({
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 	 */
 	hasDefaultHTMLNamespace: function (mimeType) {
-		return MIME_TYPE.isHTML(mimeType) || mimeType === MIME_TYPE.XML_XHTML_APPLICATION;
+		return (
+			MIME_TYPE.isHTML(mimeType) || mimeType === MIME_TYPE.XML_XHTML_APPLICATION
+		)
 	},
 
 	/**
@@ -180,7 +279,11 @@ var NAMESPACE = freeze({
 	XMLNS: 'http://www.w3.org/2000/xmlns/',
 })
 
-exports.assign = assign;
-exports.freeze = freeze;
-exports.MIME_TYPE = MIME_TYPE;
-exports.NAMESPACE = NAMESPACE;
+exports.assign = assign
+exports.freeze = freeze
+exports.HTML_BOOLEAN_ATTRIBUTES = HTML_BOOLEAN_ATTRIBUTES
+exports.HTML_VOID_ELEMENTS = HTML_VOID_ELEMENTS
+exports.isHTMLBooleanAttribute = isHTMLBooleanAttribute
+exports.isHTMLVoidElement = isHTMLVoidElement
+exports.MIME_TYPE = MIME_TYPE
+exports.NAMESPACE = NAMESPACE

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -188,7 +188,7 @@ function isHTMLRawTextElement(tagName) {
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
 function isHTMLEscapableRawTextElement(tagName) {
-	const key = tagName.toLowerCase();
+	var key = tagName.toLowerCase();
 	return HTML_RAW_TEXT_ELEMENTS.hasOwnProperty(key) && HTML_RAW_TEXT_ELEMENTS[key];
 }
 

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -9,7 +9,7 @@
  *
  * @template T
  * @param {T} object the object to freeze
- * @param {Pick<ObjectConstructor, 'freeze'> = Object} oc `Object` by default,
+ * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object] `Object` by default,
  * 				allows to inject custom object constructor for tests
  * @returns {Readonly<T>}
  *
@@ -72,10 +72,11 @@ var MIME_TYPE = freeze({
 	 * @param {string} [value]
 	 * @returns {boolean}
 	 *
-	 * @see https://www.iana.org/assignments/media-types/text/html IANA MimeType registration
-	 * @see https://en.wikipedia.org/wiki/HTML Wikipedia
-	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString MDN
-	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring 	 */
+	 * @see [IANA MimeType registration](https://www.iana.org/assignments/media-types/text/html)
+	 * @see [Wikipedia](https://en.wikipedia.org/wiki/HTML)
+	 * @see [`DOMParser.parseFromString` @ MDN](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString)
+	 * @see [`DOMParser.parseFromString` @ HTML Specification](https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring)
+	 */
 	isHTML: function (value) {
 		return value === MIME_TYPE.HTML
 	},

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -81,6 +81,21 @@ var MIME_TYPE = freeze({
 	},
 
 	/**
+	 * For both the `text/html` and the `application/xhtml+xml` namespace
+	 * the spec defines that the HTML namespace is provided as the default in some cases.
+	 *
+	 * @param {string} mimeType
+	 * @returns {boolean}
+	 *
+	 * @see https://dom.spec.whatwg.org/#dom-document-createelement
+	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument
+	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
+	 */
+	hasDefaultHTMLNamespace: function (mimeType) {
+		return MIME_TYPE.isHTML(mimeType) || mimeType === MIME_TYPE.XML_XHTML_APPLICATION;
+	},
+
+	/**
 	 * `application/xml`, the standard mime type for XML documents.
 	 *
 	 * @see https://www.iana.org/assignments/media-types/application/xml IANA MimeType registration

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -106,13 +106,15 @@ function isHTMLBooleanAttribute(name) {
 /**
  * Void elements only have a start tag; end tags must not be specified for void elements.
  * These elements should be written as self closing like this: `<area />`.
- * This should not be confused with tags that HTML allows to omit the end tag for
- * (like `li`, `tr` and others), which have content after them,
+ * This should not be confused with optional tags that HTML allows to omit the end tag for
+ * (like `li`, `tr` and others), which can have content after them,
  * so they can not be written as self closing.
- * (xmldom does not have any logic for ommitable cases and will report them as a warning.)
+ * xmldom does not have any logic for optional end tags cases and will report them as a warning.
+ * Content that would go into the unopened element will instead be added as a sibling text node.
  *
  * @type {Readonly<{area: boolean, col: boolean, img: boolean, wbr: boolean, link: boolean, hr: boolean, source: boolean, br: boolean, input: boolean, param: boolean, meta: boolean, embed: boolean, track: boolean, base: boolean}>}
  * @see https://html.spec.whatwg.org/#void-elements
+ * @see https://html.spec.whatwg.org/#optional-tags
  */
 var HTML_VOID_ELEMENTS = freeze({
 	area: true,
@@ -139,6 +141,7 @@ var HTML_VOID_ELEMENTS = freeze({
  * @param {string} tagName
  * @return {boolean}
  * @see HTML_VOID_ELEMENTS
+ * @see https://html.spec.whatwg.org/#void-elements
  */
 function isHTMLVoidElement(tagName) {
 	return HTML_VOID_ELEMENTS.hasOwnProperty(tagName.toLowerCase())

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -145,6 +145,54 @@ function isHTMLVoidElement(tagName) {
 }
 
 /**
+ * Tag names that are raw text elements according to HTML spec.
+ * The value denotes whether they are escapable or not.
+ *
+ * @see isHTMLEscapableRawTextElement
+ * @see isHTMLRawTextElement
+ * @see https://html.spec.whatwg.org/#raw-text-elements
+ * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
+ */
+var HTML_RAW_TEXT_ELEMENTS = freeze({
+	script: false,
+	style: false,
+	textarea: true,
+	title: true,
+})
+
+/**
+ * Check if `tagName` is matching one of the HTML raw text element names.
+ * It includes escapable and not escapable raw text elements.
+ * This method doesn't check if such tags are allowed
+ * in the context of the current document/parsing.
+ *
+ * @param {string} tagName
+ * @return {boolean}
+ * @see HTML_RAW_TEXT_ELEMENTS
+ * @see https://html.spec.whatwg.org/#raw-text-elements
+ * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
+ */
+function isHTMLRawTextElement(tagName) {
+	return HTML_RAW_TEXT_ELEMENTS.hasOwnProperty(tagName.toLowerCase())
+}
+/**
+ * Check if `tagName` is matching one of the HTML escapable raw text element names.
+ * This method doesn't check if such tags are allowed
+ * in the context of the current document/parsing.
+ *
+ * @param {string} tagName
+ * @return {boolean}
+ * @see isHTMLRawTextElement
+ * @see HTML_RAW_TEXT_ELEMENTS
+ * @see https://html.spec.whatwg.org/#raw-text-elements
+ * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
+ */
+function isHTMLEscapableRawTextElement(tagName) {
+	const key = tagName.toLowerCase();
+	return HTML_RAW_TEXT_ELEMENTS.hasOwnProperty(key) && HTML_RAW_TEXT_ELEMENTS[key];
+}
+
+/**
  * All mime types that are allowed as input to `DOMParser.parseFromString`
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02 MDN
@@ -282,8 +330,11 @@ var NAMESPACE = freeze({
 exports.assign = assign
 exports.freeze = freeze
 exports.HTML_BOOLEAN_ATTRIBUTES = HTML_BOOLEAN_ATTRIBUTES
+exports.HTML_RAW_TEXT_ELEMENTS = HTML_RAW_TEXT_ELEMENTS
 exports.HTML_VOID_ELEMENTS = HTML_VOID_ELEMENTS
 exports.isHTMLBooleanAttribute = isHTMLBooleanAttribute
+exports.isHTMLRawTextElement = isHTMLRawTextElement
+exports.isHTMLEscapableRawTextElement = isHTMLEscapableRawTextElement
 exports.isHTMLVoidElement = isHTMLVoidElement
 exports.MIME_TYPE = MIME_TYPE
 exports.NAMESPACE = NAMESPACE

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -162,18 +162,19 @@ var HTML_RAW_TEXT_ELEMENTS = freeze({
 
 /**
  * Check if `tagName` is matching one of the HTML raw text element names.
- * It includes escapable and not escapable raw text elements.
  * This method doesn't check if such tags are allowed
  * in the context of the current document/parsing.
  *
  * @param {string} tagName
  * @return {boolean}
+ * @see isHTMLEscapableRawTextElement
  * @see HTML_RAW_TEXT_ELEMENTS
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
 function isHTMLRawTextElement(tagName) {
-	return HTML_RAW_TEXT_ELEMENTS.hasOwnProperty(tagName.toLowerCase())
+	var key = tagName.toLowerCase();
+	return HTML_RAW_TEXT_ELEMENTS.hasOwnProperty(key) && !HTML_RAW_TEXT_ELEMENTS[key];
 }
 /**
  * Check if `tagName` is matching one of the HTML escapable raw text element names.

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -102,6 +102,14 @@ function DOMParser(options){
 	 * @see conventions.assign
 	 */
 	this.assign = this.options.assign || Object.assign || conventions.assign
+
+	/**
+	 * A function that can be invoked as the errorHandler instead of the default ones.
+	 * @type {Function | undefined}
+	 * @readonly
+	 */
+	this.errorHandler = this.options.errorHandler;
+
 	/**
 	 * used to replace line endings before parsing, defaults to `normalizeLineEndings`
 	 *
@@ -178,14 +186,13 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 			mimeType: mimeType,
 			defaultNamespace: defaultNamespace,
 		})
-	var errorHandler = this.options.errorHandler
 	var locator = this.locator ? {} : undefined;
 	if (this.locator) {
 		domBuilder.setDocumentLocator(locator)
 	}
 
 	var sax = new XMLReader()
-	sax.errorHandler = buildErrorHandler(errorHandler, domBuilder, locator)
+	sax.errorHandler = buildErrorHandler(this.errorHandler, domBuilder, locator)
 	sax.domBuilder = domBuilder
 	if (source && typeof source === 'string') {
 		sax.parse(this.normalizeLineEndings(source), defaultNSMap, entityMap)

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -74,7 +74,7 @@ function normalizeLineEndings(input) {
  */
 function DOMParser(options){
 	/**
-	 * @type {DOMParserOptions}
+	 * @type {Readonly<DOMParserOptions>}
 	 * @readonly
 	 * @private
 	 */
@@ -82,10 +82,9 @@ function DOMParser(options){
 
 	/**
 	 * Configured or pony-filled version of `Object.assign`
-	 * @type {typeof conventions.assign}
+	 * @type {Function}
 	 * @readonly
 	 * @private
-
 	 */
 	this.assign = this.options.assign || Object.assign || conventions.assign
 }
@@ -118,8 +117,7 @@ function DOMParser(options){
  * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
  */
 DOMParser.prototype.parseFromString = function (source, mimeType) {
-	var options = this.options
-	var defaultNSMap = options.xmlns || {}
+	var defaultNSMap = this.assign({}, this.options.xmlns)
 	var entityMap = entities.XML_ENTITIES
 	var defaultNamespace = defaultNSMap[''] || null
 	if (MIME_TYPE.hasDefaultHTMLNamespace(mimeType)) {
@@ -131,13 +129,13 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 	defaultNSMap.xml = defaultNSMap.xml || NAMESPACE.XML
 	defaultNSMap[''] = defaultNamespace
 	var domBuilder =
-		options.domBuilder ||
+		this.options.domBuilder ||
 		new DOMHandler({
 			mimeType: mimeType,
 			defaultNamespace: defaultNamespace,
 		})
-	var errorHandler = options.errorHandler
-	var locator = options.locator
+	var errorHandler = this.options.errorHandler
+	var locator = this.options.locator && this.assign({}, this.options.locator)
 	if (locator) {
 		domBuilder.setDocumentLocator(locator)
 	}
@@ -145,7 +143,7 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 	var sax = new XMLReader()
 	sax.errorHandler = buildErrorHandler(errorHandler, domBuilder, locator)
 	sax.domBuilder = domBuilder
-	var normalize = options.normalizeLineEndings || normalizeLineEndings
+	var normalize = this.options.normalizeLineEndings || normalizeLineEndings
 	if (source && typeof source === 'string') {
 		sax.parse(normalize(source), defaultNSMap, entityMap)
 	} else {

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -14,7 +14,7 @@ var ParseError = sax.ParseError;
 var XMLReader = sax.XMLReader;
 
 /**
- * Normalizes line ending according to https://www.w3.org/TR/xml11/#sec-line-ends:
+ * Normalizes line ending according to <https://www.w3.org/TR/xml11/#sec-line-ends>:
  *
  * > XML parsed entities are often stored in computer files which,
  * > for editing convenience, are organized into lines.

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -84,12 +84,8 @@ function normalizeLineEndings(input) {
  * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
  */
 function DOMParser(options){
-	/**
-	 * @type {Readonly<DOMParserOptions>}
-	 * @readonly
-	 * @private
-	 */
-	this.options = options || {};
+
+	options = options || {locator:true};
 
 	/**
 	 * The method to use instead of `Object.assign` (or if not available `conventions.assign`),
@@ -100,7 +96,7 @@ function DOMParser(options){
 	 * @private
 	 * @see conventions.assign
 	 */
-	this.assign = this.options.assign || Object.assign || conventions.assign
+	this.assign = options.assign || Object.assign || conventions.assign
 
 	/**
 	 * For internal testing: The class for creating an instance for handling events from the SAX parser.
@@ -110,14 +106,14 @@ function DOMParser(options){
 	 * @readonly
 	 * @private
 	 */
-	this.domHandler = this.options.domHandler || DOMHandler
+	this.domHandler = options.domHandler || DOMHandler
 
 	/**
 	 * A function that can be invoked as the errorHandler instead of the default ones.
 	 * @type {Function | undefined}
 	 * @readonly
 	 */
-	this.errorHandler = this.options.errorHandler;
+	this.errorHandler = options.errorHandler;
 
 	/**
 	 * used to replace line endings before parsing, defaults to `normalizeLineEndings`
@@ -125,7 +121,7 @@ function DOMParser(options){
 	 * @type {(string) => string}
 	 * @readonly
 	 */
-	this.normalizeLineEndings = this.options.normalizeLineEndings || normalizeLineEndings
+	this.normalizeLineEndings = options.normalizeLineEndings || normalizeLineEndings
 
 	/**
 	 * Configures if the nodes created during parsing
@@ -135,7 +131,7 @@ function DOMParser(options){
 	 * @type {boolean}
 	 * @readonly
 	 */
-	this.locator = !options || !!options.locator
+	this.locator = !!options.locator
 
 	/**
 	 * The default namespace can be provided by the key that is the empty string.
@@ -145,7 +141,7 @@ function DOMParser(options){
 	 * @type {Readonly<object>}
 	 * @readonly
 	 */
-	this.xmlns = this.options.xmlns || {}
+	this.xmlns = options.xmlns || {}
 }
 
 /**

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var conventions = require("./conventions");
 var dom = require('./dom')
 var entities = require('./entities');

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -5,6 +5,7 @@ var sax = require('./sax');
 
 var DOMImplementation = dom.DOMImplementation;
 
+var MIME_TYPE = conventions.MIME_TYPE;
 var NAMESPACE = conventions.NAMESPACE;
 
 var ParseError = sax.ParseError;
@@ -45,12 +46,14 @@ function normalizeLineEndings(input) {
 
 /**
  * @typedef DOMParserOptions
- * @property {DOMHandler} [domBuilder]
+ * @property {DOMHandler} [domBuilder] Deprecated: The instance handling events from the SAX parser.
+ *           Warning: By configuring a faulty implementation/instance for `DOMParserOptions.domBuilder`,
+ *           the complete described behavior can be completely broken in many ways.
  * @property {Function} [errorHandler]
+ * @property {Locator} [locator]
  * @property {(string) => string} [normalizeLineEndings] used to replace line endings before parsing
  * 						defaults to `normalizeLineEndings`
- * @property {Locator} [locator]
- * @property {Record<string, string>} [xmlns]
+ * @property {Record<string, string | null | undefined>} [xmlns]
  *
  * @see normalizeLineEndings
  */
@@ -60,7 +63,7 @@ function normalizeLineEndings(input) {
  * from a string into a DOM `Document`.
  *
  * _xmldom is different from the spec in that it allows an `options` parameter,
- * to override the default behavior._
+ * to control the behavior._
  *
  * @param {DOMParserOptions} [options]
  * @constructor
@@ -69,39 +72,74 @@ function normalizeLineEndings(input) {
  * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
  */
 function DOMParser(options){
+	/**
+	 * @type {DOMParserOptions}
+	 */
 	this.options = options ||{locator:{}};
 }
 
-DOMParser.prototype.parseFromString = function(source,mimeType){
-	var options = this.options;
-	var sax =  new XMLReader();
-	var domBuilder = options.domBuilder || new DOMHandler();//contentHandler and LexicalHandler
-	var errorHandler = options.errorHandler;
-	var locator = options.locator;
-	var defaultNSMap = options.xmlns||{};
-	var isHTML = /\/x?html?$/.test(mimeType);//mimeType.toLowerCase().indexOf('html') > -1;
-  	var entityMap = isHTML ? entities.HTML_ENTITIES : entities.XML_ENTITIES;
-	if(locator){
+/**
+ * Parses `source` using the options in the way configured by the `DOMParserOptions` of `this` `DOMParser`.
+ * If `mimeType` is `text/html` an HTML `Document` is created, otherwise an XML `Document` is created.
+ *
+ * __It behaves very different from the description in the living standard__:
+ * - Only allows the first argument to be a string (calls `error` handler otherwise.)
+ * - The second parameter is optional (defaults to `application/xml`) and can be any string,
+ *   no `TypeError` will be thrown for values not listed in the spec.
+ * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior/implementation.
+ * - Instead of creating a Document containing the error message,
+ *   it triggers `errorHandler`(s) when unexpected input is found, which means it can return `undefined`.
+ *   All error handlers can throw errors, by default only the `fatalError` handler throws (a `ParserError`).
+ * - All errors thrown during the parsing that are not a `ParserError` are caught and reported using an error handler.
+ * - If no `ParserError` is thrown, this method returns the `DOMHandler.doc`,
+ *   which most likely is the `Document` that has been created during parsing, or `undefined`.
+ *   __**Warning: By configuring a faulty implementation/instance for the deprecated `DOMParserOptions.domBuilder`,
+ *   the complete described behavior can be completely broken in many ways.**__
+ *
+ * @param {string} source Only string input is possible!
+ * @param {string} [mimeType='application/xml'] the mimeType or contentType of the document to be created
+ * 				determines the `type` of document created (XML or HTML)
+ * @returns {Document | undefined}
+ * @throws ParseError for specific errors depending on the configured `errorHandler`s and/or `domBuilder`
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
+ * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
+ */
+DOMParser.prototype.parseFromString = function (source, mimeType) {
+	var options = this.options
+	var defaultNSMap = options.xmlns || {}
+	var entityMap = entities.XML_ENTITIES
+	var defaultNamespace = defaultNSMap[''] || null
+	if (MIME_TYPE.hasDefaultHTMLNamespace(mimeType)) {
+		entityMap = entities.HTML_ENTITIES
+		defaultNamespace = NAMESPACE.HTML
+	} else if (mimeType === MIME_TYPE.XML_SVG_IMAGE) {
+		defaultNamespace = NAMESPACE.SVG
+	}
+	defaultNSMap.xml = defaultNSMap.xml || NAMESPACE.XML
+	defaultNSMap[''] = defaultNamespace
+	var domBuilder =
+		options.domBuilder ||
+		new DOMHandler({
+			mimeType: mimeType,
+			defaultNamespace: defaultNamespace,
+		})
+	var errorHandler = options.errorHandler
+	var locator = options.locator
+	if (locator) {
 		domBuilder.setDocumentLocator(locator)
 	}
 
-	sax.errorHandler = buildErrorHandler(errorHandler,domBuilder,locator);
-	sax.domBuilder = options.domBuilder || domBuilder;
-	if(isHTML){
-		defaultNSMap[''] = NAMESPACE.HTML;
-	}
-	defaultNSMap.xml = defaultNSMap.xml || NAMESPACE.XML;
-	var normalize = options.normalizeLineEndings || normalizeLineEndings;
+	var sax = new XMLReader()
+	sax.errorHandler = buildErrorHandler(errorHandler, domBuilder, locator)
+	sax.domBuilder = domBuilder
+	var normalize = options.normalizeLineEndings || normalizeLineEndings
 	if (source && typeof source === 'string') {
-		sax.parse(
-			normalize(source),
-			defaultNSMap,
-			entityMap
-		)
+		sax.parse(normalize(source), defaultNSMap, entityMap)
 	} else {
 		sax.errorHandler.error('invalid doc source')
 	}
-	return domBuilder.doc;
+	return domBuilder.doc
 }
 function buildErrorHandler(errorImpl,domBuilder,locator){
 	if(!errorImpl){
@@ -128,33 +166,108 @@ function buildErrorHandler(errorImpl,domBuilder,locator){
 	return errorHandler;
 }
 
-//console.log('#\n\n\n\n\n\n\n####')
 /**
- * +ContentHandler+ErrorHandler
- * +LexicalHandler+EntityResolver2
- * -DeclHandler-DTDHandler
- *
- * DefaultHandler:EntityResolver, DTDHandler, ContentHandler, ErrorHandler
- * DefaultHandler2:DefaultHandler,LexicalHandler, DeclHandler, EntityResolver2
- * @link http://www.saxproject.org/apidoc/org/xml/sax/helpers/DefaultHandler.html
+ * @typedef DOMHandlerOptions
+ * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION]
+ * @property {string|null} [defaultNamespace=null]
  */
-function DOMHandler() {
-    this.cdata = false;
+/**
+ * The class that is used to handle events from the SAX parser to create the related DOM elements.
+ *
+ * Some methods are only implemented as an empty function,
+ * since they are (at least currently) not relevant for xmldom.
+ *
+ * @constructor
+ * @param {DOMHandlerOptions} [options]
+ * @see http://www.saxproject.org/apidoc/org/xml/sax/ext/DefaultHandler2.html
+ */
+function DOMHandler(options) {
+	var opt = options || {}
+	/**
+	 * The mime type is used to determine if the DOM handler will create an XML or HTML document.
+	 * Only if it is set to `text/html` it will create an HTML document.
+	 * It defaults to MIME_TYPE.XML_APPLICATION.
+	 *
+	 * @type {string}
+	 * @readonly
+	 * @see MIME_TYPE
+	 */
+	this.mimeType = opt.mimeType || MIME_TYPE.XML_APPLICATION
+
+	/**
+	 * The namespace to use to create an XML document.
+	 * For the following reasons this is required:
+	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace,
+	 *   since at that point there is no way for the parser to know what the default namespace from the document will be.
+	 * - When creating using `DOMImplementation.createDocument` it is required to pass a namespace,
+	 *   to determine the correct `Document.contentType`, which should match `this.mimeType`.
+	 * - When parsing an XML document with the `application/xhtml+xml` mimeType,
+	 *   the HTML namespace needs to be the default namespace.
+	 *
+	 * @type {string|null}
+	 * @readonly
+	 * @private
+	 */
+	this.defaultNamespace = opt.defaultNamespace || null
+
+	/**
+	 * @private
+	 * @type {boolean}
+	 */
+	this.cdata = false
+
+
+	/**
+	 * The last `Element` that was created by `startElement`.
+	 * `endElement` sets it to the `currentElement.parentNode`.
+	 *
+	 * Note: The sax parser currently sets it to white space text nodes between tags.
+	 *
+	 * @type {Element | Node | undefined}
+	 * @private
+	 */
+	this.currentElement = undefined
+
+	/**
+	 * The Document that is created as part of `startDocument`,
+	 * and returned by `DOMParser.parseFromString`.
+	 *
+	 * @type {Document | undefined}
+	 * @readonly
+	 */
+	this.doc = undefined
+
+	/**
+	 * The locator is stored as part of setDocumentLocator.
+	 * It is controlled and mutated by the SAX parser
+	 * to store the current parsing position.
+	 * It is used by DOMHandler to set `columnNumber` and `lineNumber`
+	 * on the DOM nodes.
+	 *
+	 * @type {Readonly<Locator> | undefined}
+	 * @readonly (the sax parser currently sometimes set's it)
+	 * @private
+	 */
+	this.locator = undefined
 }
 function position(locator,node){
 	node.lineNumber = locator.lineNumber;
 	node.columnNumber = locator.columnNumber;
 }
-/**
- * @see org.xml.sax.ContentHandler#startDocument
- * @link http://www.saxproject.org/apidoc/org/xml/sax/ContentHandler.html
- */
 DOMHandler.prototype = {
+	/**
+	 * Either creates an XML or an HTML document and stores it under `this.doc`.
+	 * If it is an XML document, `this.defaultNamespace` is used to create it,
+	 * and it will not contain any `childNodes`.
+	 * If it is an HTML document, it will be created without any `childNodes`.
+	 *
+	 * @see  http://www.saxproject.org/apidoc/org/xml/sax/ContentHandler.html
+	 */
 	startDocument : function() {
-    	this.doc = new DOMImplementation().createDocument(null, null, null);
-    	if (this.locator) {
-        	this.doc.documentURI = this.locator.systemId;
-    	}
+		var impl = new DOMImplementation()
+		this.doc = MIME_TYPE.isHTML(this.mimeType)
+			? impl.createHTMLDocument(false)
+			: impl.createDocument(this.defaultNamespace, '')
 	},
 	startElement:function(namespaceURI, localName, qName, attrs) {
 		var doc = this.doc;
@@ -213,10 +326,17 @@ DOMHandler.prototype = {
 	endDocument:function() {
 		this.doc.normalize();
 	},
+	/**
+	 * Stores the locator to be able to set the `columnNumber` and `lineNumber`
+	 * on the created DOM nodes.
+	 *
+	 * @param {Locator} locator
+	 */
 	setDocumentLocator:function (locator) {
-	    if(this.locator = locator){// && !('lineNumber' in locator)){
-	    	locator.lineNumber = 0;
-	    }
+		if (locator) {
+			locator.lineNumber = 0
+		}
+		this.locator = locator
 	},
 	//LexicalHandler
 	comment:function(chars, start, length) {
@@ -259,7 +379,7 @@ DOMHandler.prototype = {
 }
 function _locator(l){
 	if(l){
-		return '\n@'+(l.systemId ||'')+'#[line:'+l.lineNumber+',col:'+l.columnNumber+']'
+		return '\n@#[line:'+l.lineNumber+',col:'+l.columnNumber+']'
 	}
 }
 function _toString(chars,start,length){

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -102,6 +102,13 @@ function DOMParser(options){
 	 * @see conventions.assign
 	 */
 	this.assign = this.options.assign || Object.assign || conventions.assign
+	/**
+	 * used to replace line endings before parsing, defaults to `normalizeLineEndings`
+	 *
+	 * @type {(string) => string}
+	 * @readonly
+	 */
+	this.normalizeLineEndings = this.options.normalizeLineEndings || normalizeLineEndings
 
 	/**
 	 * Configures if the nodes created during parsing
@@ -180,9 +187,8 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 	var sax = new XMLReader()
 	sax.errorHandler = buildErrorHandler(errorHandler, domBuilder, locator)
 	sax.domBuilder = domBuilder
-	var normalize = this.options.normalizeLineEndings || normalizeLineEndings
 	if (source && typeof source === 'string') {
-		sax.parse(normalize(source), defaultNSMap, entityMap)
+		sax.parse(this.normalizeLineEndings(source), defaultNSMap, entityMap)
 	} else {
 		sax.errorHandler.error('invalid doc source')
 	}

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -49,10 +49,9 @@ function normalizeLineEndings(input) {
  * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign]
  * The method to use instead of `Object.assign` (or if not available `conventions.assign`),
  * which is used to copy values from the options before they are used for parsing.
- * @property {DOMHandler} [domBuilder]
- * Deprecated: The instance handling events from the SAX parser.
- * Warning: By configuring a faulty implementation/instance for `DOMParserOptions.domBuilder`,
- * the complete described behavior can be completely broken in many ways.
+ * @property {typeof DOMHandler} [domHandler]
+ * For internal testing: The class for creating an instance for handling events from the SAX parser.
+ * Warning: By configuring a faulty implementation, the specified behavior can completely be broken.
  * @property {Function} [errorHandler]
  * @property {boolean} [locator=true]
  * Configures if the nodes created during parsing
@@ -102,6 +101,16 @@ function DOMParser(options){
 	 * @see conventions.assign
 	 */
 	this.assign = this.options.assign || Object.assign || conventions.assign
+
+	/**
+	 * For internal testing: The class for creating an instance for handling events from the SAX parser.
+	 * __**Warning: By configuring a faulty implementation, the specified behavior can completely be broken.**__
+	 *
+	 * @type {typeof DOMHandler}
+	 * @readonly
+	 * @private
+	 */
+	this.domHandler = this.options.domHandler || DOMHandler
 
 	/**
 	 * A function that can be invoked as the errorHandler instead of the default ones.
@@ -154,8 +163,8 @@ function DOMParser(options){
  * - All errors thrown during the parsing that are not a `ParserError` are caught and reported using an error handler.
  * - If no `ParserError` is thrown, this method returns the `DOMHandler.doc`,
  *   which most likely is the `Document` that has been created during parsing, or `undefined`.
- *   __**Warning: By configuring a faulty implementation/instance for the deprecated `DOMParserOptions.domBuilder`,
- *   the complete described behavior can be completely broken in many ways.**__
+ *   __**Warning: By configuring a faulty DOMHandler implementation,
+ *   the specified behavior can completely be broken.**__
  *
  * @param {string} source Only string input is possible!
  * @param {string} [mimeType='application/xml']
@@ -180,9 +189,7 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 	defaultNSMap[''] = defaultNamespace
 	defaultNSMap.xml = defaultNSMap.xml || NAMESPACE.XML
 
-	var domBuilder =
-		this.options.domBuilder ||
-		new DOMHandler({
+	var domBuilder = new this.domHandler({
 			mimeType: mimeType,
 			defaultNamespace: defaultNamespace,
 		})

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -155,8 +155,8 @@ function DOMParser(options){
  * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior/implementation.
  * - Instead of creating a Document containing the error message,
  *   it triggers `errorHandler`(s) when unexpected input is found, which means it can return `undefined`.
- *   All error handlers can throw errors, by default only the `fatalError` handler throws (a `ParserError`).
- * - All errors thrown during the parsing that are not a `ParserError` are caught and reported using an error handler.
+ *   All error handlers can throw an `Error`, by default only the `fatalError` handler throws (a `ParserError`).
+ * - All errors thrown during the parsing that are not a `ParserError` are caught and reported using the `error` handler.
  * - If no `ParserError` is thrown, this method returns the `DOMHandler.doc`,
  *   which most likely is the `Document` that has been created during parsing, or `undefined`.
  *   __**Warning: By configuring a faulty DOMHandler implementation,
@@ -186,9 +186,9 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 	defaultNSMap.xml = defaultNSMap.xml || NAMESPACE.XML
 
 	var domBuilder = new this.domHandler({
-			mimeType: mimeType,
-			defaultNamespace: defaultNamespace,
-		})
+		mimeType: mimeType,
+		defaultNamespace: defaultNamespace,
+	})
 	var locator = this.locator ? {} : undefined;
 	if (this.locator) {
 		domBuilder.setDocumentLocator(locator)

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -46,6 +46,7 @@ function normalizeLineEndings(input) {
 
 /**
  * @typedef DOMParserOptions
+ * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign]
  * @property {DOMHandler} [domBuilder] Deprecated: The instance handling events from the SAX parser.
  *           Warning: By configuring a faulty implementation/instance for `DOMParserOptions.domBuilder`,
  *           the complete described behavior can be completely broken in many ways.
@@ -74,8 +75,19 @@ function normalizeLineEndings(input) {
 function DOMParser(options){
 	/**
 	 * @type {DOMParserOptions}
+	 * @readonly
+	 * @private
 	 */
-	this.options = options ||{locator:{}};
+	this.options = options || {locator:{}};
+
+	/**
+	 * Configured or pony-filled version of `Object.assign`
+	 * @type {typeof conventions.assign}
+	 * @readonly
+	 * @private
+
+	 */
+	this.assign = this.options.assign || Object.assign || conventions.assign
 }
 
 /**

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -47,14 +47,26 @@ function normalizeLineEndings(input) {
 /**
  * @typedef DOMParserOptions
  * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign]
- * @property {DOMHandler} [domBuilder] Deprecated: The instance handling events from the SAX parser.
- *           Warning: By configuring a faulty implementation/instance for `DOMParserOptions.domBuilder`,
- *           the complete described behavior can be completely broken in many ways.
+ * The method to use instead of `Object.assign` (or if not available `conventions.assign`),
+ * which is used to copy values from the options before they are used for parsing.
+ * @property {DOMHandler} [domBuilder]
+ * Deprecated: The instance handling events from the SAX parser.
+ * Warning: By configuring a faulty implementation/instance for `DOMParserOptions.domBuilder`,
+ * the complete described behavior can be completely broken in many ways.
  * @property {Function} [errorHandler]
- * @property {Locator} [locator]
- * @property {(string) => string} [normalizeLineEndings] used to replace line endings before parsing
- * 						defaults to `normalizeLineEndings`
- * @property {Record<string, string | null | undefined>} [xmlns]
+ * @property {boolean} [locator=true]
+ * Configures if the nodes created during parsing
+ * will have a `lineNumber` and a `columnNumber` attribute
+ * describing their location in the XML string.
+ * Default is true.
+ * @property {(string) => string} [normalizeLineEndings]
+ * used to replace line endings before parsing, defaults to `normalizeLineEndings`
+ * @property {object} [xmlns]
+ * The XML namespaces that should be assumed when parsing.
+ * The default namespace can be provided by the key that is the empty string.
+ * When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`,
+ * the default namespace that will be used,
+ * will be overridden according to the specification.
  *
  * @see normalizeLineEndings
  */
@@ -78,15 +90,38 @@ function DOMParser(options){
 	 * @readonly
 	 * @private
 	 */
-	this.options = options || {locator:{}};
+	this.options = options || {};
 
 	/**
-	 * Configured or pony-filled version of `Object.assign`
-	 * @type {Function}
+	 * The method to use instead of `Object.assign` (or if not available `conventions.assign`),
+	 * which is used to copy values from the options before they are used for parsing.
+	 *
+	 * @type {function (target: object, source: object | null | undefined): object}
 	 * @readonly
 	 * @private
+	 * @see conventions.assign
 	 */
 	this.assign = this.options.assign || Object.assign || conventions.assign
+
+	/**
+	 * Configures if the nodes created during parsing
+	 * will have a `lineNumber` and a `columnNumber` attribute
+	 * describing their location in the XML string.
+	 * Default is true.
+	 * @type {boolean}
+	 * @readonly
+	 */
+	this.locator = !options || !!options.locator
+
+	/**
+	 * The default namespace can be provided by the key that is the empty string.
+	 * When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`,
+	 * the default namespace that will be used,
+	 * will be overridden according to the specification.
+	 * @type {Readonly<object>}
+	 * @readonly
+	 */
+	this.xmlns = this.options.xmlns || {}
 }
 
 /**
@@ -108,8 +143,9 @@ function DOMParser(options){
  *   the complete described behavior can be completely broken in many ways.**__
  *
  * @param {string} source Only string input is possible!
- * @param {string} [mimeType='application/xml'] the mimeType or contentType of the document to be created
- * 				determines the `type` of document created (XML or HTML)
+ * @param {string} [mimeType='application/xml']
+ *        the mimeType or contentType of the document to be created
+ *        determines the `type` of document created (XML or HTML)
  * @returns {Document | undefined}
  * @throws ParseError for specific errors depending on the configured `errorHandler`s and/or `domBuilder`
  *
@@ -117,7 +153,7 @@ function DOMParser(options){
  * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
  */
 DOMParser.prototype.parseFromString = function (source, mimeType) {
-	var defaultNSMap = this.assign({}, this.options.xmlns)
+	var defaultNSMap = this.assign({}, this.xmlns)
 	var entityMap = entities.XML_ENTITIES
 	var defaultNamespace = defaultNSMap[''] || null
 	if (MIME_TYPE.hasDefaultHTMLNamespace(mimeType)) {
@@ -126,8 +162,9 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 	} else if (mimeType === MIME_TYPE.XML_SVG_IMAGE) {
 		defaultNamespace = NAMESPACE.SVG
 	}
-	defaultNSMap.xml = defaultNSMap.xml || NAMESPACE.XML
 	defaultNSMap[''] = defaultNamespace
+	defaultNSMap.xml = defaultNSMap.xml || NAMESPACE.XML
+
 	var domBuilder =
 		this.options.domBuilder ||
 		new DOMHandler({
@@ -135,8 +172,8 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 			defaultNamespace: defaultNamespace,
 		})
 	var errorHandler = this.options.errorHandler
-	var locator = this.options.locator && this.assign({}, this.options.locator)
-	if (locator) {
+	var locator = this.locator ? {} : undefined;
+	if (this.locator) {
 		domBuilder.setDocumentLocator(locator)
 	}
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,6 +1,6 @@
 var conventions = require("./conventions");
-const { MIME_TYPE } = require("./conventions");
 
+var MIME_TYPE = conventions.MIME_TYPE;
 var NAMESPACE = conventions.NAMESPACE;
 
 /**
@@ -360,14 +360,14 @@ DOMImplementation.prototype = {
 	 * Creates an XML Document object of the specified type with its document element.
 	 *
 	 * __It behaves slightly different from the description in the living standard__:
-	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance.
-	 * - `contentType`, `encoding`, `mode`, `origin`, `url` fields are currently not declared.
-	 * - this implementation is not validating names or qualified names
-	 *   (when parsing XML strings, the SAX parser takes care of that)
+	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
+	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
+	 * - This implementation is not validating names or qualified names wen being called.
+	 *   (They are only validated by the SAX parser when calling `DOMParser.parseFromString`)
 	 *
-	 * @param {string|null} namespaceURI
+	 * @param {string | null} namespaceURI
 	 * @param {string} qualifiedName
-	 * @param {DocumentType} [doctype=null]
+	 * @param {DocumentType | null} [doctype=null]
 	 * @returns {Document} the XML document
 	 *
 	 * @see #createHTMLDocument
@@ -457,7 +457,7 @@ DOMImplementation.prototype = {
 			var headNode = doc.createElement('head')
 			htmlNode.appendChild(headNode)
 			if (typeof title === 'string') {
-				const titleNode = doc.createElement('title');
+				var titleNode = doc.createElement('title');
 				titleNode.appendChild(doc.createTextNode(title))
 				headNode.appendChild(titleNode)
 			}
@@ -918,7 +918,7 @@ Document.prototype = {
 		if (this.type === 'html') {
 			tagName = tagName.toLowerCase()
 		}
-		if (this.type === 'html' || this.contentType === MIME_TYPE.XML_XHTML_APPLICATION) {
+		if (MIME_TYPE.hasDefaultHTMLNamespace(this.contentType)) {
 			node.namespaceURI = NAMESPACE.HTML
 		}
 		node.nodeName = tagName;
@@ -1222,7 +1222,7 @@ XMLSerializer.prototype.serializeToString = function(node,isHtml,nodeFilter){
 Node.prototype.toString = nodeSerializeToString;
 function nodeSerializeToString(isHtml,nodeFilter){
 	var buf = [];
-	var refNode = this.nodeType == 9 && this.documentElement || this;
+	var refNode = this.nodeType === DOCUMENT_NODE && this.documentElement || this;
 	var prefix = refNode.prefix;
 	var uri = refNode.namespaceURI;
 	

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -157,14 +157,14 @@ NodeList.prototype = {
 	 * The number of nodes in the list. The range of valid child node indices is 0 to length-1 inclusive.
 	 * @standard level1
 	 */
-	length:0, 
+	length:0,
 	/**
 	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns null.
 	 * @standard level1
-	 * @param index  unsigned long 
+	 * @param index  unsigned long
 	 *   Index into the collection.
 	 * @return Node
-	 * 	The node at the indexth position in the NodeList, or null if that is not a valid index. 
+	 * 	The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 */
 	item: function(index) {
 		return this[index] || null;
@@ -208,7 +208,7 @@ _extends(LiveNodeList,NodeList);
  * but this is simply to allow convenient enumeration of the contents of a NamedNodeMap,
  * and does not imply that the DOM specifies an order to these Nodes.
  * NamedNodeMap objects in the DOM are live.
- * used for attributes or DocumentType entities 
+ * used for attributes or DocumentType entities
  */
 function NamedNodeMap() {
 };
@@ -297,10 +297,10 @@ NamedNodeMap.prototype = {
 		var attr = this.getNamedItem(key);
 		_removeNamedNode(this._ownerElement,this,attr);
 		return attr;
-		
-		
+
+
 	},// raises: NOT_FOUND_ERR,NO_MODIFICATION_ALLOWED_ERR
-	
+
 	//for level2
 	removeNamedItemNS:function(namespaceURI,localName){
 		var attr = this.getNamedItemNS(namespaceURI,localName);
@@ -362,7 +362,7 @@ DOMImplementation.prototype = {
 	 * __It behaves slightly different from the description in the living standard__:
 	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
-	 * - This methods provided by this implementation are not validating names or qualified names.
+	 * - The methods provided by this implementation are not validating names or qualified names.
 	 *   (They are only validated by the SAX parser when calling `DOMParser.parseFromString`)
 	 *
 	 * @param {string | null} namespaceURI
@@ -488,10 +488,10 @@ Node.prototype = {
 	prefix : null,
 	localName : null,
 	// Modified in DOM Level 2:
-	insertBefore:function(newChild, refChild){//raises 
+	insertBefore:function(newChild, refChild){//raises
 		return _insertBefore(this,newChild,refChild);
 	},
-	replaceChild:function(newChild, oldChild){//raises 
+	replaceChild:function(newChild, oldChild){//raises
 		this.insertBefore(newChild,oldChild);
 		if(oldChild){
 			this.removeChild(oldChild);
@@ -757,8 +757,8 @@ function _insertBefore(parentNode,newChild,nextChild){
 
 	newFirst.previousSibling = pre;
 	newLast.nextSibling = nextChild;
-	
-	
+
+
 	if(pre){
 		pre.nextSibling = newFirst;
 	}else{
@@ -1220,7 +1220,7 @@ CharacterData.prototype = {
 	},
 	insertData: function(offset,text) {
 		this.replaceData(offset,0,text);
-	
+
 	},
 	appendChild:function(newChild){
 		throw new Error(ExceptionMessage[HIERARCHY_REQUEST_ERR])
@@ -1314,7 +1314,7 @@ function nodeSerializeToString(isHtml,nodeFilter){
 	var refNode = this.nodeType === DOCUMENT_NODE && this.documentElement || this;
 	var prefix = refNode.prefix;
 	var uri = refNode.namespaceURI;
-	
+
 	if(uri && prefix == null){
 		//console.log(prefix)
 		var prefix = refNode.lookupPrefix(uri);
@@ -1347,8 +1347,8 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
 	if (prefix === "xml" && uri === NAMESPACE.XML || uri === NAMESPACE.XMLNS) {
 		return false;
 	}
-	
-	var i = visibleNamespaces.length 
+
+	var i = visibleNamespaces.length
 	while (i--) {
 		var ns = visibleNamespaces[i];
 		// get namespace prefix
@@ -1398,7 +1398,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		var len = attrs.length;
 		var child = node.firstChild;
 		var nodeName = node.tagName;
-		
+
 		isHTML = NAMESPACE.isHTML(node.namespaceURI) || isHTML
 
 		var prefixedNodeName = nodeName
@@ -1457,14 +1457,14 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 			serializeToString(attr,buf,isHTML,nodeFilter,visibleNamespaces);
 		}
 
-		// add namespace for current node		
+		// add namespace for current node
 		if (nodeName === prefixedNodeName && needNamespaceDefine(node, isHTML, visibleNamespaces)) {
 			var prefix = node.prefix||'';
 			var uri = node.namespaceURI;
 			addSerializedAttribute(buf, prefix ? 'xmlns:' + prefix : "xmlns", uri);
 			visibleNamespaces.push({ prefix: prefix, namespace:uri });
 		}
-		
+
 		if(child || isHTML && !/^(?:meta|link|img|br|hr|input)$/i.test(nodeName)){
 			buf.push('>');
 			//if is cdata child node
@@ -1677,7 +1677,7 @@ try{
 				}
 			}
 		})
-		
+
 		function getTextContent(node){
 			switch(node.nodeType){
 			case ELEMENT_NODE:

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -362,7 +362,7 @@ DOMImplementation.prototype = {
 	 * __It behaves slightly different from the description in the living standard__:
 	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
-	 * - This implementation is not validating names or qualified names wen being called.
+	 * - This methods provided by this implementation are not validating names or qualified names.
 	 *   (They are only validated by the SAX parser when calling `DOMParser.parseFromString`)
 	 *
 	 * @param {string | null} namespaceURI
@@ -911,7 +911,25 @@ Document.prototype = {
 		});
 	},
 
-	//document factory method:
+	/**
+	 * Creates a new `Element` that is owned by this `Document`.
+	 * In HTML Documents `localName` is the lower cased `tagName`,
+	 * otherwise no transformation is being applied.
+	 * When `contentType` implies the HTML namespace, it will be set as `namespaceURI`.
+	 *
+	 * __This implementation differs from the specification:__
+	 * - The provided name is not checked against the `Name` production,
+	 *   so no related error will be thrown.
+	 * - There is no interface `HTMLElement`, it is always an `Element`.
+	 * - There is no support for a second argument to indicate using custom elements.
+	 *
+	 * @param {string} tagName
+	 * @return {Element}
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement
+	 * @see https://dom.spec.whatwg.org/#dom-document-createelement
+	 * @see https://dom.spec.whatwg.org/#concept-create-element
+	 */
 	createElement :	function(tagName){
 		var node = new Element();
 		node.ownerDocument = this;
@@ -960,9 +978,30 @@ Document.prototype = {
 		node.nodeValue= node.data = data;
 		return node;
 	},
-	createAttribute :	function(name){
+	/**
+	 * Creates an `Attr` node that is owned by this document.
+	 * In HTML Documents `localName` is the lower cased `name`,
+	 * otherwise no transformation is being applied.
+	 *
+	 * __This implementation differs from the specification:__
+	 * - The provided name is not checked against the `Name` production,
+	 *   so no related error will be thrown.
+	 *
+	 * @param {string} name
+	 * @return {Attr}
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createAttribute
+	 * @see https://dom.spec.whatwg.org/#dom-document-createattribute
+	 */
+	createAttribute: function(name){
+		if (this.type === 'html') {
+			name = name.toLowerCase()
+		}
+		return this._createAttribute(name);
+	},
+	_createAttribute: function(name){
 		var node = new Attr();
-		node.ownerDocument	= this;
+		node.ownerDocument = this;
 		node.name = name;
 		node.nodeName	= name;
 		node.localName = name;
@@ -1022,6 +1061,12 @@ function Element() {
 };
 Element.prototype = {
 	nodeType : ELEMENT_NODE,
+	getQualifiedName: function () {
+		return this.prefix ? this.prefix+':'+this.localName : this.localName
+	},
+	_isInHTMLDocumentAndNamespace: function () {
+		return this.ownerDocument.type === 'html' && this.namespaceURI === NAMESPACE.HTML;
+	},
 	hasAttribute : function(name){
 		return this.getAttributeNode(name)!=null;
 	},
@@ -1030,10 +1075,16 @@ Element.prototype = {
 		return attr && attr.value || '';
 	},
 	getAttributeNode : function(name){
+		if (this._isInHTMLDocumentAndNamespace()) {
+			name = name.toLowerCase()
+		}
 		return this.attributes.getNamedItem(name);
 	},
 	setAttribute : function(name, value){
-		var attr = this.ownerDocument.createAttribute(name);
+		if (this._isInHTMLDocumentAndNamespace()) {
+			name = name.toLowerCase()
+		}
+		var attr = this.ownerDocument._createAttribute(name)
 		attr.value = attr.nodeValue = "" + value;
 		this.setAttributeNode(attr)
 	},
@@ -1041,8 +1092,8 @@ Element.prototype = {
 		var attr = this.getAttributeNode(name)
 		attr && this.removeAttributeNode(attr);
 	},
-	
-	//four real opeartion method
+
+	// four real operation method
 	appendChild:function(newChild){
 		if(newChild.nodeType === DOCUMENT_FRAGMENT_NODE){
 			return this.insertBefore(newChild,null);
@@ -1065,7 +1116,7 @@ Element.prototype = {
 		var old = this.getAttributeNodeNS(namespaceURI, localName);
 		old && this.removeAttributeNode(old);
 	},
-	
+
 	hasAttributeNS : function(namespaceURI, localName){
 		return this.getAttributeNodeNS(namespaceURI, localName)!=null;
 	},
@@ -1081,13 +1132,51 @@ Element.prototype = {
 	getAttributeNodeNS : function(namespaceURI, localName){
 		return this.attributes.getNamedItemNS(namespaceURI, localName);
 	},
-	
-	getElementsByTagName : function(tagName){
+
+	/**
+	 * Returns a LiveNodeList of elements with the given qualifiedName.
+	 * Searching for all descendants can be done by passing `*` as `qualifiedName`.
+	 *
+	 * All descendants of the specified element are searched, but not the element itself.
+	 * The returned list is live, which means it updates itself with the DOM tree automatically.
+	 * Therefore, there is no need to call `Element.getElementsByTagName()`
+	 * with the same element and arguments repeatedly if the DOM changes in between calls.
+	 *
+	 * When called on an HTML element in an HTML document,
+	 * `getElementsByTagName` lower-cases the argument before searching for it.
+	 * This is undesirable when trying to match camel-cased SVG elements
+	 * (such as `<linearGradient>`) in an HTML document.
+	 * Instead, use `Element.getElementsByTagNameNS()`,
+	 * which preserves the capitalization of the tag name.
+	 *
+	 * `Element.getElementsByTagName` is similar to `Document.getElementsByTagName()`,
+	 * except that it only searches for elements that are descendants of the specified element.
+	 *
+	 * @param {string} qualifiedName
+	 * @return {LiveNodeList}
+	 *
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByTagName
+	 * @see https://dom.spec.whatwg.org/#concept-getelementsbytagname
+	 */
+	getElementsByTagName : function(qualifiedName){
+		var isHTMLDocument = (this.nodeType === DOCUMENT_NODE ? this : this.ownerDocument).type === 'html'
+		var lowerQualifiedName = qualifiedName.toLowerCase()
 		return new LiveNodeList(this,function(base){
 			var ls = [];
-			_visitNode(base,function(node){
-				if(node !== base && node.nodeType == ELEMENT_NODE && (tagName === '*' || node.tagName == tagName)){
+			_visitNode(base, function(node) {
+				if (node === base || node.nodeType !==  ELEMENT_NODE) {
+					return
+				}
+				if (qualifiedName === '*') {
 					ls.push(node);
+				} else {
+					var nodeQualifiedName = node.getQualifiedName();
+					var matchingQName = isHTMLDocument && node.namespaceURI === NAMESPACE.HTML
+						? lowerQualifiedName
+						: qualifiedName
+					if(nodeQualifiedName === matchingQName){
+						ls.push(node);
+					}
 				}
 			});
 			return ls;
@@ -1102,7 +1191,7 @@ Element.prototype = {
 				}
 			});
 			return ls;
-			
+
 		});
 	}
 };

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,5 +1,6 @@
 var conventions = require("./conventions");
-
+var isHTMLRawTextElement = conventions.isHTMLRawTextElement;
+var isHTMLVoidElement = conventions.isHTMLVoidElement;
 var MIME_TYPE = conventions.MIME_TYPE;
 var NAMESPACE = conventions.NAMESPACE;
 
@@ -169,11 +170,11 @@ NodeList.prototype = {
 	item: function(index) {
 		return this[index] || null;
 	},
-	toString:function(isHTML,nodeFilter){
+	toString: function (nodeFilter) {
 		for(var buf = [], i = 0;i<this.length;i++){
-			serializeToString(this[i],buf,isHTML,nodeFilter);
+			serializeToString(this[i], buf, nodeFilter)
 		}
-		return buf.join('');
+		return buf.join('')
 	}
 };
 
@@ -1305,29 +1306,26 @@ function ProcessingInstruction() {
 ProcessingInstruction.prototype.nodeType = PROCESSING_INSTRUCTION_NODE;
 _extends(ProcessingInstruction,Node);
 function XMLSerializer(){}
-XMLSerializer.prototype.serializeToString = function(node,isHtml,nodeFilter){
-	return nodeSerializeToString.call(node,isHtml,nodeFilter);
+XMLSerializer.prototype.serializeToString = function (node, nodeFilter) {
+	return nodeSerializeToString.call(node, nodeFilter);
 }
 Node.prototype.toString = nodeSerializeToString;
-function nodeSerializeToString(isHtml,nodeFilter){
+function nodeSerializeToString(nodeFilter) {
 	var buf = [];
 	var refNode = this.nodeType === DOCUMENT_NODE && this.documentElement || this;
 	var prefix = refNode.prefix;
 	var uri = refNode.namespaceURI;
 
 	if(uri && prefix == null){
-		//console.log(prefix)
 		var prefix = refNode.lookupPrefix(uri);
 		if(prefix == null){
-			//isHTML = true;
 			var visibleNamespaces=[
 			{namespace:uri,prefix:null}
 			//{namespace:uri,prefix:''}
 			]
 		}
 	}
-	serializeToString(this,buf,isHtml,nodeFilter,visibleNamespaces);
-	//console.log('###',this.nodeType,uri,prefix,buf.join(''))
+	serializeToString(this,buf,nodeFilter,visibleNamespaces);
 	return buf.join('');
 }
 
@@ -1374,10 +1372,12 @@ function addSerializedAttribute(buf, qualifiedName, value) {
 	buf.push(' ', qualifiedName, '="', value.replace(/[<&"\t\n\r]/g, _xmlEncoder), '"')
 }
 
-function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
+function serializeToString (node, buf, nodeFilter, visibleNamespaces) {
 	if (!visibleNamespaces) {
 		visibleNamespaces = [];
 	}
+	var doc = node.nodeType === DOCUMENT_NODE ? node : node.ownerDocument
+	var isHTML = doc.type === 'html'
 
 	if(nodeFilter){
 		node = nodeFilter(node);
@@ -1398,8 +1398,6 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		var len = attrs.length;
 		var child = node.firstChild;
 		var nodeName = node.tagName;
-
-		isHTML = NAMESPACE.isHTML(node.namespaceURI) || isHTML
 
 		var prefixedNodeName = nodeName
 		if (!isHTML && !node.prefix && node.namespaceURI) {
@@ -1454,7 +1452,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 				addSerializedAttribute(buf, prefix ? 'xmlns:' + prefix : "xmlns", uri);
 				visibleNamespaces.push({ prefix: prefix, namespace:uri });
 			}
-			serializeToString(attr,buf,isHTML,nodeFilter,visibleNamespaces);
+			serializeToString(attr,buf,nodeFilter,visibleNamespaces);
 		}
 
 		// add namespace for current node
@@ -1464,29 +1462,33 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 			addSerializedAttribute(buf, prefix ? 'xmlns:' + prefix : "xmlns", uri);
 			visibleNamespaces.push({ prefix: prefix, namespace:uri });
 		}
-
-		if(child || isHTML && !/^(?:meta|link|img|br|hr|input)$/i.test(nodeName)){
-			buf.push('>');
+		// in XML elements can be closed when they have no children
+		var canCloseTag = !child;
+		if (canCloseTag && (isHTML || NAMESPACE.isHTML(node.namespaceURI))) {
+			// in HTML (doc or ns) only void elements can be closed right away
+			canCloseTag = isHTMLVoidElement(nodeName)
+		}
+		if (canCloseTag) {
+			buf.push("/>");
+		} else {
+			buf.push(">");
 			//if is cdata child node
-			if(isHTML && /^script$/i.test(nodeName)){
+			if (isHTML && isHTMLRawTextElement(nodeName)) {
 				while(child){
 					if(child.data){
 						buf.push(child.data);
 					}else{
-						serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice());
+						serializeToString(child, buf, nodeFilter, visibleNamespaces.slice());
 					}
 					child = child.nextSibling;
 				}
-			}else
-			{
+			} else {
 				while(child){
-					serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice());
+					serializeToString(child, buf, nodeFilter, visibleNamespaces.slice());
 					child = child.nextSibling;
 				}
 			}
-			buf.push('</',prefixedNodeName,'>');
-		}else{
-			buf.push('/>');
+			buf.push("</", prefixedNodeName, ">");
 		}
 		// remove added visible namespaces
 		//visibleNamespaces.length = startVisibleNamespaces;
@@ -1495,7 +1497,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 	case DOCUMENT_FRAGMENT_NODE:
 		var child = node.firstChild;
 		while(child){
-			serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice());
+			serializeToString(child, buf, nodeFilter, visibleNamespaces.slice());
 			child = child.nextSibling;
 		}
 		return;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,4 +1,5 @@
 var conventions = require("./conventions");
+const { MIME_TYPE } = require("./conventions");
 
 var NAMESPACE = conventions.NAMESPACE;
 
@@ -366,8 +367,10 @@ DOMImplementation.prototype = {
 	 *
 	 * @param {string|null} namespaceURI
 	 * @param {string} qualifiedName
-	 * @param {DocumentType=null} doctype
-	 * @returns {Document}
+	 * @param {DocumentType} [doctype=null]
+	 * @returns {Document} the XML document
+	 *
+	 * @see #createHTMLDocument
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM Level 2 Core (initial)
@@ -378,7 +381,13 @@ DOMImplementation.prototype = {
 	 * @see https://www.w3.org/TR/xml-names/#ns-qualnames XML Namespaces: Qualified names
 	 */
 	createDocument: function(namespaceURI,  qualifiedName, doctype){
-		var doc = new Document();
+		var contentType = MIME_TYPE.XML_APPLICATION;
+		if (namespaceURI === NAMESPACE.HTML) {
+			contentType = MIME_TYPE.XML_XHTML_APPLICATION;
+		} else if (namespaceURI === NAMESPACE.SVG) {
+			contentType = MIME_TYPE.XML_SVG_IMAGE
+		}
+		var doc = new Document({contentType: contentType});
 		doc.implementation = this;
 		doc.childNodes = new NodeList();
 		doc.doctype = doctype || null;
@@ -397,6 +406,7 @@ DOMImplementation.prototype = {
 	 * __This behavior is slightly different from the in the specs__:
 	 * - this implementation is not validating names or qualified names
 	 *   (when parsing XML strings, the SAX parser takes care of that)
+	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string} qualifiedName
 	 * @param {string} [publicId]
@@ -420,6 +430,40 @@ DOMImplementation.prototype = {
 		node.systemId = systemId || '';
 
 		return node;
+	},
+	/**
+	 * Returns an HTML document, that might already have a basic DOM structure.
+	 *
+	 * __It behaves slightly different from the description in the living standard__:
+	 * - If the first argument is `false` no initial nodes are added (steps 3-7 in the specs are omitted)
+	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
+	 *
+	 * @param {string | false} [title]
+	 * @returns {Document} The HTML document
+	 *
+	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
+	 * @see https://dom.spec.whatwg.org/#html-document
+	 */
+	createHTMLDocument: function(title) {
+		var doc = new Document({contentType: MIME_TYPE.HTML})
+		doc.implementation = this
+		doc.childNodes = new NodeList()
+		if (title !== false) {
+			doc.doctype = this.createDocumentType('html')
+			doc.doctype.ownerDocument = this;
+			doc.appendChild(doc.doctype);
+			var htmlNode = doc.createElement('html')
+			doc.appendChild(htmlNode)
+			var headNode = doc.createElement('head')
+			htmlNode.appendChild(headNode)
+			if (typeof title === 'string') {
+				const titleNode = doc.createElement('title');
+				titleNode.appendChild(doc.createTextNode(title))
+				headNode.appendChild(titleNode)
+			}
+			htmlNode.appendChild(doc.createElement('body'))
+		}
+		return doc
 	}
 };
 
@@ -427,7 +471,6 @@ DOMImplementation.prototype = {
 /**
  * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247
  */
-
 function Node() {
 };
 
@@ -568,9 +611,48 @@ function _visitNode(node,callback){
     }
 }
 
-
-
-function Document(){
+/**
+ * @typedef DocumentOptions
+ * @property {string} [contentType=MIME_TYPE.XML_APPLICATION]
+ */
+/**
+ * The Document interface describes the common properties and methods for any kind of document.
+ *
+ * It should usually be created using `new DOMImplementation().createDocument(...)`
+ * or `new DOMImplementation().createHTMLDocument(...)`.
+ *
+ * The constructor is considered a private API and offers to initially set the `contentType` property
+ * via it's options parameter.
+ *
+ * @param {DocumentOptions} [options]
+ * @private
+ * @constructor
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Document
+ * @see https://dom.spec.whatwg.org/#interface-document
+ */
+function Document(options){
+	var opt = options || {};
+	/**
+	 * The mime type of the document is determined at creation time and can not be modified.
+	 *
+	 * @type {string}
+	 * @readonly
+	 *
+	 * @see https://dom.spec.whatwg.org/#concept-document-content-type
+	 * @see DOMImplementation
+	 * @see MIME_TYPE
+	 */
+	this.contentType = opt.contentType || MIME_TYPE.XML_APPLICATION
+	/**
+	 *
+	 * @type {'html' | 'xml'}
+	 * @readonly
+	 *
+	 * @see https://dom.spec.whatwg.org/#concept-document-type
+	 * @see DOMImplementation
+	 */
+	this.type = MIME_TYPE.isHTML(this.contentType) ? 'html' : 'xml'
 }
 
 function _onAddAttribute(doc,el,newAttr){
@@ -727,7 +809,12 @@ function _appendSingleChild (parentNode, newChild) {
 }
 
 Document.prototype = {
-	//implementation : null,
+	/**
+	 * The implementation that created this document
+	 * @readonly
+	 * @type DOMImplementation
+	 */
+	implementation : null,
 	nodeName :  '#document',
 	nodeType :  DOCUMENT_NODE,
 	/**
@@ -828,6 +915,12 @@ Document.prototype = {
 	createElement :	function(tagName){
 		var node = new Element();
 		node.ownerDocument = this;
+		if (this.type === 'html') {
+			tagName = tagName.toLowerCase()
+		}
+		if (this.type === 'html' || this.contentType === MIME_TYPE.XML_XHTML_APPLICATION) {
+			node.namespaceURI = NAMESPACE.HTML
+		}
 		node.nodeName = tagName;
 		node.tagName = tagName;
 		node.localName = tagName;
@@ -1522,12 +1615,11 @@ try{
 }catch(e){//ie8
 }
 
-//if(typeof require == 'function'){
-	exports.DocumentType = DocumentType;
-	exports.DOMException = DOMException;
-	exports.DOMImplementation = DOMImplementation;
-	exports.Element = Element;
-	exports.Node = Node;
-	exports.NodeList = NodeList;
-	exports.XMLSerializer = XMLSerializer;
-//}
+exports.Document = Document;
+exports.DocumentType = DocumentType;
+exports.DOMException = DOMException;
+exports.DOMImplementation = DOMImplementation;
+exports.Element = Element;
+exports.Node = Node;
+exports.NodeList = NodeList;
+exports.XMLSerializer = XMLSerializer;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var freeze = require('./conventions').freeze;
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var dom = require('./dom')
 exports.DOMImplementation = dom.DOMImplementation
 exports.XMLSerializer = dom.XMLSerializer

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -509,11 +509,12 @@ function parseHtmlSpecialContent(source,elStartEnd,tagName,entityReplacer,domBui
 	// https://html.spec.whatwg.org/#escapable-raw-text-elements
 	// https://html.spec.whatwg.org/#cdata-rcdata-restrictions:raw-text-elements
 	// TODO: https://html.spec.whatwg.org/#cdata-rcdata-restrictions
-	if(isHTMLRawTextElement(tagName)){
+	var isEscapableRaw = isHTMLEscapableRawTextElement(tagName);
+	if(isEscapableRaw || isHTMLRawTextElement(tagName)){
 		var elEndStart =  source.indexOf('</'+tagName+'>',elStartEnd);
 		var text = source.substring(elStartEnd+1,elEndStart);
 
-		if(isHTMLEscapableRawTextElement(tagName)){
+		if(isEscapableRaw){
 				text = text.replace(/&#?\w+;/g,entityReplacer);
 		}
 				domBuilder.characters(text,0,text.length);

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1,3 +1,5 @@
+'use strict'
+
 var conventions = require("./conventions");
 var NAMESPACE = conventions.NAMESPACE;
 var MIME_TYPE = conventions.MIME_TYPE;

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1,4 +1,6 @@
-var NAMESPACE = require("./conventions").NAMESPACE;
+var conventions = require("./conventions");
+var NAMESPACE = conventions.NAMESPACE;
+var MIME_TYPE = conventions.MIME_TYPE;
 
 //[4]   	NameStartChar	   ::=   	":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
 //[4a]   	NameChar	   ::=   	NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
@@ -50,6 +52,7 @@ XMLReader.prototype = {
 	}
 }
 function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
+	var isHTML = MIME_TYPE.isHTML(domBuilder.mimeType);
 	function fixedFromCharCode(code) {
 		// String.prototype.fromCharCode does not supports
 		// > 2 bytes unicode chars directly
@@ -162,7 +165,15 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 				var el = new ElementAttributes();
 				var currentNSMap = parseStack[parseStack.length-1].currentNSMap;
 				//elStartEnd
-				var end = parseElementStartPart(source,tagStart,el,currentNSMap,entityReplacer,errorHandler);
+				var end = parseElementStartPart(
+					source,
+					tagStart,
+					el,
+					currentNSMap,
+					entityReplacer,
+					errorHandler,
+					isHTML
+				)
 				var len = el.length;
 
 
@@ -191,7 +202,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 					}
 				}
 
-				if (NAMESPACE.isHTML(el.uri) && !el.closed) {
+				if (isHTML && !el.closed) {
 					end = parseHtmlSpecialContent(source,end,el.tagName,entityReplacer,domBuilder)
 				} else {
 					end++;
@@ -222,7 +233,9 @@ function copyLocator(f,t){
  * @see #appendElement(source,elStartEnd,el,selfClosed,entityReplacer,domBuilder,parseStack);
  * @return end of the elementStartPart(end of elementEndPart for selfClosed el)
  */
-function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,errorHandler){
+function parseElementStartPart(
+	source,start,el,currentNSMap,entityReplacer,errorHandler, isHTML
+){
 
 	/**
 	 * @param {string} qname
@@ -337,7 +350,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 					errorHandler.warning('attribute "'+value+'" missed quot(")!');
 					addAttribute(attrName, value, start)
 				}else{
-					if(!NAMESPACE.isHTML(currentNSMap['']) || !value.match(/^(?:disabled|checked|selected)$/i)){
+					if(!isHTML || !value.match(/^(?:disabled|checked|selected)$/i)){
 						errorHandler.warning('attribute "'+value+'" missed value!! "'+value+'" instead!!')
 					}
 					addAttribute(value, value, start)
@@ -385,7 +398,7 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 				//case S_ATTR_NOQUOT_VALUE:void();break;
 				case S_ATTR_SPACE:
 					var tagName =  el.tagName;
-					if (!NAMESPACE.isHTML(currentNSMap['']) || !attrName.match(/^(?:disabled|checked|selected)$/i)) {
+					if (!isHTML || !attrName.match(/^(?:disabled|checked|selected)$/i)) {
 						errorHandler.warning('attribute "'+attrName+'" missed value!! "'+attrName+'" instead2!!')
 					}
 					addAttribute(attrName, attrName, start);

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -457,8 +457,6 @@ function appendElement(el,domBuilder,currentNSMap){
 				a.uri = NAMESPACE.XML;
 			}if(prefix !== 'xmlns'){
 				a.uri = currentNSMap[prefix || '']
-
-				//{console.log('###'+a.qName,domBuilder.locator.systemId+'',currentNSMap,a.uri)}
 			}
 		}
 	}

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1,6 +1,8 @@
 'use strict'
 
 var conventions = require("./conventions");
+var isHTMLRawTextElement = conventions.isHTMLRawTextElement;
+var isHTMLEscapableRawTextElement = conventions.isHTMLEscapableRawTextElement;
 var NAMESPACE = conventions.NAMESPACE;
 var MIME_TYPE = conventions.MIME_TYPE;
 
@@ -181,7 +183,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 
 				if(!el.closed && fixSelfClosed(source,end,el.tagName,closeMap)){
 					el.closed = true;
-					if(!entityMap.nbsp){
+					if(!isHTML){
 						errorHandler.warning('unclosed xml attribute');
 					}
 				}
@@ -352,7 +354,7 @@ function parseElementStartPart(
 					errorHandler.warning('attribute "'+value+'" missed quot(")!');
 					addAttribute(attrName, value, start)
 				}else{
-					if(!isHTML || !value.match(/^(?:disabled|checked|selected)$/i)){
+					if(!isHTML){
 						errorHandler.warning('attribute "'+value+'" missed value!! "'+value+'" instead!!')
 					}
 					addAttribute(value, value, start)
@@ -400,7 +402,7 @@ function parseElementStartPart(
 				//case S_ATTR_NOQUOT_VALUE:void();break;
 				case S_ATTR_SPACE:
 					var tagName =  el.tagName;
-					if (!isHTML || !attrName.match(/^(?:disabled|checked|selected)$/i)) {
+					if (!isHTML) {
 						errorHandler.warning('attribute "'+attrName+'" missed value!! "'+attrName+'" instead2!!')
 					}
 					addAttribute(attrName, attrName, start);
@@ -503,24 +505,19 @@ function appendElement(el,domBuilder,currentNSMap){
 	}
 }
 function parseHtmlSpecialContent(source,elStartEnd,tagName,entityReplacer,domBuilder){
-	if(/^(?:script|textarea)$/i.test(tagName)){
+	// https://html.spec.whatwg.org/#raw-text-elements
+	// https://html.spec.whatwg.org/#escapable-raw-text-elements
+	// https://html.spec.whatwg.org/#cdata-rcdata-restrictions:raw-text-elements
+	// TODO: https://html.spec.whatwg.org/#cdata-rcdata-restrictions
+	if(isHTMLRawTextElement(tagName)){
 		var elEndStart =  source.indexOf('</'+tagName+'>',elStartEnd);
 		var text = source.substring(elStartEnd+1,elEndStart);
-		if(/[&<]/.test(text)){
-			if(/^script$/i.test(tagName)){
-				//if(!/\]\]>/.test(text)){
-					//lexHandler.startCDATA();
-					domBuilder.characters(text,0,text.length);
-					//lexHandler.endCDATA();
-					return elEndStart;
-				//}
-			}//}else{//text area
+
+		if(isHTMLEscapableRawTextElement(tagName)){
 				text = text.replace(/&#?\w+;/g,entityReplacer);
+		}
 				domBuilder.characters(text,0,text.length);
 				return elEndStart;
-			//}
-
-		}
 	}
 	return elStartEnd+1;
 }

--- a/test/conventions/__snapshots__/html.test.js.snap
+++ b/test/conventions/__snapshots__/html.test.js.snap
@@ -1,0 +1,295 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable allowfullscreen with value 'true' 1`] = `
+Array [
+  "allowfullscreen",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable async with value 'true' 1`] = `
+Array [
+  "async",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable autofocus with value 'true' 1`] = `
+Array [
+  "autofocus",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable autoplay with value 'true' 1`] = `
+Array [
+  "autoplay",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable checked with value 'true' 1`] = `
+Array [
+  "checked",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable controls with value 'true' 1`] = `
+Array [
+  "controls",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable default with value 'true' 1`] = `
+Array [
+  "default",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable defer with value 'true' 1`] = `
+Array [
+  "defer",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable disabled with value 'true' 1`] = `
+Array [
+  "disabled",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable formnovalidate with value 'true' 1`] = `
+Array [
+  "formnovalidate",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable hidden with value 'true' 1`] = `
+Array [
+  "hidden",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable ismap with value 'true' 1`] = `
+Array [
+  "ismap",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable itemscope with value 'true' 1`] = `
+Array [
+  "itemscope",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable loop with value 'true' 1`] = `
+Array [
+  "loop",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable multiple with value 'true' 1`] = `
+Array [
+  "multiple",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable muted with value 'true' 1`] = `
+Array [
+  "muted",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable nomodule with value 'true' 1`] = `
+Array [
+  "nomodule",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable novalidate with value 'true' 1`] = `
+Array [
+  "novalidate",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable open with value 'true' 1`] = `
+Array [
+  "open",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable playsinline with value 'true' 1`] = `
+Array [
+  "playsinline",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable readonly with value 'true' 1`] = `
+Array [
+  "readonly",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable required with value 'true' 1`] = `
+Array [
+  "required",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable reversed with value 'true' 1`] = `
+Array [
+  "reversed",
+  true,
+]
+`;
+
+exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable selected with value 'true' 1`] = `
+Array [
+  "selected",
+  true,
+]
+`;
+
+exports[`HTML_RAW_TEXT_ELEMENTS should contain immutable script with value 'true' 1`] = `
+Array [
+  "script",
+  false,
+]
+`;
+
+exports[`HTML_RAW_TEXT_ELEMENTS should contain immutable style with value 'true' 1`] = `
+Array [
+  "style",
+  false,
+]
+`;
+
+exports[`HTML_RAW_TEXT_ELEMENTS should contain immutable textarea with value 'true' 1`] = `
+Array [
+  "textarea",
+  true,
+]
+`;
+
+exports[`HTML_RAW_TEXT_ELEMENTS should contain immutable title with value 'true' 1`] = `
+Array [
+  "title",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable area with value 'true' 1`] = `
+Array [
+  "area",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable base with value 'true' 1`] = `
+Array [
+  "base",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable br with value 'true' 1`] = `
+Array [
+  "br",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable col with value 'true' 1`] = `
+Array [
+  "col",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable embed with value 'true' 1`] = `
+Array [
+  "embed",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable hr with value 'true' 1`] = `
+Array [
+  "hr",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable img with value 'true' 1`] = `
+Array [
+  "img",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable input with value 'true' 1`] = `
+Array [
+  "input",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable link with value 'true' 1`] = `
+Array [
+  "link",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable meta with value 'true' 1`] = `
+Array [
+  "meta",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable param with value 'true' 1`] = `
+Array [
+  "param",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable source with value 'true' 1`] = `
+Array [
+  "source",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable track with value 'true' 1`] = `
+Array [
+  "track",
+  true,
+]
+`;
+
+exports[`HTML_VOID_ELEMENTS should contain immutable wbr with value 'true' 1`] = `
+Array [
+  "wbr",
+  true,
+]
+`;

--- a/test/conventions/__snapshots__/mime-type.test.js.snap
+++ b/test/conventions/__snapshots__/mime-type.test.js.snap
@@ -34,3 +34,10 @@ Array [
   "application/xhtml+xml",
 ]
 `;
+
+exports[`MIME_TYPE should contain immutable hasDefaultHTMLNamespace with correct value 1`] = `
+Array [
+  "hasDefaultHTMLNamespace",
+  [Function],
+]
+`;

--- a/test/conventions/html.test.js
+++ b/test/conventions/html.test.js
@@ -36,12 +36,12 @@ describe('isHTMLBooleanAttribute', () => {
 			expect(isHTMLBooleanAttribute(mixedKey)).toBe(true)
 		})
 	})
-	it("should not detect prototype properties", () => {
+	it('should not detect prototype properties', () => {
 		expect(isHTMLBooleanAttribute('hasOwnProperty')).toBe(false)
 		expect(isHTMLBooleanAttribute('constructor')).toBe(false)
 		expect(isHTMLBooleanAttribute('prototype')).toBe(false)
 		expect(isHTMLBooleanAttribute('__proto__')).toBe(false)
-	});
+	})
 })
 describe('HTML_VOID_ELEMENTS', () => {
 	Object.keys(HTML_VOID_ELEMENTS).forEach((key) => {
@@ -69,12 +69,12 @@ describe('isHTMLVoidElement', () => {
 			expect(isHTMLVoidElement(mixedKey)).toBe(true)
 		})
 	})
-	it("should not detect prototype properties", () => {
+	it('should not detect prototype properties', () => {
 		expect(isHTMLVoidElement('hasOwnProperty')).toBe(false)
 		expect(isHTMLVoidElement('constructor')).toBe(false)
 		expect(isHTMLVoidElement('prototype')).toBe(false)
 		expect(isHTMLVoidElement('__proto__')).toBe(false)
-	});
+	})
 })
 describe('HTML_RAW_TEXT_ELEMENTS', () => {
 	Object.keys(HTML_RAW_TEXT_ELEMENTS).forEach((key) => {
@@ -102,12 +102,12 @@ describe('isHTMLRawTextElement', () => {
 			expect(isHTMLRawTextElement(mixedKey)).toBe(true)
 		})
 	})
-	it("should not detect prototype properties", () => {
+	it('should not detect prototype properties', () => {
 		expect(isHTMLRawTextElement('hasOwnProperty')).toBe(false)
 		expect(isHTMLRawTextElement('constructor')).toBe(false)
 		expect(isHTMLRawTextElement('prototype')).toBe(false)
 		expect(isHTMLRawTextElement('__proto__')).toBe(false)
-	});
+	})
 })
 describe('isHTMLEscapableRawTextElement', () => {
 	Object.keys(HTML_RAW_TEXT_ELEMENTS).forEach((key) => {
@@ -124,10 +124,10 @@ describe('isHTMLEscapableRawTextElement', () => {
 			expect(isHTMLEscapableRawTextElement(mixedKey)).toBe(expected)
 		})
 	})
-	it("should not detect prototype properties", () => {
+	it('should not detect prototype properties', () => {
 		expect(isHTMLEscapableRawTextElement('hasOwnProperty')).toBe(false)
 		expect(isHTMLEscapableRawTextElement('constructor')).toBe(false)
 		expect(isHTMLEscapableRawTextElement('prototype')).toBe(false)
 		expect(isHTMLEscapableRawTextElement('__proto__')).toBe(false)
-	});
+	})
 })

--- a/test/conventions/html.test.js
+++ b/test/conventions/html.test.js
@@ -3,6 +3,9 @@
 const {
 	HTML_BOOLEAN_ATTRIBUTES,
 	isHTMLBooleanAttribute,
+	HTML_RAW_TEXT_ELEMENTS,
+	isHTMLRawTextElement,
+	isHTMLEscapableRawTextElement,
 	HTML_VOID_ELEMENTS,
 	isHTMLVoidElement,
 } = require('../../lib/conventions')
@@ -71,5 +74,60 @@ describe('isHTMLVoidElement', () => {
 		expect(isHTMLVoidElement('constructor')).toBe(false)
 		expect(isHTMLVoidElement('prototype')).toBe(false)
 		expect(isHTMLVoidElement('__proto__')).toBe(false)
+	});
+})
+describe('HTML_RAW_TEXT_ELEMENTS', () => {
+	Object.keys(HTML_RAW_TEXT_ELEMENTS).forEach((key) => {
+		const value = HTML_RAW_TEXT_ELEMENTS[key]
+		it(`should contain immutable ${key} with value 'true'`, () => {
+			expect([key, value]).toMatchSnapshot()
+			try {
+				HTML_RAW_TEXT_ELEMENTS[key] = 'boo'
+			} catch {}
+			expect(HTML_RAW_TEXT_ELEMENTS[key]).toBe(value)
+		})
+	})
+})
+describe('isHTMLRawTextElement', () => {
+	Object.keys(HTML_RAW_TEXT_ELEMENTS).forEach((key) => {
+		it(`should detect attribute '${key}'`, () => {
+			expect(isHTMLRawTextElement(key)).toBe(true)
+		})
+		const upperKey = key.toUpperCase()
+		it(`should detect attribute '${upperKey}'`, () => {
+			expect(isHTMLRawTextElement(upperKey)).toBe(true)
+		})
+		const mixedKey = key[0].toUpperCase() + key.substring(1)
+		it(`should detect attribute '${mixedKey}'`, () => {
+			expect(isHTMLRawTextElement(mixedKey)).toBe(true)
+		})
+	})
+	it("should not detect prototype properties", () => {
+		expect(isHTMLRawTextElement('hasOwnProperty')).toBe(false)
+		expect(isHTMLRawTextElement('constructor')).toBe(false)
+		expect(isHTMLRawTextElement('prototype')).toBe(false)
+		expect(isHTMLRawTextElement('__proto__')).toBe(false)
+	});
+})
+describe('isHTMLEscapableRawTextElement', () => {
+	Object.keys(HTML_RAW_TEXT_ELEMENTS).forEach((key) => {
+		const expected = HTML_RAW_TEXT_ELEMENTS[key]
+		it(`should detect attribute '${key}' as ${expected}`, () => {
+			expect(isHTMLEscapableRawTextElement(key)).toBe(expected)
+		})
+		const upperKey = key.toUpperCase()
+		it(`should detect attribute '${upperKey}' as ${expected}`, () => {
+			expect(isHTMLEscapableRawTextElement(upperKey)).toBe(expected)
+		})
+		const mixedKey = key[0].toUpperCase() + key.substring(1)
+		it(`should detect attribute '${mixedKey}' as ${expected}`, () => {
+			expect(isHTMLEscapableRawTextElement(mixedKey)).toBe(expected)
+		})
+	})
+	it("should not detect prototype properties", () => {
+		expect(isHTMLEscapableRawTextElement('hasOwnProperty')).toBe(false)
+		expect(isHTMLEscapableRawTextElement('constructor')).toBe(false)
+		expect(isHTMLEscapableRawTextElement('prototype')).toBe(false)
+		expect(isHTMLEscapableRawTextElement('__proto__')).toBe(false)
 	});
 })

--- a/test/conventions/html.test.js
+++ b/test/conventions/html.test.js
@@ -90,16 +90,17 @@ describe('HTML_RAW_TEXT_ELEMENTS', () => {
 })
 describe('isHTMLRawTextElement', () => {
 	Object.keys(HTML_RAW_TEXT_ELEMENTS).forEach((key) => {
-		it(`should detect attribute '${key}'`, () => {
-			expect(isHTMLRawTextElement(key)).toBe(true)
+		const expected = HTML_RAW_TEXT_ELEMENTS[key] === false
+		it(`should detect attribute '${key}' as ${expected}`, () => {
+			expect(isHTMLRawTextElement(key)).toBe(expected)
 		})
 		const upperKey = key.toUpperCase()
-		it(`should detect attribute '${upperKey}'`, () => {
-			expect(isHTMLRawTextElement(upperKey)).toBe(true)
+		it(`should detect attribute '${upperKey}' as ${expected}`, () => {
+			expect(isHTMLRawTextElement(upperKey)).toBe(expected)
 		})
 		const mixedKey = key[0].toUpperCase() + key.substring(1)
-		it(`should detect attribute '${mixedKey}'`, () => {
-			expect(isHTMLRawTextElement(mixedKey)).toBe(true)
+		it(`should detect attribute '${mixedKey}' as ${expected}`, () => {
+			expect(isHTMLRawTextElement(mixedKey)).toBe(expected)
 		})
 	})
 	it('should not detect prototype properties', () => {

--- a/test/conventions/html.test.js
+++ b/test/conventions/html.test.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const {
+	HTML_BOOLEAN_ATTRIBUTES,
+	isHTMLBooleanAttribute,
+	HTML_VOID_ELEMENTS,
+	isHTMLVoidElement,
+} = require('../../lib/conventions')
+
+describe('HTML_BOOLEAN_ATTRIBUTES', () => {
+	Object.keys(HTML_BOOLEAN_ATTRIBUTES).forEach((key) => {
+		const value = HTML_BOOLEAN_ATTRIBUTES[key]
+		it(`should contain immutable ${key} with value 'true'`, () => {
+			expect([key, value]).toMatchSnapshot()
+			try {
+				HTML_BOOLEAN_ATTRIBUTES[key] = 'boo'
+			} catch {}
+			expect(HTML_BOOLEAN_ATTRIBUTES[key]).toBe(value)
+		})
+	})
+})
+describe('isHTMLBooleanAttribute', () => {
+	Object.keys(HTML_BOOLEAN_ATTRIBUTES).forEach((key) => {
+		it(`should detect attribute '${key}'`, () => {
+			expect(isHTMLBooleanAttribute(key)).toBe(true)
+		})
+		const upperKey = key.toUpperCase()
+		it(`should detect attribute '${upperKey}'`, () => {
+			expect(isHTMLBooleanAttribute(upperKey)).toBe(true)
+		})
+		const mixedKey = key[0].toUpperCase() + key.substring(1)
+		it(`should detect attribute '${mixedKey}'`, () => {
+			expect(isHTMLBooleanAttribute(mixedKey)).toBe(true)
+		})
+	})
+	it("should not detect prototype properties", () => {
+		expect(isHTMLBooleanAttribute('hasOwnProperty')).toBe(false)
+		expect(isHTMLBooleanAttribute('constructor')).toBe(false)
+		expect(isHTMLBooleanAttribute('prototype')).toBe(false)
+		expect(isHTMLBooleanAttribute('__proto__')).toBe(false)
+	});
+})
+describe('HTML_VOID_ELEMENTS', () => {
+	Object.keys(HTML_VOID_ELEMENTS).forEach((key) => {
+		const value = HTML_VOID_ELEMENTS[key]
+		it(`should contain immutable ${key} with value 'true'`, () => {
+			expect([key, value]).toMatchSnapshot()
+			try {
+				HTML_VOID_ELEMENTS[key] = 'boo'
+			} catch {}
+			expect(HTML_VOID_ELEMENTS[key]).toBe(true)
+		})
+	})
+})
+describe('isHTMLVoidElement', () => {
+	Object.keys(HTML_VOID_ELEMENTS).forEach((key) => {
+		it(`should detect attribute '${key}'`, () => {
+			expect(isHTMLVoidElement(key)).toBe(true)
+		})
+		const upperKey = key.toUpperCase()
+		it(`should detect attribute '${upperKey}'`, () => {
+			expect(isHTMLVoidElement(upperKey)).toBe(true)
+		})
+		const mixedKey = key[0].toUpperCase() + key.substring(1)
+		it(`should detect attribute '${mixedKey}'`, () => {
+			expect(isHTMLVoidElement(mixedKey)).toBe(true)
+		})
+	})
+	it("should not detect prototype properties", () => {
+		expect(isHTMLVoidElement('hasOwnProperty')).toBe(false)
+		expect(isHTMLVoidElement('constructor')).toBe(false)
+		expect(isHTMLVoidElement('prototype')).toBe(false)
+		expect(isHTMLVoidElement('__proto__')).toBe(false)
+	});
+})

--- a/test/dom-parser.test.js
+++ b/test/dom-parser.test.js
@@ -12,31 +12,51 @@ describe('DOMParser', () => {
 			const options = { locator: {} }
 			const it = new DOMParser(options)
 
-			it.parseFromString('<xml/>')
+			const doc = it.parseFromString('<xml/>')
 
 			const expected = {
 				columnNumber: 1,
 				lineNumber: 1,
 			}
-			expect(options.locator).toStrictEqual(expected)
+			expect(doc.documentElement).toMatchObject(expected)
+		})
+		test('should use locator when options is not passed', () => {
+			const it = new DOMParser()
+
+			const doc = it.parseFromString('<xml/>')
+
+			const expected = {
+				columnNumber: 1,
+				lineNumber: 1,
+			}
+			expect(doc.documentElement).toMatchObject(expected)
+		})
+		test("should not use locator when it's not set in options", () => {
+			const options = {}
+			const it = new DOMParser(options)
+
+			const doc = it.parseFromString('<xml/>')
+
+			expect(doc.documentElement).not.toHaveProperty('columnNumber')
+			expect(doc.documentElement).not.toHaveProperty('lineNumber')
 		})
 
 		test('should set the default namespace to null by default', () => {
 			const options = { xmlns: {} }
 			const it = new DOMParser(options)
 
-			it.parseFromString('<xml/>')
+			const doc = it.parseFromString('<xml/>')
 
-			expect(options.xmlns['']).toBeNull()
+			expect(doc.documentElement.namespaceURI).toBeNull()
 		})
 
 		test('should set the default namespace to null by default', () => {
 			const options = { xmlns: {} }
 			const it = new DOMParser(options)
 
-			it.parseFromString('<xml/>')
+			const doc = it.parseFromString('<xml/>')
 
-			expect(options.xmlns['']).toBeNull()
+			expect(doc.documentElement.namespaceURI).toBeNull()
 		})
 
 		test('should store passed options.xmlns for default mime type', () => {
@@ -47,43 +67,47 @@ describe('DOMParser', () => {
 			const actual = it.parseFromString('<xml/>')
 
 			expect(actual.toString()).toBe('<xml xmlns="custom-default-ns"/>')
-			expect(xmlns['']).toBe(NS_CUSTOM)
+			expect(actual.documentElement.namespaceURI).toBe(NS_CUSTOM)
 		})
 
 		test('should store and modify passed options.xmlns for html mime type', () => {
 			const xmlns = { '': NS_CUSTOM }
 			const it = new DOMParser({ xmlns })
 
-			it.parseFromString('<xml/>', 'text/html')
+			const doc = it.parseFromString('<xml/>', MIME_TYPE.HTML)
 
-			expect(xmlns['']).toBe(NAMESPACE.HTML)
+			expect(doc.documentElement.namespaceURI).toBe(NAMESPACE.HTML)
+			expect(xmlns['']).toBe(NS_CUSTOM)
 		})
 
 		test('should store the default namespace for html mime type', () => {
 			const xmlns = {}
 			const it = new DOMParser({ xmlns })
 
-			it.parseFromString('<xml/>', 'text/html')
+			const doc = it.parseFromString('<xml/>', MIME_TYPE.HTML)
 
-			expect(xmlns['']).toBe(NAMESPACE.HTML)
+			expect(doc.documentElement.namespaceURI).toBe(NAMESPACE.HTML)
+			expect(xmlns).not.toHaveProperty('')
 		})
 
-		test('should store  default namespace for XHTML mime type', () => {
+		test('should store default namespace for XHTML mime type', () => {
 			const xmlns = {}
 			const it = new DOMParser({ xmlns })
 
-			it.parseFromString('<xml/>', MIME_TYPE.XML_XHTML_APPLICATION)
+			const doc = it.parseFromString('<xml/>', MIME_TYPE.XML_XHTML_APPLICATION)
 
-			expect(xmlns['']).toBe(NAMESPACE.HTML)
+			expect(doc.documentElement.namespaceURI).toBe(NAMESPACE.HTML)
+			expect(xmlns).not.toHaveProperty('')
 		})
 
-		test('should store and modify default namespace for XHTML mime type', () => {
+		test('should override default namespace for XHTML mime type', () => {
 			const xmlns = { '': NS_CUSTOM }
 			const it = new DOMParser({ xmlns })
 
-			it.parseFromString('<xml/>', MIME_TYPE.XML_XHTML_APPLICATION)
+			const doc = it.parseFromString('<xml/>', MIME_TYPE.XML_XHTML_APPLICATION)
 
-			expect(xmlns['']).toBe(NAMESPACE.HTML)
+			expect(doc.documentElement.namespaceURI).toBe(NAMESPACE.HTML)
+			expect(xmlns['']).toBe(NS_CUSTOM)
 		})
 		describe('property assign', () => {
 			const OBJECT_ASSIGN = Object.assign

--- a/test/dom-parser.test.js
+++ b/test/dom-parser.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { DOMParser } = require('../lib')
-const { MIME_TYPE, NAMESPACE } = require('../lib/conventions')
+const { assign, MIME_TYPE, NAMESPACE } = require('../lib/conventions')
 const { __DOMHandler } = require('../lib/dom-parser')
 
 const NS_CUSTOM = 'custom-default-ns'
@@ -84,6 +84,48 @@ describe('DOMParser', () => {
 			it.parseFromString('<xml/>', MIME_TYPE.XML_XHTML_APPLICATION)
 
 			expect(xmlns['']).toBe(NAMESPACE.HTML)
+		})
+		describe('property assign', () => {
+			const OBJECT_ASSIGN = Object.assign
+			beforeAll(() => {
+				expect(OBJECT_ASSIGN).toBeDefined()
+				expect(typeof OBJECT_ASSIGN).toBe('function')
+			})
+			afterEach(() => {
+				Object.assign = OBJECT_ASSIGN
+			})
+			afterAll(() => {
+				expect(Object.assign).toBeDefined()
+				expect(typeof Object.assign).toBe('function')
+			})
+			test('should use `options.assign` when passed', () => {
+				const stub = (t, s) => t
+				const it = new DOMParser({ assign: stub })
+
+				expect(it.assign).toBe(stub)
+			})
+
+			test('should use `Object.assign` when `options.assign` is undefined', () => {
+				expect(Object.assign).toBeDefined()
+				const it = new DOMParser({ assign: undefined })
+
+				expect(it.assign).toBe(Object.assign)
+			})
+
+			test('should use `Object.assign` when `options` is undefined', () => {
+				expect(Object.assign).toBeDefined()
+				const it = new DOMParser()
+
+				expect(it.assign).toBe(Object.assign)
+			})
+
+			test('should use `conventions.assign` when `Object.assign` is undefined', () => {
+				Object.assign = undefined // is reset by afterEach
+
+				const it = new DOMParser()
+
+				expect(it.assign).toBe(assign)
+			})
 		})
 	})
 

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -97,6 +97,7 @@ describe('Document.prototype', () => {
 			const element = doc.createElement('XmL')
 
 			expect(element.nodeName).toBe('XmL')
+			expect(element.localName).toBe(element.nodeName)
 		})
 		it('should create elements with exact cased name in an XHTML document', () => {
 			const impl = new DOMImplementation()
@@ -105,6 +106,7 @@ describe('Document.prototype', () => {
 			const element = doc.createElement('XmL')
 
 			expect(element.nodeName).toBe('XmL')
+			expect(element.localName).toBe(element.nodeName)
 		})
 		it('should create elements with lower cased name in an HTML document', () => {
 			// https://dom.spec.whatwg.org/#dom-document-createelement
@@ -113,7 +115,9 @@ describe('Document.prototype', () => {
 
 			const element = doc.createElement('XmL')
 
+			expect(element.localName).toBe('xml')
 			expect(element.nodeName).toBe('xml')
+			expect(element.tagName).toBe(element.nodeName)
 		})
 		it('should create elements with no namespace in an XML document without default namespace', () => {
 			const impl = new DOMImplementation()
@@ -138,6 +142,39 @@ describe('Document.prototype', () => {
 			const element = doc.createElement('a')
 
 			expect(element.namespaceURI).toBe(NAMESPACE.HTML)
+		})
+	})
+	describe('createAttribute', () => {
+		const NAME = 'NaMe'
+		test('should create name as passed in XML documents', () => {
+			const doc = new DOMImplementation().createDocument(null, '')
+
+			const attr = doc.createAttribute(NAME)
+
+			expect(attr.ownerDocument).toBe(doc)
+			expect(attr.name).toBe(NAME)
+			expect(attr.localName).toBe(NAME)
+			expect(attr.nodeName).toBe(NAME)
+		})
+		test('should create name as passed in XHTML documents', () => {
+			const doc = new DOMImplementation().createDocument(NAMESPACE.HTML, '')
+
+			const attr = doc.createAttribute(NAME)
+
+			expect(attr.ownerDocument).toBe(doc)
+			expect(attr.name).toBe(NAME)
+			expect(attr.localName).toBe(NAME)
+			expect(attr.nodeName).toBe(NAME)
+		})
+		test('should create lower cased name when passed in HTML document', () => {
+			const doc = new DOMImplementation().createHTMLDocument(false)
+
+			const attr = doc.createAttribute(NAME)
+
+			expect(attr.ownerDocument).toBe(doc)
+			expect(attr.name).toBe('name')
+			expect(attr.localName).toBe('name')
+			expect(attr.nodeName).toBe('name')
 		})
 	})
 })

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -2,6 +2,7 @@
 
 const { getTestParser } = require('../get-test-parser')
 const { DOMImplementation } = require('../../lib/dom')
+const { NAMESPACE } = require('../../lib/conventions')
 
 const INPUT = (first = '', second = '', third = '', fourth = '') => `
 <html >
@@ -88,15 +89,55 @@ describe('Document.prototype', () => {
 			})
 		})
 	})
-	describe('doctype', () => {
-		it('should be added when passed to createDocument', () => {
+	describe('createElement', () => {
+		it('should create elements with exact cased name in an XML document', () => {
 			const impl = new DOMImplementation()
-			const doctype = impl.createDocumentType('name')
-			const doc = impl.createDocument(null, undefined, doctype)
+			const doc = impl.createDocument(null, 'xml')
 
-			expect(doc.doctype === doctype).toBe(true)
-			expect(doctype.ownerDocument === doc).toBe(true)
-			expect(doc.firstChild === doctype).toBe(true)
+			const element = doc.createElement('XmL')
+
+			expect(element.nodeName).toBe('XmL')
+		})
+		it('should create elements with exact cased name in an XHTML document', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createDocument(NAMESPACE.HTML, '')
+
+			const element = doc.createElement('XmL')
+
+			expect(element.nodeName).toBe('XmL')
+		})
+		it('should create elements with lower cased name in an HTML document', () => {
+			// https://dom.spec.whatwg.org/#dom-document-createelement
+			const impl = new DOMImplementation()
+			const doc = impl.createHTMLDocument(false)
+
+			const element = doc.createElement('XmL')
+
+			expect(element.nodeName).toBe('xml')
+		})
+		it('should create elements with no namespace in an XML document without default namespace', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createDocument(null, 'xml')
+
+			const element = doc.createElement('XmL')
+
+			expect(element.namespaceURI).toBeNull()
+		})
+		it('should create elements with the HTML namespace in an XML document with HTML namespace', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createDocument(NAMESPACE.HTML, 'xml')
+
+			const element = doc.createElement('XmL')
+
+			expect(element.namespaceURI).toBe(NAMESPACE.HTML)
+		})
+		it('should create elements with the HTML namespace in an HTML document', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createHTMLDocument()
+
+			const element = doc.createElement('a')
+
+			expect(element.namespaceURI).toBe(NAMESPACE.HTML)
 		})
 	})
 })

--- a/test/dom/dom-implementation.test.js
+++ b/test/dom/dom-implementation.test.js
@@ -219,8 +219,9 @@ describe('DOMImplementation', () => {
 			expect(doc.firstChild).toBe(doc.doctype)
 
 			expect(doc.documentElement).not.toBeNull()
+			expect(doc.documentElement.localName).toBe('html')
 			expect(doc.documentElement.nodeName).toBe('html')
-			expect(doc.documentElement.tagName).toBe('html')
+			expect(doc.documentElement.tagName).toBe(doc.documentElement.nodeName)
 			const htmlNode = doc.documentElement
 			expect(htmlNode.firstChild).not.toBeNull()
 			expect(htmlNode.firstChild.nodeName).toBe('head')
@@ -246,8 +247,9 @@ describe('DOMImplementation', () => {
 			expect(doc.firstChild).toBe(doc.doctype)
 
 			expect(doc.documentElement).not.toBeNull()
+			expect(doc.documentElement.localName).toBe('html')
 			expect(doc.documentElement.nodeName).toBe('html')
-			expect(doc.documentElement.tagName).toBe('html')
+			expect(doc.documentElement.tagName).toBe(doc.documentElement.nodeName)
 			const htmlNode = doc.documentElement
 
 			expect(htmlNode.firstChild).not.toBeNull()
@@ -270,8 +272,9 @@ describe('DOMImplementation', () => {
 			expect(doc.type).toBe('html')
 
 			expect(doc.documentElement).not.toBeNull()
+			expect(doc.documentElement.localName).toBe('html')
 			expect(doc.documentElement.nodeName).toBe('html')
-			expect(doc.documentElement.tagName).toBe('html')
+			expect(doc.documentElement.tagName).toBe(doc.documentElement.nodeName)
 			const htmlNode = doc.documentElement
 
 			expect(htmlNode.firstChild).not.toBeNull()

--- a/test/dom/dom-implementation.test.js
+++ b/test/dom/dom-implementation.test.js
@@ -7,6 +7,7 @@ const {
 	Node,
 	NodeList,
 } = require('../../lib/dom')
+const { NAMESPACE, MIME_TYPE } = require('../../lib/conventions')
 
 const NAME = 'NAME'
 const PREFIX = 'PREFIX'
@@ -40,6 +41,8 @@ describe('DOMImplementation', () => {
 			expect(doc.doctype).toBe(null)
 			expect(doc.childNodes).toBeInstanceOf(NodeList)
 			expect(doc.documentElement).toBe(null)
+			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION)
+			expect(doc.type).toBe('xml')
 		})
 
 		it('should create a Document with only a doc type', () => {
@@ -50,6 +53,8 @@ describe('DOMImplementation', () => {
 			expect(doc.doctype).toBe(doctype)
 			expect(doctype.ownerDocument).toBe(doc)
 			expect(doc.childNodes.item(0)).toBe(doctype)
+			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION)
+			expect(doc.type).toBe('xml')
 		})
 
 		it('should create a Document with root element without a namespace', () => {
@@ -65,6 +70,8 @@ describe('DOMImplementation', () => {
 			expect(root.prefix).toBe(null)
 			expect(root.localName).toBe(NAME)
 			expect(doc.documentElement).toBe(root)
+			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION)
+			expect(doc.type).toBe('xml')
 		})
 
 		it('should create a Document with root element in a default namespace', () => {
@@ -81,6 +88,8 @@ describe('DOMImplementation', () => {
 			expect(root.tagName).toBe(NAME)
 
 			expect(doc.documentElement).toBe(root)
+			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION)
+			expect(doc.type).toBe('xml')
 		})
 
 		it('should create a Document with root element in a named namespace', () => {
@@ -98,6 +107,8 @@ describe('DOMImplementation', () => {
 			expect(root.tagName).toBe(qualifiedName)
 
 			expect(doc.documentElement).toBe(root)
+			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION)
+			expect(doc.type).toBe('xml')
 		})
 
 		it('should create a Document with root element in a named namespace', () => {
@@ -115,6 +126,8 @@ describe('DOMImplementation', () => {
 			expect(root.tagName).toBe(qualifiedName)
 
 			expect(doc.documentElement).toBe(root)
+			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION)
+			expect(doc.type).toBe('xml')
 		})
 
 		it('should create a Document with namespaced root element and doctype', () => {
@@ -137,6 +150,22 @@ describe('DOMImplementation', () => {
 			expect(root.tagName).toBe(qualifiedName)
 
 			expect(doc.documentElement).toBe(root)
+			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION)
+			expect(doc.type).toBe('xml')
+		})
+
+		it('should create SVG document from the SVG namespace', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createDocument(NAMESPACE.SVG, 'svg')
+			expect(doc.contentType).toBe(MIME_TYPE.XML_SVG_IMAGE)
+			expect(doc.type).toBe('xml')
+		})
+
+		it('should create XHTML document from the HTML namespace', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createDocument(NAMESPACE.HTML, 'svg')
+			expect(doc.contentType).toBe(MIME_TYPE.XML_XHTML_APPLICATION)
+			expect(doc.type).toBe('xml')
 		})
 	})
 
@@ -160,6 +189,102 @@ describe('DOMImplementation', () => {
 			expect(doctype.name).toBe(NAME)
 			expect(doctype.publicId).toBe('"PUBLIC"')
 			expect(doctype.systemId).toBe('"SYSTEM"')
+		})
+	})
+	describe('createHTMLDocument', () => {
+		it('should create an empty HTML document without any elements', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createHTMLDocument(false)
+
+			expect(doc.implementation).toBe(impl)
+			expect(doc.contentType).toBe(MIME_TYPE.HTML)
+			expect(doc.type).toBe('html')
+			expect(doc.childNodes.length).toBe(0)
+			expect(doc.doctype).toBeNull()
+			expect(doc.documentElement).toBeNull()
+		})
+		it('should create an HTML document with minimum specified elements when title not provided', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createHTMLDocument()
+
+			expect(doc.implementation).toBe(impl)
+			expect(doc.contentType).toBe(MIME_TYPE.HTML)
+			expect(doc.type).toBe('html')
+
+			expect(doc.doctype).not.toBeNull()
+			expect(doc.doctype.name).toBe('html')
+			expect(doc.doctype.nodeName).toBe('html')
+			expect(doc.doctype.ownerDocument).toBe(doc)
+			expect(doc.childNodes.item(0)).toBe(doc.doctype)
+			expect(doc.firstChild).toBe(doc.doctype)
+
+			expect(doc.documentElement).not.toBeNull()
+			expect(doc.documentElement.nodeName).toBe('html')
+			expect(doc.documentElement.tagName).toBe('html')
+			const htmlNode = doc.documentElement
+			expect(htmlNode.firstChild).not.toBeNull()
+			expect(htmlNode.firstChild.nodeName).toBe('head')
+			expect(htmlNode.firstChild.childNodes).toHaveLength(0)
+
+			expect(htmlNode.lastChild).not.toBeNull()
+			expect(htmlNode.lastChild.nodeName).toBe('body')
+			expect(htmlNode.lastChild.childNodes).toHaveLength(0)
+		})
+		it('should create an HTML document with specified elements including an empty title', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createHTMLDocument('')
+
+			expect(doc.implementation).toBe(impl)
+			expect(doc.contentType).toBe(MIME_TYPE.HTML)
+			expect(doc.type).toBe('html')
+
+			expect(doc.doctype).not.toBeNull()
+			expect(doc.doctype.name).toBe('html')
+			expect(doc.doctype.nodeName).toBe('html')
+			expect(doc.doctype.ownerDocument).toBe(doc)
+			expect(doc.childNodes.item(0)).toBe(doc.doctype)
+			expect(doc.firstChild).toBe(doc.doctype)
+
+			expect(doc.documentElement).not.toBeNull()
+			expect(doc.documentElement.nodeName).toBe('html')
+			expect(doc.documentElement.tagName).toBe('html')
+			const htmlNode = doc.documentElement
+
+			expect(htmlNode.firstChild).not.toBeNull()
+			expect(htmlNode.firstChild.nodeName).toBe('head')
+			const headNode = htmlNode.firstChild
+
+			expect(headNode.firstChild).not.toBeNull()
+			expect(headNode.firstChild.nodeName).toBe('title')
+			expect(headNode.firstChild.firstChild).not.toBeNull()
+			expect(headNode.firstChild.firstChild.ownerDocument).toBe(doc)
+			expect(headNode.firstChild.firstChild.nodeType).toBe(Node.TEXT_NODE)
+			expect(headNode.firstChild.firstChild.nodeValue).toBe('')
+		})
+		it('should create an HTML document with specified elements including an provided title', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createHTMLDocument('eltiT')
+
+			expect(doc.implementation).toBe(impl)
+			expect(doc.contentType).toBe(MIME_TYPE.HTML)
+			expect(doc.type).toBe('html')
+
+			expect(doc.documentElement).not.toBeNull()
+			expect(doc.documentElement.nodeName).toBe('html')
+			expect(doc.documentElement.tagName).toBe('html')
+			const htmlNode = doc.documentElement
+
+			expect(htmlNode.firstChild).not.toBeNull()
+			expect(htmlNode.firstChild.nodeName).toBe('head')
+			const headNode = htmlNode.firstChild
+
+			expect(headNode.firstChild).not.toBeNull()
+			expect(headNode.firstChild.nodeName).toBe('title')
+
+			expect(headNode.firstChild.firstChild).not.toBeNull()
+			expect(headNode.firstChild.firstChild.ownerDocument).toBe(doc)
+			expect(headNode.firstChild.firstChild.nodeType).toBe(Node.TEXT_NODE)
+			expect(headNode.firstChild.firstChild.nodeValue).toBe('eltiT')
 		})
 	})
 })

--- a/test/dom/element.test.js
+++ b/test/dom/element.test.js
@@ -209,16 +209,6 @@ describe('Document', () => {
 		expect(doc.documentElement.toString()).toBe('<test>bye</test>')
 	})
 
-	describe('createElement', () => {
-		it('should set localName', () => {
-			const doc = new DOMImplementation().createDocument(null, 'test', null)
-
-			const elem = doc.createElement('foo')
-
-			expect(elem.localName === 'foo')
-		})
-	})
-
 	it('appendElement and removeElement', () => {
 		const dom = new DOMParser().parseFromString(`<root><A/><B/><C/></root>`)
 		const doc = dom.documentElement

--- a/test/dom/ns-test.test.js
+++ b/test/dom/ns-test.test.js
@@ -17,7 +17,7 @@ describe('XML Namespace Parse', () => {
 		const el = doc.getElementsByTagName('c:var')[0]
 		expect(el.namespaceURI).toBe('http://www.xidea.org/lite/core')
 		expect(doc.toString()).toBe(
-			'<html xmlns="http://www.w3.org/1999/xhtml"><body><c:var name="a" value="${1}" xmlns:c="http://www.xidea.org/lite/core"></c:var></body></html>'
+			'<html xmlns="http://www.w3.org/1999/xhtml"><body><c:var name="a" value="${1}" xmlns:c="http://www.xidea.org/lite/core"/></body></html>'
 		)
 	})
 
@@ -25,12 +25,7 @@ describe('XML Namespace Parse', () => {
 		const w3 = 'http://www.w3.org/1999/xhtml'
 		const n1 = 'http://www.frankston.com/public'
 		const n2 = 'http://rmf.vc/n2'
-		const hx =
-			'<html test="a" xmlns="' +
-			w3 +
-			'" xmlns:rmf="' +
-			n1 +
-			'"><rmf:foo hello="asdfa"/></html>'
+		const hx = `<html test="a" xmlns="${w3}" xmlns:rmf="${n1}"><rmf:foo hello="asdfa"/></html>`
 
 		const doc = new DOMParser().parseFromString(hx, 'text/xml')
 		const els = [].slice.call(
@@ -39,17 +34,19 @@ describe('XML Namespace Parse', () => {
 		for (let _i = 0, els_1 = els; _i < els_1.length; _i++) {
 			const el = els_1[_i]
 
-			const te = doc.createElementNS(n1, 'test')
-			te.setAttributeNS(n1, 'bar', 'valx')
-			expect(te.toString()).toBe('<test xmlns="' + n1 + '" bar="valx"/>')
-			el.appendChild(te)
-			const tx = doc.createElementNS(n2, 'test')
-			tx.setAttributeNS(n2, 'bar', 'valx')
-			expect(tx.toString()).toBe('<test xmlns="' + n2 + '" bar="valx"/>')
-			el.appendChild(tx)
+			const n1_test = doc.createElementNS(n1, 'test')
+			n1_test.setAttribute('xmlns', n1)
+			n1_test.setAttributeNS(n1, 'bar', 'valx')
+			expect(n1_test.toString()).toBe('<test xmlns="' + n1 + '" bar="valx"/>')
+			el.appendChild(n1_test)
+			const n2_test = doc.createElementNS(n2, 'test')
+			n2_test.setAttribute('xmlns', n2)
+			n2_test.setAttributeNS(n2, 'bar', 'valx')
+			expect(n2_test.toString()).toBe('<test xmlns="' + n2 + '" bar="valx"/>')
+			el.appendChild(n2_test)
 		}
 		expect(doc.toString()).toBe(
-			'<html test="a" xmlns="http://www.w3.org/1999/xhtml" xmlns:rmf="http://www.frankston.com/public"><rmf:foo hello="asdfa"><test xmlns="http://www.frankston.com/public" bar="valx"></test><test xmlns="http://rmf.vc/n2" bar="valx"></test></rmf:foo></html>'
+			'<html test="a" xmlns="http://www.w3.org/1999/xhtml" xmlns:rmf="http://www.frankston.com/public"><rmf:foo hello="asdfa"><test xmlns="http://www.frankston.com/public" bar="valx"/><test xmlns="http://rmf.vc/n2" bar="valx"/></rmf:foo></html>'
 		)
 	})
 })

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -83,19 +83,19 @@ describe('XML Serializer', () => {
 			const doc = new DOMParser().parseFromString(str, MIME_TYPE.HTML)
 
 			const child = doc.createElementNS('AAA', 'child')
-			expect(new XMLSerializer().serializeToString(child, true)).toBe(
+			expect(new XMLSerializer().serializeToString(child)).toBe(
 				'<child xmlns="AAA"></child>'
 			)
 			doc.documentElement.appendChild(child)
-			expect(new XMLSerializer().serializeToString(doc, true)).toBe(
+			expect(new XMLSerializer().serializeToString(doc)).toBe(
 				'<a:foo xmlns:a="AAA"><child xmlns="AAA"></child></a:foo>'
 			)
 			const nested = doc.createElementNS('AAA', 'nested')
-			expect(new XMLSerializer().serializeToString(nested, true)).toBe(
+			expect(new XMLSerializer().serializeToString(nested)).toBe(
 				'<nested xmlns="AAA"></nested>'
 			)
 			child.appendChild(nested)
-			expect(new XMLSerializer().serializeToString(doc, true)).toBe(
+			expect(new XMLSerializer().serializeToString(doc)).toBe(
 				'<a:foo xmlns:a="AAA"><child xmlns="AAA"><nested></nested></child></a:foo>'
 			)
 		})

--- a/test/error/__snapshots__/reported-levels.test.js.snap
+++ b/test/error/__snapshots__/reported-levels.test.js.snap
@@ -352,20 +352,6 @@ Array [
 ]
 `;
 
-exports[`WF_AttributeMissingValue with mimeType text/html should be reported as warning 1`] = `
-Array [
-  "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead!!
-@#[line:1,col:1]",
-]
-`;
-
-exports[`WF_AttributeMissingValue with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
-Array [
-  "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#15)",
-]
-`;
-
 exports[`WF_AttributeMissingValue with mimeType text/xml should be reported as warning 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead!!
@@ -377,22 +363,6 @@ exports[`WF_AttributeMissingValue with mimeType text/xml should escalate Error t
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead!!||@#[line:1,col:1]
     at parseElementStartPart (lib/sax.js:#15)",
-]
-`;
-
-exports[`WF_AttributeMissingValue2 with mimeType text/html should be reported as warning 1`] = `
-Array [
-  "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead2!!
-@#[line:1,col:1]",
-  "[xmldom warning]	attribute \\"attr2\\" missed value!! \\"attr2\\" instead!!
-@#[line:1,col:1]",
-]
-`;
-
-exports[`WF_AttributeMissingValue2 with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
-Array [
-  "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead2!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#18)",
 ]
 `;
 

--- a/test/error/__snapshots__/xml-error.test.js.snap
+++ b/test/error/__snapshots__/xml-error.test.js.snap
@@ -48,7 +48,7 @@ Object {
   -->
 
   <state id=\\"start\\" name=\\"start\\">
-    <transition event=\\"init\\" name=\\"init\\" target=\\"main_state\\"/>
+    <transition event=\\"init\\" name=\\"init\\" target=\\"main_state\\"></transition>
   </state>
 
   </scxml>",

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -223,6 +223,7 @@ const REPORTED = {
 		source: '<xml attr ></xml>',
 		level: 'warning',
 		match: (msg) => /missed value/.test(msg) && /instead!!/.test(msg),
+		skippedInHtml: true,
 	},
 	/**
 	 * Triggered by lib/sax.js:376
@@ -236,6 +237,7 @@ const REPORTED = {
 		source: '<xml attr attr2 ></xml>',
 		level: 'warning',
 		match: (msg) => /missed value/.test(msg) && /instead2!!/.test(msg),
+		skippedInHtml: true,
 	},
 }
 

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -14,18 +14,17 @@ const { DOMParser } = require('../lib/dom-parser')
  * - `errors`: the object for the `errorHandler` to use,
  * 						is also returned with the same name for later assertions,
  * 						default is an empty object
- * - `locator`: The `locator` to pass to DOMParser constructor options,
- * 			  		 default is an empty object
+ * - `locator`: Whether to record node locations in the XML string, default is true
  *
  * @param options {{
  * 					errorHandler?: function (key: ErrorLevel, msg: string)
  * 				  							| Partial<Record<ErrorLevel, function(msg:string)>>,
  * 					errors?: Partial<Record<ErrorLevel, string[]>>,
- * 					locator?: Object
+ * 					locator?: boolean
  *				}}
  * @returns {{parser: DOMParser, errors: Partial<Record<ErrorLevel, string[]>>}}
  */
-function getTestParser({ errorHandler, errors = {}, locator = {} } = {}) {
+function getTestParser({ errorHandler, errors = {}, locator = true } = {}) {
 	errorHandler =
 		errorHandler ||
 		((key, msg) => {

--- a/test/html/__snapshots__/normalize.test.js.snap
+++ b/test/html/__snapshots__/normalize.test.js.snap
@@ -146,6 +146,12 @@ Object {
 }
 `;
 
+exports[`html normalizer text/html: script <ul><li>abc<li>def</ul> 1`] = `
+Object {
+  "actual": "<ul xmlns=\\"http://www.w3.org/1999/xhtml\\"><li></li>abc<li></li>def</ul>",
+}
+`;
+
 exports[`html normalizer text/xml: script <input type="button" disabled></input> 1`] = `
 Object {
   "actual": "<input type=\\"button\\" disabled=\\"disabled\\"/>",
@@ -216,6 +222,18 @@ Object {
   "warning": Array [
     "[xmldom warning]	unclosed xml attribute
 @#[line:1,col:25]",
+  ],
+}
+`;
+
+exports[`html normalizer text/xml: script <ul><li>abc<li>def</ul> 1`] = `
+Object {
+  "actual": "<ul><li/>abc<li/>def</ul>",
+  "warning": Array [
+    "[xmldom warning]	unclosed xml attribute
+@#[line:1,col:5]",
+    "[xmldom warning]	unclosed xml attribute
+@#[line:1,col:12]",
   ],
 }
 `;

--- a/test/html/__snapshots__/normalize.test.js.snap
+++ b/test/html/__snapshots__/normalize.test.js.snap
@@ -20,8 +20,6 @@ Object {
   "warning": Array [
     "[xmldom warning]	attribute \\"&\\" missed quot(\\")!!
 @#[line:1,col:1]",
-    "[xmldom warning]	attribute \\"b\\" missed value!! \\"b\\" instead!!
-@#[line:1,col:1]",
   ],
 }
 `;
@@ -31,10 +29,6 @@ Object {
   "actual": "<div a=\\"&amp;\\" bb=\\"bb\\" c=\\"c\\" d=\\"123&amp;&amp;456\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></div>",
   "warning": Array [
     "[xmldom warning]	attribute \\"&\\" missed quot(\\")!!
-@#[line:1,col:1]",
-    "[xmldom warning]	attribute \\"bb\\" missed value!! \\"bb\\" instead2!!
-@#[line:1,col:1]",
-    "[xmldom warning]	attribute \\"c\\" missed value!! \\"c\\" instead2!!
 @#[line:1,col:1]",
     "[xmldom warning]	attribute \\"123&&456\\" missed quot(\\")!
 @#[line:1,col:1]",
@@ -110,6 +104,24 @@ Object {
 }
 `;
 
+exports[`html normalizer text/html: script <input type="button" disabled></input> 1`] = `
+Object {
+  "actual": "<input type=\\"button\\" disabled=\\"disabled\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"/>",
+}
+`;
+
+exports[`html normalizer text/html: script <input type="checkbox" checked></input> 1`] = `
+Object {
+  "actual": "<input type=\\"checkbox\\" checked=\\"checked\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"/>",
+}
+`;
+
+exports[`html normalizer text/html: script <option selected></option> 1`] = `
+Object {
+  "actual": "<option selected=\\"selected\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></option>",
+}
+`;
+
 exports[`html normalizer text/html: script <script src="./test.js"/> 1`] = `
 Object {
   "actual": "<script src=\\"./test.js\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></script>",
@@ -131,6 +143,36 @@ Object {
 exports[`html normalizer text/html: script <textarea>alert(a<b&&c?"<br>":">>");</textarea> 1`] = `
 Object {
   "actual": "<textarea xmlns=\\"http://www.w3.org/1999/xhtml\\">alert(a&lt;b&amp;&amp;c?\\"&lt;br>\\":\\">>\\");</textarea>",
+}
+`;
+
+exports[`html normalizer text/xml: script <input type="button" disabled></input> 1`] = `
+Object {
+  "actual": "<input type=\\"button\\" disabled=\\"disabled\\"/>",
+  "warning": Array [
+    "[xmldom warning]	attribute \\"disabled\\" missed value!! \\"disabled\\" instead!!
+@#[line:1,col:1]",
+  ],
+}
+`;
+
+exports[`html normalizer text/xml: script <input type="checkbox" checked></input> 1`] = `
+Object {
+  "actual": "<input type=\\"checkbox\\" checked=\\"checked\\"/>",
+  "warning": Array [
+    "[xmldom warning]	attribute \\"checked\\" missed value!! \\"checked\\" instead!!
+@#[line:1,col:1]",
+  ],
+}
+`;
+
+exports[`html normalizer text/xml: script <option selected></option> 1`] = `
+Object {
+  "actual": "<option selected=\\"selected\\"/>",
+  "warning": Array [
+    "[xmldom warning]	attribute \\"selected\\" missed value!! \\"selected\\" instead!!
+@#[line:1,col:1]",
+  ],
 }
 `;
 
@@ -201,10 +243,6 @@ Object {
 exports[`html normalizer unclosed html <html title/> 1`] = `
 Object {
   "actual": "<html title=\\"title\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></html>",
-  "warning": Array [
-    "[xmldom warning]	attribute \\"title\\" missed value!! \\"title\\" instead!!
-@#[line:1,col:1]",
-  ],
 }
 `;
 

--- a/test/html/normalize.test.js
+++ b/test/html/normalize.test.js
@@ -47,7 +47,7 @@ describe('html normalizer', () => {
 			'<input type="button" disabled></input>',
 			'<input type="checkbox" checked></input>',
 			'<option selected></option>',
-			,
+			'<ul><li>abc<li>def</ul>',
 		])(`${mimeType}: script %s`, (xml) => {
 			const { errors, parser } = getTestParser()
 

--- a/test/html/normalize.test.js
+++ b/test/html/normalize.test.js
@@ -61,7 +61,9 @@ describe('html normalizer', () => {
 
 		const actual = parser.parseFromString(xml, 'application/xml')
 
-		expect(actual.documentElement.firstChild.textContent).toBe('let message = " & ETH";');
+		expect(actual.documentElement.firstChild.textContent).toBe(
+			'let message = " & ETH";'
+		)
 	})
 	it.each([
 		`<html xmlns="http://www.w3.org/1999/xhtml"><script>let message = " &amp; ETH";</script></html>`,
@@ -71,7 +73,9 @@ describe('html normalizer', () => {
 
 		const actual = parser.parseFromString(xml, 'text/html')
 
-		expect(actual.documentElement.firstChild.textContent).toBe('let message = " &amp; ETH";');
+		expect(actual.documentElement.firstChild.textContent).toBe(
+			'let message = " &amp; ETH";'
+		)
 	})
 
 	it('European entities', () => {

--- a/test/html/normalize.test.js
+++ b/test/html/normalize.test.js
@@ -44,6 +44,10 @@ describe('html normalizer', () => {
 			'<script>alert(a<b&&c?"<br/>":">>");</script>',
 			'<script src="./test.js"/>',
 			'<textarea>alert(a<b&&c?"<br>":">>");</textarea>',
+			'<input type="button" disabled></input>',
+			'<input type="checkbox" checked></input>',
+			'<option selected></option>',
+			,
 		])(`${mimeType}: script %s`, (xml) => {
 			const { errors, parser } = getTestParser()
 

--- a/test/html/normalize.test.js
+++ b/test/html/normalize.test.js
@@ -53,6 +53,27 @@ describe('html normalizer', () => {
 		})
 	})
 
+	it.each([
+		`<html xmlns="http://www.w3.org/1999/xhtml"><script>let message = " &amp; ETH";</script></html>`,
+		`<html><script>let message = " &amp; ETH";</script></html>`,
+	])(`should map entity in %s`, (xml) => {
+		const { parser } = getTestParser()
+
+		const actual = parser.parseFromString(xml, 'application/xml')
+
+		expect(actual.documentElement.firstChild.textContent).toBe('let message = " & ETH";');
+	})
+	it.each([
+		`<html xmlns="http://www.w3.org/1999/xhtml"><script>let message = " &amp; ETH";</script></html>`,
+		`<html><script>let message = " &amp; ETH";</script></html>`,
+	])(`should not map entity in %s`, (xml) => {
+		const { parser } = getTestParser()
+
+		const actual = parser.parseFromString(xml, 'text/html')
+
+		expect(actual.documentElement.firstChild.textContent).toBe('let message = " &amp; ETH";');
+	})
+
 	it('European entities', () => {
 		const { errors, parser } = getTestParser()
 

--- a/test/xss.test.js
+++ b/test/xss.test.js
@@ -35,7 +35,7 @@ function xss(html) {
 	const dom = new DOMParser({
 		xmlns: { '': 'http://www.w3.org/1999/xhtml' },
 	}).parseFromString(html, 'text/html')
-	return dom.documentElement.toString(true, function (node) {
+	return dom.documentElement.toString(function (node) {
 		switch (node.nodeType) {
 			case 1: //element
 				const tagName = node.tagName


### PR DESCRIPTION
In the living specs for parsing XML and HTML, that this library is trying to implement,
there is a distinction between the different types of documents being parsed:
There are quite some rules that are different for parsing, constructing and serializing XML vs HTML documents.

So far xmldom was always "detecting" whether "the HTML rules should be applied" by looking at the current namespace. So from the first time an the HTML default namespace (`http://www.w3.org/1999/xhtml`) was found, every node was treated as being part of an HTML document. This misconception is the root cause for quite some reported bugs.

BREAKING CHANGE: HTML rules are no longer applied just because of the namespace, but require the `mimeType` argument passed to `DOMParser.parseFromString(source, mimeType)` to match `'text/html'`. Doing so implies all rules for handling casing for tag and attribute names when parsing, creation of nodes and searching nodes.

BREAKING CHANGE: Correct the return type of `DOMParser.parseFromString` to `Document | undefined`. In case of parsing errors it was always possible that "the returned `Document`" has not been created. In case you are using Typescript you now need to handle those cases.

BREAKING CHANGE: The instance property `DOMParser.options` is no longer available, instead use the individual `readonly` property per option (`assign`, `domHandler`, `errorHandler`, `normalizeLineEndings`, `locator`, `xmlns`). Those also provides the default value if the option was not passed. The 'locator' option is now just a boolean (default remains `true`).

BREAKING CHANGE: The following methods no longer allow a (non spec compliant) boolean argument to toggle "HTML rules":
- `XMLSerializer.serializeToString`
- `Node.toString`
- `Document.toString`

The following interfaces have been implemented:
`DOMImplementation` now implements all methods defined in the DOM spec, but not all of the behavior is implemented (see docstring):
- `createDocument` creates an "XML Document" (prototype: `Document`, property `type` is `'xml'`)
- `createHTMLDocument` creates an "HTML Document" (type/prototype: `Document`, property `type` is `'html'`).
  - when no argument is passed or the first argument is a string, the basic nodes for an HTML structure are created, as specified
  - when the first argument is `false` no child nodes are created

`Document` now has two new readonly properties as specified in the DOM spec: 
- `contentType` which is the mime-type that was used to create the document
- `type` which is either the string literal `'xml'` or `'html'`

`MIME_TYPE` (`/lib/conventions.js`):
- `hasDefaultHTMLNamespace` test if the provided string is one of the miem types that implies the default HTML namespace: `text/html` or `application/xhtml+xml`
