### PR TITLE
fix: Complete multi-character sanitization

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -120,12 +120,11 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 				var tagName = source.substring(tagStart + 2, end).replace(/[ \t\n\r]+$/g, '');
 				var config = parseStack.pop();
 				if(end<0){
-
-	        		tagName = source.substring(tagStart+2).replace(/[\s<].*/,'');
+	        		tagName = source.substring(tagStart+2).replace(/[\s<].*/g,'');
 	        		errorHandler.error("end tag name: "+tagName+' is not complete:'+config.tagName);
 	        		end = tagStart+1+tagName.length;
 	        	}else if(tagName.match(/\s</)){
-	        		tagName = tagName.replace(/[\s<].*/,'');
+	        		tagName = tagName.replace(/[\s<].*/g,'');
 	        		errorHandler.error("end tag name: "+tagName+' maybe not complete');
 	        		end = tagStart+1+tagName.length;
 				}

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -124,9 +124,9 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 	        		errorHandler.error("end tag name: "+tagName+' is not complete:'+config.tagName);
 	        		end = tagStart+1+tagName.length;
 	        	}else if(tagName.match(/\s</)){
+	        		end = tagStart + 2 + tagName.length;
 	        		tagName = tagName.replace(/[\s<].*/g,'');
 	        		errorHandler.error("end tag name: "+tagName+' maybe not complete');
-	        		end = tagStart+1+tagName.length;
 				}
 				var localNSMap = config.localNSMap;
 				var endMatch = config.tagName == tagName;

--- a/test/parse/__snapshots__/simple.test.js.snap
+++ b/test/parse/__snapshots__/simple.test.js.snap
@@ -29,7 +29,7 @@ Object {
 
 exports[`parse unclosed inner 1`] = `
 Object {
-  "actual": "<r><Page><Label/></Page>  <Page/></r>",
+  "actual": "<r><Page><Label/></Page></r>",
   "error": Array [
     "[xmldom error]	end tag name: Page maybe not complete
 @#[line:1,col:10]",

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -46,6 +46,14 @@ describe('XML Node Parse', () => {
 		expect(actual).toBe(`<book/><title>Harry Potter</title>`)
 	})
 
+	it('multiline sanitization', () => {
+		// disabling error logger to keep test log clean
+		const actual = new DOMParser({ errorHandler: { error: () => {} } })
+			.parseFromString(`<xml><child></child <injected></xml>`, 'text/xml')
+			.toString()
+		expect(actual).toBe(`<xml><child/></xml>`)
+	})
+
 	describe('simple attributes', () => {
 		describe('nothing special', () => {
 			it.each([


### PR DESCRIPTION
Go to know by CodeQL in another project, that there is a missing multi-character sanitization.

https://github.com/whelk-io/maven-settings-xml-action/pull/144/files#diff-3d2b59189eeedc2d428ddd632e97658fe310f587f7cb63b01f9b98ffc11c0197R909

![image](https://user-images.githubusercontent.com/16131873/175343805-371be039-f51c-44da-a272-0479157a941a.png)
