### PR TITLE
fix(dom): Serialize `>` as specified

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1187,9 +1187,10 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
  * are serialized as their entity references, so they will be preserved.
  * (In contrast to whitespace literals in the input which are normalized to spaces)
  * @see https://www.w3.org/TR/xml11/#AVNormalize
+ * @see https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes
  */
 function addSerializedAttribute(buf, qualifiedName, value) {
-	buf.push(' ', qualifiedName, '="', value.replace(/[<&"\t\n\r]/g, _xmlEncoder), '"')
+	buf.push(' ', qualifiedName, '="', value.replace(/[<>&"\t\n\r]/g, _xmlEncoder), '"')
 }
 
 function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
@@ -1334,10 +1335,10 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 		 * and does not include the CDATA-section-close delimiter, `]]>`.
 		 *
 		 * @see https://www.w3.org/TR/xml/#NT-CharData
+		 * @see https://w3c.github.io/DOM-Parsing/#xml-serializing-a-text-node
 		 */
 		return buf.push(node.data
-			.replace(/[<&]/g,_xmlEncoder)
-			.replace(/]]>/g, ']]&gt;')
+			.replace(/[<&>]/g,_xmlEncoder)
 		);
 	case CDATA_SECTION_NODE:
 		return buf.push( '<![CDATA[',node.data,']]>');

--- a/test/html/__snapshots__/normalize.test.js.snap
+++ b/test/html/__snapshots__/normalize.test.js.snap
@@ -44,13 +44,13 @@ Object {
 
 exports[`html normalizer <div test="a<b&&a< c && a>d"></div> 1`] = `
 Object {
-  "actual": "<div test=\\"a&lt;b&amp;&amp;a&lt; c &amp;&amp; a>d\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></div>",
+  "actual": "<div test=\\"a&lt;b&amp;&amp;a&lt; c &amp;&amp; a&gt;d\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></div>",
 }
 `;
 
 exports[`html normalizer <div test="alert('<br/>')"/> 1`] = `
 Object {
-  "actual": "<div test=\\"alert('&lt;br/>')\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></div>",
+  "actual": "<div test=\\"alert('&lt;br/&gt;')\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></div>",
 }
 `;
 
@@ -72,7 +72,7 @@ Object {
 
 exports[`html normalizer <div><123e>&<a<br/></div> 1`] = `
 Object {
-  "actual": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\">&lt;123e>&amp;&lt;a<br/></div>",
+  "actual": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\">&lt;123e&gt;&amp;&lt;a<br/></div>",
   "error": Array [
     "[xmldom error]	element parse error: Error: invalid tagName:123e
 @#[line:1,col:6]",
@@ -90,7 +90,7 @@ Object {
 
 exports[`html normalizer <html test="a<b && a>b && '&amp;&&'"/> 1`] = `
 Object {
-  "actual": "<html test=\\"a&lt;b &amp;&amp; a>b &amp;&amp; '&amp;&amp;&amp;'\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></html>",
+  "actual": "<html test=\\"a&lt;b &amp;&amp; a&gt;b &amp;&amp; '&amp;&amp;&amp;'\\" xmlns=\\"http://www.w3.org/1999/xhtml\\"></html>",
 }
 `;
 
@@ -102,7 +102,7 @@ Object {
 
 exports[`html normalizer <r><Label onClick="doClick..>Hello, World</Label></r> 1`] = `
 Object {
-  "actual": "<r xmlns=\\"http://www.w3.org/1999/xhtml\\">&lt;Label onClick=\\"doClick..>Hello, World</r>",
+  "actual": "<r xmlns=\\"http://www.w3.org/1999/xhtml\\">&lt;Label onClick=\\"doClick..&gt;Hello, World</r>",
   "error": Array [
     "[xmldom error]	element parse error: Error: attribute value no end '\\"' match
 @#[line:1,col:4]",
@@ -130,7 +130,7 @@ Object {
 
 exports[`html normalizer text/html: script <textarea>alert(a<b&&c?"<br>":">>");</textarea> 1`] = `
 Object {
-  "actual": "<textarea xmlns=\\"http://www.w3.org/1999/xhtml\\">alert(a&lt;b&amp;&amp;c?\\"&lt;br>\\":\\">>\\");</textarea>",
+  "actual": "<textarea xmlns=\\"http://www.w3.org/1999/xhtml\\">alert(a&lt;b&amp;&amp;c?\\"&lt;br&gt;\\":\\"&gt;&gt;\\");</textarea>",
 }
 `;
 
@@ -142,7 +142,7 @@ Object {
 
 exports[`html normalizer text/xml: script <script>alert(a<b&&c?"<br/>":">>");</script> 1`] = `
 Object {
-  "actual": "<script>alert(a&lt;b&amp;&amp;c?\\"<br/>\\":\\">>\\");</script>",
+  "actual": "<script>alert(a&lt;b&amp;&amp;c?\\"<br/>\\":\\"&gt;&gt;\\");</script>",
   "error": Array [
     "[xmldom error]	element parse error: Error: attribute value must after \\"=\\"
 @#[line:1,col:16]",
@@ -152,7 +152,7 @@ Object {
 
 exports[`html normalizer text/xml: script <script>alert(a<b&&c?"<br>":">>");</script> 1`] = `
 Object {
-  "actual": "<script>alert(a&lt;b&amp;&amp;c?\\"<br/>\\":\\">>\\");</script>",
+  "actual": "<script>alert(a&lt;b&amp;&amp;c?\\"<br/>\\":\\"&gt;&gt;\\");</script>",
   "error": Array [
     "[xmldom error]	element parse error: Error: attribute value must after \\"=\\"
 @#[line:1,col:16]",
@@ -166,7 +166,7 @@ Object {
 
 exports[`html normalizer text/xml: script <textarea>alert(a<b&&c?"<br>":">>");</textarea> 1`] = `
 Object {
-  "actual": "<textarea>alert(a&lt;b&amp;&amp;c?\\"<br/>\\":\\">>\\");</textarea>",
+  "actual": "<textarea>alert(a&lt;b&amp;&amp;c?\\"<br/>\\":\\"&gt;&gt;\\");</textarea>",
   "error": Array [
     "[xmldom error]	element parse error: Error: attribute value must after \\"=\\"
 @#[line:1,col:18]",

--- a/test/xmltest/__snapshots__/not-wf.test.js.snap
+++ b/test/xmltest/__snapshots__/not-wf.test.js.snap
@@ -23,7 +23,7 @@ Object {
 exports[`xmltest/not-wellformed standalone should match 002.xml with snapshot 1`] = `
 Object {
   "actual": "<doc>
-&lt;.doc>
+&lt;.doc&gt;
 </doc>",
   "error": Array [
     "[xmldom error]	element parse error: Error: invalid tagName:.doc
@@ -40,7 +40,7 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 004.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&lt;?target some data></doc>",
+  "actual": "<doc>&lt;?target some data&gt;</doc>",
 }
 `;
 
@@ -112,7 +112,7 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 014.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"&lt;foo>\\"/>",
+  "actual": "<doc a1=\\"&lt;foo&gt;\\"/>",
 }
 `;
 
@@ -193,7 +193,7 @@ Object {
 exports[`xmltest/not-wellformed standalone should match 024.xml with snapshot 1`] = `
 Object {
   "actual": "<doc>
-&lt;123>
+&lt;123&gt;
 </doc>",
   "error": Array [
     "[xmldom error]	element parse error: Error: invalid tagName:123
@@ -1369,7 +1369,7 @@ Object {
 
 exports[`xmltest/not-wellformed standalone should match 182.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;e;--></doc>",
+  "actual": "<doc>&amp;e;--&gt;</doc>",
   "error": Array [
     "[xmldom error]	entity not found:&e;
 @#[line:1,col:1]",

--- a/test/xmltest/__snapshots__/valid.test.js.snap
+++ b/test/xmltest/__snapshots__/valid.test.js.snap
@@ -50,7 +50,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 008.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&amp;&lt;>\\"'</doc>",
+  "actual": "<doc>&amp;&lt;&gt;\\"'</doc>",
   "expected": "<doc>&amp;&lt;&gt;&quot;'</doc>",
 }
 `;
@@ -293,7 +293,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 040.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc a1=\\"&quot;&lt;&amp;>'\\"/>",
+  "actual": "<doc a1=\\"&quot;&lt;&amp;&gt;'\\"/>",
   "expected": "<doc a1=\\"&quot;&lt;&amp;&gt;'\\"></doc>",
 }
 `;
@@ -359,7 +359,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 049.xml with snapshot 1`] = `
 Object {
-  "actual": "{!0!}/{!0!}d{!0!}o{!0!}c{!0!}>{!0!}
+  "actual": "{!0!}/{!0!}d{!0!}o{!0!}c{!0!}&gt;{!0!}
 {!0!}
 {!0!}",
   "error": Array [
@@ -378,7 +378,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 050.xml with snapshot 1`] = `
 Object {
-  "actual": "{!0!}/{!0!}d{!0!}o{!0!}c{!0!}>{!0!}
+  "actual": "{!0!}/{!0!}d{!0!}o{!0!}c{!0!}&gt;{!0!}
 {!0!}
 {!0!}",
   "error": Array [
@@ -397,7 +397,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 051.xml with snapshot 1`] = `
 Object {
-  "actual": "{!0!}/{!0!}@!*L>{!0!}
+  "actual": "{!0!}/{!0!}@!*L&gt;{!0!}
 {!0!}
 {!0!}",
   "error": Array [
@@ -816,8 +816,7 @@ Object {
 
 exports[`xmltest/valid standalone should match 103.xml with snapshot 1`] = `
 Object {
-  "actual": "<doc>&lt;doc></doc>",
-  "expected": "<doc>&lt;doc&gt;</doc>",
+  "actual": "<doc>&lt;doc&gt;</doc>",
 }
 `;
 


### PR DESCRIPTION
in both attributes and text content

Fixes #58

https://w3c.github.io/DOM-Parsing/#xml-serializing-a-text-node
https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes