### PR TITLE
feat: Add minimal `Object.assign` ponyfill

### DIFF
--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -23,6 +23,31 @@ function freeze(object, oc) {
 }
 
 /**
+ * Since we can not rely on `Object.assign` we provide a simplified version
+ * that is sufficient for our needs.
+ *
+ * @param {Object} target
+ * @param {Object | null | undefined} source
+ *
+ * @returns {Object} target
+ * @throws TypeError if target is not an object
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+ * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
+ */
+function assign(target, source) {
+	if (target === null || typeof target !== 'object') {
+		throw new TypeError('target is not an object')
+	}
+	for (var key in source) {
+		if (Object.prototype.hasOwnProperty.call(source, key)) {
+			target[key] = source[key]
+		}
+	}
+	return target
+}
+
+/**
  * All mime types that are allowed as input to `DOMParser.parseFromString`
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02 MDN
@@ -139,6 +164,7 @@ var NAMESPACE = freeze({
 	XMLNS: 'http://www.w3.org/2000/xmlns/',
 })
 
+exports.assign = assign;
 exports.freeze = freeze;
 exports.MIME_TYPE = MIME_TYPE;
 exports.NAMESPACE = NAMESPACE;

--- a/test/conventions/assign.test.js
+++ b/test/conventions/assign.test.js
@@ -1,0 +1,52 @@
+'use strict'
+const { assign } = require('../../lib/conventions')
+
+describe('assign', () => {
+	test.each([null, undefined, true, false, 0, NaN])(
+		'should throw when `target` is `%s`',
+		(target) => {
+			expect(() => assign(target, {})).toThrow(TypeError)
+		}
+	)
+	test('should return target', () => {
+		const target = {}
+		expect(assign(target, undefined)).toBe(target)
+	})
+	test('should copy all enumerable fields from source to target', () => {
+		const target = {}
+		const source = { a: 'A', 0: 0 }
+
+		assign(target, source)
+
+		expect(target).toEqual(source)
+	})
+	test('should not copy prototype properties to source', () => {
+		const target = {}
+		function Clazz(yes) {
+			this.yes = yes
+		}
+		Clazz.prototype.dont = 5
+		Clazz.prototype.hasOwnProperty = () => true
+		const source = new Clazz(1)
+
+		assign(target, source)
+
+		expect(target).toEqual({ yes: 1 })
+	})
+	test('should have no issue with null source', () => {
+		const target = {}
+		assign(target, null)
+	})
+	test('should have no issue with undefined source', () => {
+		const target = {}
+		assign(target, undefined)
+	})
+	test('should override existing keys', () => {
+		const target = { key: 4, same: 'same' }
+		const source = { key: undefined }
+
+		assign(target, source)
+
+		expect(target).toEqual({ key: undefined, same: 'same' })
+	})
+})


### PR DESCRIPTION
since we can not rely on it being present in all supported runtimes.
Even though the interface is the same as `Object.assign`,
it behaves slightly differently from the one provided by browsers (see tests).

This was extracted from #338 to support development in #367