### PR TITLE
feat: Add traversal methods to Element

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -636,6 +636,25 @@ function _onUpdateChild (doc, el, newChild) {
  * @private
  */
 function _removeChild (parentNode, child) {
+	if (child.nodeType === ELEMENT_NODE) {
+		parentNode.childElementCount -= 1;
+
+		if (child.previousElementSibling) {
+			child.previousElementSibling.nextElementSibling = child.nextElementSibling;
+		} else {
+			parentNode.firstElementChild = child.nextElementSibling;
+		}
+
+		if (child.nextElementSibling) {
+			child.nextElementSibling.previousElementSibling = child.previousElementSibling;
+		} else {
+			parentNode.lastElementChild = child.previousElementSibling;
+		}
+
+		child.previousElementSibling = null;
+		child.nextElementSibling = null;
+	}
+
 	var previous = child.previousSibling;
 	var next = child.nextSibling;
 	if (previous) {
@@ -721,6 +740,19 @@ function _appendSingleChild (parentNode, newChild) {
 	} else {
 		parentNode.firstChild = newChild;
 	}
+
+	if (newChild.nodeType === ELEMENT_NODE) {
+		newChild.previousElementSibling = parentNode.lastElementChild
+		if (newChild.previousElementSibling) {
+			parentNode.lastElementChild.nextElementSibling = newChild
+		} else {
+			parentNode.firstElementChild = newChild;
+		}
+
+		parentNode.lastElementChild = newChild
+		parentNode.childElementCount += 1
+	}
+
 	parentNode.lastChild = newChild;
 	_onUpdateChild(parentNode.ownerDocument, parentNode, newChild);
 	return newChild;
@@ -831,7 +863,6 @@ Document.prototype = {
 		node.nodeName = tagName;
 		node.tagName = tagName;
 		node.localName = tagName;
-		node.childNodes = new NodeList();
 		var attrs	= node.attributes = new NamedNodeMap();
 		attrs._ownerElement = node;
 		return node;
@@ -887,7 +918,6 @@ Document.prototype = {
 		var node = new Element();
 		var pl = qualifiedName.split(':');
 		var attrs	= node.attributes = new NamedNodeMap();
-		node.childNodes = new NodeList();
 		node.ownerDocument = this;
 		node.nodeName = qualifiedName;
 		node.tagName = qualifiedName;
@@ -926,6 +956,12 @@ _extends(Document,Node);
 
 function Element() {
 	this._nsMap = {};
+	this.childElementCount = 0;
+	this.childNodes = new NodeList();
+	this.firstElementChild = null;
+	this.lastElementChild = null;
+	this.nextElementSibling = null;
+	this.previousElementSibling = null;
 };
 Element.prototype = {
 	nodeType : ELEMENT_NODE,
@@ -949,7 +985,7 @@ Element.prototype = {
 		attr && this.removeAttributeNode(attr);
 	},
 	
-	//four real opeartion method
+	//four real operation method
 	appendChild:function(newChild){
 		if(newChild.nodeType === DOCUMENT_FRAGMENT_NODE){
 			return this.insertBefore(newChild,null);

--- a/test/dom/element.test.js
+++ b/test/dom/element.test.js
@@ -208,6 +208,87 @@ describe('Document', () => {
 		expect(doc.childNodes.toString()).toBe(`<A/><B/><C/>`)
 	})
 
+	it('ElementTraversal', () => {
+		const doc = new DOMParser().parseFromString(`<A><B/></A>`)
+		const aElement = doc.firstChild
+		const bElement = doc.firstChild.firstChild
+
+		expect(aElement.childElementCount).toBe(1)
+		expect(aElement.firstElementChild === bElement).toBe(true)
+		expect(aElement.lastElementChild === bElement).toBe(true)
+		expect(aElement.previousElementSibling).toBeNull()
+		expect(aElement.nextElementSibling).toBeNull()
+
+		// verify that we correctly initialize
+		expect(bElement.childElementCount).toBe(0)
+		expect(bElement.firstElementChild).toBeNull()
+		expect(bElement.lastElementChild).toBeNull()
+		expect(bElement.previousElementSibling).toBeNull()
+		expect(bElement.nextElementSibling).toBeNull()
+
+		const cElement = doc.createElement('C')
+		aElement.appendChild(cElement)
+
+		expect(aElement.childElementCount).toBe(2)
+		expect(aElement.firstElementChild === bElement).toBe(true)
+		expect(aElement.lastElementChild === cElement).toBe(true)
+
+		expect(bElement.previousElementSibling).toBeNull()
+		expect(bElement.nextElementSibling === cElement).toBe(true)
+
+		expect(cElement.previousElementSibling === bElement).toBe(true)
+		expect(cElement.nextElementSibling).toBeNull()
+
+		const dElement = doc.createElement('D')
+		aElement.appendChild(dElement)
+
+		expect(aElement.childElementCount).toBe(3)
+		expect(aElement.firstElementChild === bElement).toBe(true)
+		expect(aElement.lastElementChild === dElement).toBe(true)
+
+		expect(bElement.previousElementSibling).toBeNull()
+		expect(bElement.nextElementSibling === cElement).toBe(true)
+
+		expect(cElement.previousElementSibling === bElement).toBe(true)
+		expect(cElement.nextElementSibling === dElement).toBe(true)
+
+		expect(dElement.previousElementSibling === cElement).toBe(true)
+		expect(dElement.nextElementSibling).toBeNull()
+
+		// remove the element in the middle
+		aElement.removeChild(cElement)
+
+		expect(aElement.childElementCount).toBe(2)
+		expect(aElement.firstElementChild === bElement).toBe(true)
+		expect(aElement.lastElementChild === dElement).toBe(true)
+
+		expect(bElement.previousElementSibling).toBeNull()
+		expect(bElement.nextElementSibling === dElement).toBe(true)
+
+		expect(dElement.previousElementSibling === bElement).toBe(true)
+		expect(dElement.nextElementSibling).toBeNull()
+
+		// verify that we correctly reset XXXElementSiblings attributes
+		expect(cElement.previousElementSibling).toBeNull()
+		expect(cElement.nextElementSibling).toBeNull()
+
+		// remove first element
+		aElement.removeChild(bElement)
+		expect(aElement.childElementCount).toBe(1)
+		expect(aElement.firstElementChild === dElement).toBe(true)
+		expect(aElement.lastElementChild === dElement).toBe(true)
+
+		expect(dElement.previousElementSibling).toBeNull()
+		expect(dElement.nextElementSibling).toBeNull()
+
+		// remove last element
+		aElement.removeChild(dElement)
+
+		expect(aElement.childElementCount).toBe(0)
+		expect(aElement.firstElementChild).toBeNull()
+		expect(aElement.lastElementChild).toBeNull()
+	})
+
 	xit('nested append failed', () => {})
 
 	xit('self append failed', () => {})


### PR DESCRIPTION
What does this PR do? 
- Add traversal methods to `Element`

I used the word `traversal` because it used in the official documentation to refers to these methods ([link](https://www.w3.org/TR/ElementTraversal/#attribute-lastElementChild)) 