### PR TITLE
Parse internal entity declarations in internal DTD

### DIFF
--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -249,7 +249,16 @@ DOMHandler.prototype = {
 	    }
 	},
 
+	/**
+	 * If the same entity is declared more than once, the first declaration
+	 * encountered is binding, and a warning is issued.
+	 * @link https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-entity-decl
+	 */
 	internalEntityDecl:function(name, value) {
+		if (name in this.entityMap) {
+			this.warning("entity '"+ name +"' has already been declared");
+			return;
+		}
 		this.entityMap[name] = value;
 	},
 

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -80,7 +80,12 @@ DOMParser.prototype.parseFromString = function(source,mimeType){
 	var locator = options.locator;
 	var defaultNSMap = options.xmlns||{};
 	var isHTML = /\/x?html?$/.test(mimeType);//mimeType.toLowerCase().indexOf('html') > -1;
-  	var entityMap = isHTML ? entities.HTML_ENTITIES : entities.XML_ENTITIES;
+	var entityMap = isHTML ? entities.HTML_ENTITIES : entities.XML_ENTITIES;
+	// Using prototypical inheritance to avoid copying nedlessly
+	function EntityMap() {}
+	EntityMap.prototype = entityMap;
+	entityMap = new EntityMap();
+	domBuilder.entityMap = entityMap;
 	if(locator){
 		domBuilder.setDocumentLocator(locator)
 	}
@@ -243,6 +248,11 @@ DOMHandler.prototype = {
 					this.doc.doctype = dt;
 	    }
 	},
+
+	internalEntityDecl:function(name, value) {
+		this.entityMap[name] = value;
+	},
+
 	/**
 	 * @see org.xml.sax.ErrorHandler
 	 * @link http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
@@ -293,7 +303,6 @@ function _toString(chars,start,length){
  * 	#attributeDecl(eName, aName, type, mode, value)
  *  #elementDecl(name, model)
  *  #externalEntityDecl(name, publicId, systemId)
- *  #internalEntityDecl(name, value)
  * @link http://www.saxproject.org/apidoc/org/xml/sax/ext/EntityResolver2.html
  * IGNORED method of org.xml.sax.EntityResolver2
  *  #resolveEntity(String name,String publicId,String baseURI,String systemId)
@@ -304,7 +313,7 @@ function _toString(chars,start,length){
  *  #notationDecl(name, publicId, systemId) {};
  *  #unparsedEntityDecl(name, publicId, systemId, notationName) {};
  */
-"endDTD,startEntity,endEntity,attributeDecl,elementDecl,externalEntityDecl,internalEntityDecl,resolveEntity,getExternalSubset,notationDecl,unparsedEntityDecl".replace(/\w+/g,function(key){
+"endDTD,startEntity,endEntity,attributeDecl,elementDecl,externalEntityDecl,resolveEntity,getExternalSubset,notationDecl,unparsedEntityDecl".replace(/\w+/g,function(key){
 	DOMHandler.prototype[key] = function(){return null}
 })
 

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -568,8 +568,8 @@ function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
 			var rest = match[3];
 			var value = rest.substring(0, rest.indexOf(delim));
 			domBuilder.internalEntityDecl(name, value);
-			let nextTagStart = source.indexOf('<', end);
-			let dtdEnd = source.indexOf(']>', end);
+			var nextTagStart = source.indexOf('<', end);
+			var dtdEnd = source.indexOf(']>', end);
 			if (dtdEnd < nextTagStart) {
 				domBuilder.endDTD();
 			}

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -557,23 +557,26 @@ function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
 		// TODO: move to parseInternalDTD (see below)
 		if(source.substr(start+2,6) == 'ENTITY'){
 			var end = source.indexOf('>', start+8);
-			var chunk = source.substring(start+8, end)
-			var match = chunk.match(/\s+(\w+)\s+(["'])(.*)/);
+			var chunk = source.substring(start+8, end);
+			var match = chunk.match(/\s+(\w+)\s+(["'])/);
 			if (!match) {
 				errorHandler.error("Malformed internal entity declaration");
 				return -1;
 			}
+			var declStart = start+8+match[0].length;
 			var name = match[1];
-			var delim = match[2]
-			var rest = match[3];
-			var value = rest.substring(0, rest.indexOf(delim));
+			var delim = match[2];
+			var delimEnd = source.indexOf(delim, declStart);
+			if (delimEnd > end) {
+				end = source.indexOf('>', delimEnd);
+			}
+			var value = source.substring(declStart, delimEnd);
 			domBuilder.internalEntityDecl(name, value);
 			var nextTagStart = source.indexOf('<', end);
 			var dtdEnd = source.indexOf(']>', end);
 			if (dtdEnd < nextTagStart) {
 				domBuilder.endDTD();
 			}
-			source.indexOf();
 			return end+2;
 		}
 		//<!DOCTYPE

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -554,7 +554,6 @@ function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
 			domBuilder.endCDATA() 
 			return end+3;
 		}
-		// TODO: move to parseInternalDTD (see below)
 		if(source.substr(start+2,6) == 'ENTITY'){
 			var end = source.indexOf('>', start+8);
 			var chunk = source.substring(start+8, end);
@@ -571,6 +570,9 @@ function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
 				end = source.indexOf('>', delimEnd);
 			}
 			var value = source.substring(declStart, delimEnd);
+			// NOTE: This value is not further processed, but treated as PCDATA.
+			// If recursive processing is implemented, ENSURE to avoid an XML Bomb
+			// attack vector!
 			domBuilder.internalEntityDecl(name, value);
 			var nextTagStart = source.indexOf('<', end);
 			var dtdEnd = source.indexOf(']>', end);
@@ -598,9 +600,10 @@ function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
 			domBuilder.startDTD(name, pubid, sysid);
 
 			var hasInternalDTD = matchs[2][0] === '[';
+			// NOTE: Currently only handles entity declarations and not the full
+			// [internal DTD subset](https://www.w3.org/TR/xml/#NT-doctypedecl).
 			if (hasInternalDTD) {
-				// TODO: move internalEntityDecl parsing to here!
-				//return parseInternalDTD(source, start, domBuilder, errorHandler);
+				// NOTE: endDTD must be called by the last internal subset item.
 				return matchs[2].index;
 			} else {
 				domBuilder.endDTD();

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -78,7 +78,7 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 		if(end>start){
 			var xt = source.substring(start,end).replace(/&#?\w+;/g,entityReplacer);
 			locator&&position(start);
-			domBuilder.characters(xt,0,end-start);
+			domBuilder.characters(xt,0,xt.length);
 			start = end
 		}
 	}

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -557,17 +557,22 @@ function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
 		if(source.substr(start+2,6) == 'ENTITY'){
 			var end = source.indexOf('>', start+8);
 			var chunk = source.substring(start+8, end);
-			var match = chunk.match(/\s+(\w+)\s+(["'])/);
+			var match = chunk.match(/^\s+(?:(%)\s+)?(\S+)\s+(["'])/);
 			if (!match) {
-				errorHandler.error("Malformed internal entity declaration");
+				// NOTE: Ignoring unhandled forms of entity declarations
 				return -1;
 			}
 			var declStart = start+8+match[0].length;
-			var name = match[1];
-			var delim = match[2];
+			var name = match[2];
+			var delim = match[3];
 			var delimEnd = source.indexOf(delim, declStart);
 			if (delimEnd > end) {
 				end = source.indexOf('>', delimEnd);
+			}
+			if (match[1] === '%') {
+				// NOTE: Ignoring the PEDef form of entity declaration after forwarding
+				// to the declaratino end.
+				return end;
 			}
 			var value = source.substring(declStart, delimEnd);
 			// NOTE: This value is not further processed, but treated as PCDATA.

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -554,6 +554,28 @@ function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
 			domBuilder.endCDATA() 
 			return end+3;
 		}
+		// TODO: move to parseInternalDTD (see below)
+		if(source.substr(start+2,6) == 'ENTITY'){
+			var end = source.indexOf('>', start+8);
+			var chunk = source.substring(start+8, end)
+			var match = chunk.match(/\s+(\w+)\s+(["'])(.*)/);
+			if (!match) {
+				errorHandler.error("Malformed internal entity declaration");
+				return -1;
+			}
+			var name = match[1];
+			var delim = match[2]
+			var rest = match[3];
+			var value = rest.substring(0, rest.indexOf(delim));
+			domBuilder.internalEntityDecl(name, value);
+			let nextTagStart = source.indexOf('<', end);
+			let dtdEnd = source.indexOf(']>', end);
+			if (dtdEnd < nextTagStart) {
+				domBuilder.endDTD();
+			}
+			source.indexOf();
+			return end+2;
+		}
 		//<!DOCTYPE
 		//startDTD(java.lang.String name, java.lang.String publicId, java.lang.String systemId) 
 		var matchs = split(source,start);
@@ -570,11 +592,20 @@ function parseDCC(source,start,domBuilder,errorHandler){//sure start with '<!'
 					sysid = matchs[3][0];
 				}
 			}
-			var lastMatch = matchs[len-1]
 			domBuilder.startDTD(name, pubid, sysid);
-			domBuilder.endDTD();
+
+			var hasInternalDTD = matchs[2][0] === '[';
+			if (hasInternalDTD) {
+				// TODO: move internalEntityDecl parsing to here!
+				//return parseInternalDTD(source, start, domBuilder, errorHandler);
+				return matchs[2].index;
+			} else {
+				domBuilder.endDTD();
+			}
 			
-			return lastMatch.index+lastMatch[0].length
+			var lastMatch = matchs[len-1];
+			var end = lastMatch.index+lastMatch[0].length;
+			return end;
 		}
 	}
 	return -1;

--- a/test/xmltest/__snapshots__/not-wf.test.js.snap
+++ b/test/xmltest/__snapshots__/not-wf.test.js.snap
@@ -439,7 +439,7 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 055.xml with snapshot 1`] = `
 Object {
-  "actual": "<!DOCTYPE doc>",
+  "actual": "<!DOCTYPE doc><doc/>",
 }
 `;
 
@@ -1213,11 +1213,7 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 159.xml with snapshot 1`] = `
 Object {
-  "actual": "<!DOCTYPE doc><doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:5,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&lt;![CDATA[Tim &amp; Michael]]&gt;</doc>",
 }
 `;
 

--- a/test/xmltest/__snapshots__/valid.test.js.snap
+++ b/test/xmltest/__snapshots__/valid.test.js.snap
@@ -2,85 +2,87 @@
 
 exports[`xmltest/valid standalone should match 001.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 002.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 003.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 004.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"v1\\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\"v1\\"/>",
   "expected": "<doc a1=\\"v1\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 005.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"v1\\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\"v1\\"/>",
   "expected": "<doc a1=\\"v1\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 006.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"v1\\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\"v1\\"/>",
   "expected": "<doc a1=\\"v1\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 007.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc> </doc>",
+  "actual": "<!DOCTYPE doc><doc> </doc>",
+  "expected": "<doc> </doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 008.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;&lt;>\\"'</doc>",
+  "actual": "<!DOCTYPE doc><doc>&amp;&lt;>\\"'</doc>",
   "expected": "<doc>&amp;&lt;&gt;&quot;'</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 009.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc> </doc>",
+  "actual": "<!DOCTYPE doc><doc> </doc>",
+  "expected": "<doc> </doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 010.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"v1\\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\"v1\\"/>",
   "expected": "<doc a1=\\"v1\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 011.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"v1\\" a2=\\"v2\\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\"v1\\" a2=\\"v2\\"/>",
   "expected": "<doc a1=\\"v1\\" a2=\\"v2\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 012.xml with snapshot 1`] = `
 Object {
-  "actual": "",
+  "actual": "<!DOCTYPE doc>",
   "error": Array [
     "[xmldom error]	element parse error: Error: invalid attribute::
-@#[line:1,col:1]",
+@#[line:5,col:1]",
   ],
   "expected": "<doc :=\\"v1\\"></doc>",
 }
@@ -88,111 +90,105 @@ Object {
 
 exports[`xmltest/valid standalone should match 013.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc _.-0123456789=\\"v1\\"/>",
+  "actual": "<!DOCTYPE doc><doc _.-0123456789=\\"v1\\"/>",
   "expected": "<doc _.-0123456789=\\"v1\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 014.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc abcdefghijklmnopqrstuvwxyz=\\"v1\\"/>",
+  "actual": "<!DOCTYPE doc><doc abcdefghijklmnopqrstuvwxyz=\\"v1\\"/>",
   "expected": "<doc abcdefghijklmnopqrstuvwxyz=\\"v1\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 015.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc ABCDEFGHIJKLMNOPQRSTUVWXYZ=\\"v1\\"/>",
+  "actual": "<!DOCTYPE doc><doc ABCDEFGHIJKLMNOPQRSTUVWXYZ=\\"v1\\"/>",
   "expected": "<doc ABCDEFGHIJKLMNOPQRSTUVWXYZ=\\"v1\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 016.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><?pi ?></doc>",
+  "actual": "<!DOCTYPE doc><doc><?pi ?></doc>",
+  "expected": "<doc><?pi ?></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 017.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><?pi some data ? > <??></doc>",
+  "actual": "<!DOCTYPE doc><doc><?pi some data ? > <??></doc>",
+  "expected": "<doc><?pi some data ? > <??></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 018.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><![CDATA[<foo>]]></doc>",
+  "actual": "<!DOCTYPE doc><doc><![CDATA[<foo>]]></doc>",
   "expected": "<doc>&lt;foo&gt;</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 019.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><![CDATA[<&]]></doc>",
+  "actual": "<!DOCTYPE doc><doc><![CDATA[<&]]></doc>",
   "expected": "<doc>&lt;&amp;</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 020.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><![CDATA[<&]>]]]></doc>",
+  "actual": "<!DOCTYPE doc><doc><![CDATA[<&]>]]]></doc>",
   "expected": "<doc>&lt;&amp;]&gt;]</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 021.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><!-- a comment --></doc>",
+  "actual": "<!DOCTYPE doc><doc><!-- a comment --></doc>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 022.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><!-- a comment ->--></doc>",
+  "actual": "<!DOCTYPE doc><doc><!-- a comment ->--></doc>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 023.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 024.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&amp;#60;foo>&lt;/foo></doc>",
   "expected": "<doc><foo></foo></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 025.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><foo/><foo/></doc>",
+  "actual": "<!DOCTYPE doc><doc><foo/><foo/></doc>",
   "expected": "<doc><foo></foo><foo></foo></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 026.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><foo/><foo/></doc>",
+  "actual": "<!DOCTYPE doc><doc><foo/><foo/></doc>",
   "expected": "<doc><foo></foo><foo></foo></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 027.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><foo/><foo/></doc>",
+  "actual": "<!DOCTYPE doc><doc><foo/><foo/></doc>",
   "expected": "<doc><foo></foo><foo></foo></doc>",
 }
 `;
@@ -200,7 +196,7 @@ Object {
 exports[`xmltest/valid standalone should match 028.xml with snapshot 1`] = `
 Object {
   "actual": "<?xml version=\\"1.0\\"?>
-<doc/>",
+<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
@@ -208,7 +204,7 @@ Object {
 exports[`xmltest/valid standalone should match 029.xml with snapshot 1`] = `
 Object {
   "actual": "<?xml version='1.0'?>
-<doc/>",
+<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
@@ -216,7 +212,7 @@ Object {
 exports[`xmltest/valid standalone should match 030.xml with snapshot 1`] = `
 Object {
   "actual": "<?xml version = \\"1.0\\"?>
-<doc/>",
+<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
@@ -224,7 +220,7 @@ Object {
 exports[`xmltest/valid standalone should match 031.xml with snapshot 1`] = `
 Object {
   "actual": "<?xml version='1.0' encoding=\\"UTF-8\\"?>
-<doc/>",
+<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
@@ -232,7 +228,7 @@ Object {
 exports[`xmltest/valid standalone should match 032.xml with snapshot 1`] = `
 Object {
   "actual": "<?xml version='1.0' standalone='yes'?>
-<doc/>",
+<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
@@ -240,28 +236,28 @@ Object {
 exports[`xmltest/valid standalone should match 033.xml with snapshot 1`] = `
 Object {
   "actual": "<?xml version='1.0' encoding=\\"UTF-8\\" standalone='yes'?>
-<doc/>",
+<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 034.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 035.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 036.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>
+  "actual": "<!DOCTYPE doc><doc/>
 <?pi data?>",
   "expected": "<doc></doc><?pi data?>",
 }
@@ -269,7 +265,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 037.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>
+  "actual": "<!DOCTYPE doc><doc/>
 <!-- comment -->",
   "expected": "<doc></doc>",
 }
@@ -278,7 +274,7 @@ Object {
 exports[`xmltest/valid standalone should match 038.xml with snapshot 1`] = `
 Object {
   "actual": "<!-- comment -->
-<doc/>",
+<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
@@ -286,41 +282,42 @@ Object {
 exports[`xmltest/valid standalone should match 039.xml with snapshot 1`] = `
 Object {
   "actual": "<?pi data?>
-<doc/>",
+<!DOCTYPE doc><doc/>",
   "expected": "<?pi data?><doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 040.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"&quot;&lt;&amp;>'\\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\"&quot;&lt;&amp;>'\\"/>",
   "expected": "<doc a1=\\"&quot;&lt;&amp;&gt;'\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 041.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"A\\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\"A\\"/>",
   "expected": "<doc a1=\\"A\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 042.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>A</doc>",
+  "actual": "<!DOCTYPE doc><doc>A</doc>",
+  "expected": "<doc>A</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 043.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"foo bar\\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\"foo bar\\"/>",
   "expected": "<doc a1=\\"foo bar\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 044.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>
+  "actual": "<!DOCTYPE doc><doc>
 <e a3=\\"v3\\"/>
 <e a1=\\"w1\\"/>
 <e a2=\\"w2\\" a3=\\"v3\\"/>
@@ -331,21 +328,21 @@ Object {
 
 exports[`xmltest/valid standalone should match 045.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc a1=\\"v1\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 046.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc a1=\\"v1\\" a2=\\"v2\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 047.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>X
+  "actual": "<!DOCTYPE doc><doc>X
 Y</doc>",
   "expected": "<doc>X&#10;Y</doc>",
 }
@@ -353,7 +350,8 @@ Y</doc>",
 
 exports[`xmltest/valid standalone should match 048.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>]</doc>",
+  "actual": "<!DOCTYPE doc><doc>]</doc>",
+  "expected": "<doc>]</doc>",
 }
 `;
 
@@ -416,31 +414,28 @@ Object {
 
 exports[`xmltest/valid standalone should match 052.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>𐀀􏿽</doc>",
+  "actual": "<!DOCTYPE doc><doc>𐀀􏿽</doc>",
+  "expected": "<doc>𐀀􏿽</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 053.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&lt;e/></doc>",
   "expected": "<doc><e></e></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 054.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 055.xml with snapshot 1`] = `
 Object {
-  "actual": "<?pi data?>
+  "actual": "<!DOCTYPE doc><?pi data?>
 <doc/>",
   "expected": "<?pi data?><doc></doc>",
 }
@@ -448,27 +443,28 @@ Object {
 
 exports[`xmltest/valid standalone should match 056.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>A</doc>",
+  "actual": "<!DOCTYPE doc><doc>A</doc>",
+  "expected": "<doc>A</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 057.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 058.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\" 1   2  \\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\" 1   2  \\"/>",
   "expected": "<doc a1=\\"1 2\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 059.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>
+  "actual": "<!DOCTYPE doc><doc>
 <e a1=\\"v1\\" a2=\\"v2\\" a3=\\"v3\\"/>
 <e a1=\\"w1\\" a2=\\"v2\\"/>
 <e a1=\\"v1\\" a2=\\"w2\\" a3=\\"v3\\"/>
@@ -479,7 +475,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 060.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>X
+  "actual": "<!DOCTYPE doc><doc>X
 Y</doc>",
   "expected": "<doc>X&#10;Y</doc>",
 }
@@ -487,13 +483,15 @@ Y</doc>",
 
 exports[`xmltest/valid standalone should match 061.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>£</doc>",
+  "actual": "<!DOCTYPE doc><doc>£</doc>",
+  "expected": "<doc>£</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 062.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>เจมส์</doc>",
+  "actual": "<!DOCTYPE doc><doc>เจมส์</doc>",
+  "expected": "<doc>เจมส์</doc>",
 }
 `;
 
@@ -506,31 +504,28 @@ Object {
 
 exports[`xmltest/valid standalone should match 064.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>𐀀􏿽</doc>",
+  "actual": "<!DOCTYPE doc><doc>𐀀􏿽</doc>",
+  "expected": "<doc>𐀀􏿽</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 065.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 066.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"&amp;e1;\\"/>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e1;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><!-- 34 is double quote -->\n<doc a1=\\"&amp;#34;\\"/>",
   "expected": "<doc a1=\\"&quot;\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 067.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>
+  "actual": "<!DOCTYPE doc><doc>
 </doc>",
   "expected": "<doc>&#13;</doc>",
 }
@@ -538,199 +533,175 @@ Object {
 
 exports[`xmltest/valid standalone should match 068.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&amp;#13;</doc>",
   "expected": "<doc>&#13;</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 069.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 070.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 071.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 072.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 073.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 074.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 075.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 076.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 077.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 078.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"v\\"/>",
+  "actual": "<!DOCTYPE doc><doc a=\\"v\\"/>",
   "expected": "<doc a=\\"v\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 079.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"v\\"/>",
+  "actual": "<!DOCTYPE doc><doc a=\\"v\\"/>",
   "expected": "<doc a=\\"v\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 080.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc a=\\"v\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 081.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><a/><b/><c><a/></c></doc>",
+  "actual": "<!DOCTYPE doc><doc><a/><b/><c><a/></c></doc>",
   "expected": "<doc><a></a><b></b><c><a></a></c></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 082.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 083.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 084.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 085.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 086.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&lt;foo></doc>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 087.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&lt;foo/&amp;#62;</doc>",
   "expected": "<doc><foo></foo></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 088.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&amp;lt;foo></doc>",
   "expected": "<doc>&lt;foo&gt;</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 089.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&amp;#x10000;&amp;#x10FFFD;&amp;#x10FFFF;</doc>",
   "expected": "<doc>𐀀􏿽􏿿</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 090.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 091.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc a=\\"e\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 092.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>
+  "actual": "<!DOCTYPE doc><doc>
 <a/>
     <a/>	<a/>
 
@@ -742,7 +713,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 093.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>
+  "actual": "<!DOCTYPE doc><doc>
 
 
 </doc>",
@@ -752,35 +723,37 @@ Object {
 
 exports[`xmltest/valid standalone should match 094.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc a1=\\"%e;\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 095.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"1  2\\"/>",
+  "actual": "<!DOCTYPE doc><doc a1=\\"1  2\\"/>",
   "expected": "<doc a1=\\"1  2\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 096.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc a1=\\"1 2\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 097.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc a1=\\"v1\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 098.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><?pi x
+  "actual": "<!DOCTYPE doc><doc><?pi x
+y?></doc>",
+  "expected": "<doc><?pi x
 y?></doc>",
 }
 `;
@@ -788,142 +761,126 @@ y?></doc>",
 exports[`xmltest/valid standalone should match 099.xml with snapshot 1`] = `
 Object {
   "actual": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
-<doc/>",
+<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 100.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 101.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 102.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"&quot;\\"/>",
+  "actual": "<!DOCTYPE doc><doc a=\\"&quot;\\"/>",
   "expected": "<doc a=\\"&quot;\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 103.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&lt;doc></doc>",
+  "actual": "<!DOCTYPE doc><doc>&lt;doc></doc>",
   "expected": "<doc>&lt;doc&gt;</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 104.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x y\\"/>",
+  "actual": "<!DOCTYPE doc><doc a=\\"x y\\"/>",
   "expected": "<doc a=\\"x y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 105.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x&#9;y\\"/>",
+  "actual": "<!DOCTYPE doc><doc a=\\"x&#9;y\\"/>",
   "expected": "<doc a=\\"x&#9;y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 106.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x&#10;y\\"/>",
+  "actual": "<!DOCTYPE doc><doc a=\\"x&#10;y\\"/>",
   "expected": "<doc a=\\"x&#10;y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 107.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x&#13;y\\"/>",
+  "actual": "<!DOCTYPE doc><doc a=\\"x&#13;y\\"/>",
   "expected": "<doc a=\\"x&#13;y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 108.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x&amp;e;y\\"/>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc a=\\"x&#10;y\\"/>",
   "expected": "<doc a=\\"x y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 109.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"\\"/>",
+  "actual": "<!DOCTYPE doc><doc a=\\"\\"/>",
   "expected": "<doc a=\\"\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 110.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\"x&amp;e;y\\"/>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc a=\\"x&amp;#13;&amp;#10;y\\"/>",
   "expected": "<doc a=\\"x  y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 111.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a=\\" x  y \\"/>",
+  "actual": "<!DOCTYPE doc><doc a=\\" x  y \\"/>",
   "expected": "<doc a=\\"x y\\"></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 112.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><a/></doc>",
+  "actual": "<!DOCTYPE doc><doc><a/></doc>",
   "expected": "<doc><a></a></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 113.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc/>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 114.xml with snapshot 1`] = `
 Object {
-  "actual": "<!DOCTYPE doc><doc>&amp;e;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e;
-@#[line:5,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&lt;![CDATA[&amp;foo;]]&gt;</doc>",
   "expected": "<doc>&amp;foo;</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 115.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e1;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&e1;
-@#[line:1,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>&amp;e2;</doc>",
   "expected": "<doc>v</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 116.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><![CDATA[
+  "actual": "<!DOCTYPE doc><doc><![CDATA[
 ]]></doc>",
   "expected": "<doc>&#10;</doc>",
 }
@@ -931,29 +888,21 @@ Object {
 
 exports[`xmltest/valid standalone should match 117.xml with snapshot 1`] = `
 Object {
-  "actual": "<!DOCTYPE doc><doc>&amp;rsqb;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&rsqb;
-@#[line:5,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>]</doc>",
   "expected": "<doc>]</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 118.xml with snapshot 1`] = `
 Object {
-  "actual": "<!DOCTYPE doc><doc>&amp;rsqb;</doc>",
-  "error": Array [
-    "[xmldom error]	entity not found:&rsqb;
-@#[line:5,col:1]",
-  ],
+  "actual": "<!DOCTYPE doc><doc>]]</doc>",
   "expected": "<doc>]]</doc>",
 }
 `;
 
 exports[`xmltest/valid standalone should match 119.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc><!-- -á --></doc>",
+  "actual": "<!DOCTYPE doc><doc><!-- -á --></doc>",
   "expected": "<doc></doc>",
 }
 `;

--- a/test/xmltest/__snapshots__/valid.test.js.snap
+++ b/test/xmltest/__snapshots__/valid.test.js.snap
@@ -659,7 +659,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 086.xml with snapshot 1`] = `
 Object {
-  "actual": "<!DOCTYPE doc><doc>&lt;foo></doc>",
+  "actual": "<!DOCTYPE doc><doc/>",
   "expected": "<doc></doc>",
 }
 `;

--- a/test/xmltest/valid.test.js
+++ b/test/xmltest/valid.test.js
@@ -13,11 +13,7 @@ describe('xmltest/valid', () => {
 
 		Object.entries(entries).forEach(([pathInZip, filename]) => {
 			test(`should match ${filename} with snapshot`, async () => {
-				const input = (await xmltest.getContent(pathInZip))
-					// TODO: The DOCTYPE totally confuses xmldom :sic:
-					// for now we remove it and any newlines after it so we have reasonable tests
-					.replace(/^<!DOCTYPE doc \[[^\]]+]>[\r\n]*/m, '')
-
+				const input = await xmltest.getContent(pathInZip)
 				const expected = await xmltest.getContent(
 					xmltest.RELATED.out(pathInZip)
 				)


### PR DESCRIPTION
This handles the basic (and fairly common) use of internal DTD entity declarations in RDF/XML. Example:

```xml
<?xml version="1.0"?>
<!DOCTYPE rdf:RDF [
    <!ENTITY rdf 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
    <!ENTITY sdo 'http://schema.org/'>
]>
<rdf:RDF xmlns:rdf="&rdf;"
         xmlns="&sdo;"
         xml:base="http://example.org/">
    <CreativeWork rdf:about="/doc">
        <name xml:lang="en">A Document &amp; a &quot;name&quot;</name>
        <dateCreated rdf:datatype="&sdo;Date">2016-07-10T14:34:50+0200</dateCreated>
    </CreativeWork>
</rdf:RDF>
```

Note that this needs:
- [ ] Some unit testing. (I just threw the case above at my local instance of [LDTR](https://github.com/niklasl/ldtr), using this modified xmldom code.)
- [ ] Overseeing the way I handled the entityMap.
- [ ] Actually matching the root element (QName) to be conformant.
- [ ] *Ensurance* that this doesn't lead to an [XML Bomb](https://en.wikipedia.org/wiki/Billion_laughs_attack) attack vector. Tthis specific handling is non-recursive and safe as written. But if logic for external references or recursive entities would be added this quickly gets complex and dangerous.

When ready, this should solve the basic case of https://github.com/xmldom/xmldom/issues/117.