### PR TITLE
docs: Add `nodeType` values to public interface description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -98,182 +98,204 @@ import { DOMParser } from '@xmldom/xmldom'
 	```
 ### DOM level2 method and attribute:
 
- * [Node](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247)
-	
-		attribute:
-			nodeValue|prefix
-		readonly attribute:
-			nodeName|nodeType|parentNode|childNodes|firstChild|lastChild|previousSibling|nextSibling|attributes|ownerDocument|namespaceURI|localName
-		method:	
-			insertBefore(newChild, refChild)
-			replaceChild(newChild, oldChild)
-			removeChild(oldChild)
-			appendChild(newChild)
-			hasChildNodes()
-			cloneNode(deep)
-			normalize()
-			isSupported(feature, version)
-			hasAttributes()
-* [DOMException](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/ecma-script-binding.html)
-   The DOMException class has the following constants (and `value` of type `Number`):
+* [Node](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247)
+
+  readonly class properties (aka `NodeType`),  
+  these can be accessed from any `Node` instance `node`:  
+  `if (node.nodeType === node.ELEMENT_NODE) {...`
   
-  1. `DOMException.INDEX_SIZE_ERR` (`1`)
-  1. `DOMException.DOMSTRING_SIZE_ERR` (`2`)
-  1. `DOMException.HIERARCHY_REQUEST_ERR` (`3`)
-  1. `DOMException.WRONG_DOCUMENT_ERR` (`4`)
-  1. `DOMException.INVALID_CHARACTER_ERR` (`5`)
-  1. `DOMException.NO_DATA_ALLOWED_ERR` (`6`)
-  1. `DOMException.NO_MODIFICATION_ALLOWED_ERR` (`7`)
-  1. `DOMException.NOT_FOUND_ERR` (`8`)
-  1. `DOMException.NOT_SUPPORTED_ERR` (`9`)
-  1. `DOMException.INUSE_ATTRIBUTE_ERR` (`10`)
-  1. `DOMException.INVALID_STATE_ERR` (`11`)
-  1. `DOMException.SYNTAX_ERR` (`12`)
-  1. `DOMException.INVALID_MODIFICATION_ERR` (`13`)
-  1. `DOMException.NAMESPACE_ERR` (`14`)
-  1. `DOMException.INVALID_ACCESS_ERR` (`15`)
+    1. `ELEMENT_NODE` (`1`)
+    2. `ATTRIBUTE_NODE` (`2`)
+    3. `TEXT_NODE` (`3`)
+    4. `CDATA_SECTION_NODE` (`4`)
+    5. `ENTITY_REFERENCE_NODE` (`5`)
+    6. `ENTITY_NODE` (`6`)
+    7. `PROCESSING_INSTRUCTION_NODE` (`7`)
+    8. `COMMENT_NODE` (`8`)
+    9. `DOCUMENT_NODE` (`9`)
+    10. `DOCUMENT_TYPE_NODE` (`10`)
+    11. `DOCUMENT_FRAGMENT_NODE` (`11`)
+    12. `NOTATION_NODE` (`12`)
+  
+  attribute:
+    - `nodeValue` | `prefix`
+  
+  readonly attribute:
+    - `nodeName` | `nodeType` | `parentNode` | `childNodes` | `firstChild` | `lastChild` | `previousSibling` | `nextSibling` | `attributes` | `ownerDocument` | `namespaceURI` | `localName`
+  
+  method:	
+    * `insertBefore(newChild, refChild)`
+    * `replaceChild(newChild, oldChild)`
+    * `removeChild(oldChild)`
+    * `appendChild(newChild)`
+    * `hasChildNodes()`
+    * `cloneNode(deep)`
+    * `normalize()`
+    * `isSupported(feature, version)`
+    * `hasAttributes()`
+* [DOMException](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/ecma-script-binding.html)
+
+  extends the Error type thrown as part of DOM API.
+
+  readonly class properties:
+  - `INDEX_SIZE_ERR` (`1`)
+  - `DOMSTRING_SIZE_ERR` (`2`)
+  - `HIERARCHY_REQUEST_ERR` (`3`)
+  - `WRONG_DOCUMENT_ERR` (`4`)
+  - `INVALID_CHARACTER_ERR` (`5`)
+  - `NO_DATA_ALLOWED_ERR` (`6`)
+  - `NO_MODIFICATION_ALLOWED_ERR` (`7`)
+  - `NOT_FOUND_ERR` (`8`)
+  - `NOT_SUPPORTED_ERR` (`9`)
+  - `INUSE_ATTRIBUTE_ERR` (`10`)
+  - `INVALID_STATE_ERR` (`11`)
+  - `SYNTAX_ERR` (`12`)
+  - `INVALID_MODIFICATION_ERR` (`13`)
+  - `NAMESPACE_ERR` (`14`)
+  - `INVALID_ACCESS_ERR` (`15`)
    
-   The DOMException object has the following properties:
-   code
-   This property is of type Number.
+  attributes:
+  -  `code` with a value matching one of the above constants.
 
-	 * extends the Error type thrown as part of DOM API:
+* [DOMImplementation](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-102161490)
 
- * [DOMImplementation](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-102161490)
+  method:
+  - `hasFeature(feature, version)`
+  - `createDocumentType(qualifiedName, publicId, systemId)`
+  - `createDocument(namespaceURI, qualifiedName, doctype)`
+
+* [Document](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#i-Document) : Node
 		
-		method:
-			hasFeature(feature, version)
-			createDocumentType(qualifiedName, publicId, systemId)
-			createDocument(namespaceURI, qualifiedName, doctype)
+  readonly attribute:
+  - `doctype` | `implementation` | `documentElement`
+  
+  method:
+  - `createElement(tagName)`
+  - `createDocumentFragment()`
+  - `createTextNode(data)`
+  - `createComment(data)`
+  - `createCDATASection(data)`
+  - `createProcessingInstruction(target, data)`
+  - `createAttribute(name)`
+  - `createEntityReference(name)`
+  - `getElementsByTagName(tagname)`
+  - `importNode(importedNode, deep)`
+  - `createElementNS(namespaceURI, qualifiedName)`
+  - `createAttributeNS(namespaceURI, qualifiedName)`
+  - `getElementsByTagNameNS(namespaceURI, localName)`
+  - `getElementById(elementId)`
 
- * [Document](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#i-Document) : Node
+* [DocumentFragment](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-B63ED1A3) : Node
+* [Element](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-745549614) : Node
 		
-		readonly attribute:
-			doctype|implementation|documentElement
-		method:
-			createElement(tagName)
-			createDocumentFragment()
-			createTextNode(data)
-			createComment(data)
-			createCDATASection(data)
-			createProcessingInstruction(target, data)
-			createAttribute(name)
-			createEntityReference(name)
-			getElementsByTagName(tagname)
-			importNode(importedNode, deep)
-			createElementNS(namespaceURI, qualifiedName)
-			createAttributeNS(namespaceURI, qualifiedName)
-			getElementsByTagNameNS(namespaceURI, localName)
-			getElementById(elementId)
+  readonly attribute:
+  - `tagName`
 
- * [DocumentFragment](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-B63ED1A3) : Node
- * [Element](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-745549614) : Node
+  method:
+  - `getAttribute(name)`
+  - `setAttribute(name, value)`
+  - `removeAttribute(name)`
+  - `getAttributeNode(name)`
+  - `setAttributeNode(newAttr)`
+  - `removeAttributeNode(oldAttr)`
+  - `getElementsByTagName(name)`
+  - `getAttributeNS(namespaceURI, localName)`
+  - `setAttributeNS(namespaceURI, qualifiedName, value)`
+  - `removeAttributeNS(namespaceURI, localName)`
+  - `getAttributeNodeNS(namespaceURI, localName)`
+  - `setAttributeNodeNS(newAttr)`
+  - `getElementsByTagNameNS(namespaceURI, localName)`
+  - `hasAttribute(name)`
+  - `hasAttributeNS(namespaceURI, localName)`
+
+* [Attr](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-637646024) : Node
+
+  attribute:
+  - `value`
+
+  readonly attribute:
+  - `name` | `specified` | `ownerElement`
+
+* [NodeList](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177)
 		
-		readonly attribute:
-			tagName
-		method:
-			getAttribute(name)
-			setAttribute(name, value)
-			removeAttribute(name)
-			getAttributeNode(name)
-			setAttributeNode(newAttr)
-			removeAttributeNode(oldAttr)
-			getElementsByTagName(name)
-			getAttributeNS(namespaceURI, localName)
-			setAttributeNS(namespaceURI, qualifiedName, value)
-			removeAttributeNS(namespaceURI, localName)
-			getAttributeNodeNS(namespaceURI, localName)
-			setAttributeNodeNS(newAttr)
-			getElementsByTagNameNS(namespaceURI, localName)
-			hasAttribute(name)
-			hasAttributeNS(namespaceURI, localName)
-
- * [Attr](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-637646024) : Node
+  readonly attribute:
+  - `length`
+  
+  method:
+  - `item(index)`
 	
-		attribute:
-			value
-		readonly attribute:
-			name|specified|ownerElement
+* [NamedNodeMap](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1780488922)
 
- * [NodeList](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177)
+  readonly attribute:
+  - `length`
+  
+  method:
+  - `getNamedItem(name)`
+  - `setNamedItem(arg)`
+  - `removeNamedItem(name)`
+  - `item(index)`
+  - `getNamedItemNS(namespaceURI, localName)`
+  - `setNamedItemNS(arg)`
+  - `removeNamedItemNS(namespaceURI, localName)`
 		
-		readonly attribute:
-			length
-		method:
-			item(index)
+* [CharacterData](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-FF21A306) : Node
 	
- * [NamedNodeMap](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1780488922)
-
-		readonly attribute:
-			length
-		method:
-			getNamedItem(name)
-			setNamedItem(arg)
-			removeNamedItem(name)
-			item(index)
-			getNamedItemNS(namespaceURI, localName)
-			setNamedItemNS(arg)
-			removeNamedItemNS(namespaceURI, localName)
+  method:
+  - `substringData(offset, count)`
+  - `appendData(arg)`
+  - `insertData(offset, arg)`
+  - `deleteData(offset, count)`
+  - `replaceData(offset, count, arg)`
 		
- * [CharacterData](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-FF21A306) : Node
-	
-		method:
-			substringData(offset, count)
-			appendData(arg)
-			insertData(offset, arg)
-			deleteData(offset, count)
-			replaceData(offset, count, arg)
-		
- * [Text](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1312295772) : CharacterData
-	
-		method:
-			splitText(offset)
+* [Text](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1312295772) : CharacterData
+	 
+  method:
+  - `splitText(offset)`
 			
- * [CDATASection](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-667469212)
- * [Comment](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1728279322) : CharacterData
+* [CDATASection](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-667469212)
+* [Comment](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1728279322) : CharacterData
 	
- * [DocumentType](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-412266927)
+* [DocumentType](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-412266927)
 	
-		readonly attribute:
-			name|entities|notations|publicId|systemId|internalSubset
+  readonly attribute:
+  - `name` | `entities` | `notations` | `publicId` | `systemId` | `internalSubset`
 			
- * Notation : Node
+* Notation : Node
 	
-		readonly attribute:
-			publicId|systemId
+  readonly attribute:
+  - `publicId` | `systemId`
 			
- * Entity : Node
+* Entity : Node
 	
-		readonly attribute:
-			publicId|systemId|notationName
+  readonly attribute:
+  - `publicId` | `systemId` | `notationName`
 			
- * EntityReference : Node 
- * ProcessingInstruction : Node 
-	
-		attribute:
-			data
-		readonly attribute:
-			target
+* EntityReference : Node 
+* ProcessingInstruction : Node 
+
+  attribute:
+  - `data`
+  readonly attribute:
+  - `target`
 		
 ### DOM level 3 support:
 
- * [Node](http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-textContent)
+* [Node](http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-textContent)
 		
-		attribute:
-			textContent
-		method:
-			isDefaultNamespace(namespaceURI){
-			lookupNamespaceURI(prefix)
+  attribute:
+  - `textContent`
+  
+  method:
+  - `isDefaultNamespace(namespaceURI)`
+  - `lookupNamespaceURI(prefix)`
 
 ### DOM extension by xmldom
 
 * [Node] Source position extension; 
 		
-		attribute:
-			//Numbered starting from '1'
-			lineNumber
-			//Numbered starting from '1'
-			columnNumber
+  attribute:
+  - `lineNumber` //number starting from `1`
+  - `columnNumber` //number starting from `1`
 
 ## Specs
 
@@ -331,4 +353,4 @@ xmldom has an own SAX parser implementation to do the actual parsing, which impl
 - `XMLReader`
 - `DOMHandler`
 
-There is an idea/proposal to make ti possible to replace it with something else in <https://github.com/xmldom/xmldom/issues/55>
+There is an idea/proposal to make it possible to replace it with something else in <https://github.com/xmldom/xmldom/issues/55>


### PR DESCRIPTION
and (manually) align how those properties are documented

fixes #351