### PR TITLE
fix: Stop adding tags after incomplete closing tag

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -122,19 +122,18 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 				appendText(tagStart);
 			}
 			switch(source.charAt(tagStart+1)){
-			case '/':
-				var end = source.indexOf('>',tagStart+3);
-				var tagName = source.substring(tagStart + 2, end).replace(/[ \t\n\r]+$/g, '');
+				case '/':
 				var config = parseStack.pop();
-				if(end<0){
-
-	        		tagName = source.substring(tagStart+2).replace(/[\s<].*/,'');
-	        		errorHandler.error("end tag name: "+tagName+' is not complete:'+config.tagName);
-	        		end = tagStart+1+tagName.length;
-	        	}else if(tagName.match(/\s</)){
-	        		tagName = tagName.replace(/[\s<].*/,'');
-	        		errorHandler.error("end tag name: "+tagName+' maybe not complete');
-	        		end = tagStart+1+tagName.length;
+				var end = source.indexOf(">", tagStart + 3);
+				var tagNameRaw = source.substring(tagStart + 2, end > 0 ? end : undefined);
+				var tagNameMatch = new RegExp("(" + tagNamePattern.source.slice(0, -1) + ")").exec(tagNameRaw);
+				// for the root level the config does not contain the tagName
+				var tagName = tagNameMatch && tagNameMatch[1] ? tagNameMatch[1] : (config.tagName || domBuilder.doc.documentElement.tagName);
+				if (end < 0) {
+					errorHandler.error("end tag name: " + tagName + " is not complete");
+					end = tagStart + 1 + tagName.length;
+				} else if (tagNameRaw.match(/</) && !isHTML) {
+					errorHandler.error("end tag name: " + tagName + " maybe not complete");
 				}
 				var localNSMap = config.localNSMap;
 				var endMatch = config.tagName == tagName;

--- a/test/error/__snapshots__/reported-levels.test.js.snap
+++ b/test/error/__snapshots__/reported-levels.test.js.snap
@@ -84,22 +84,6 @@ Array [
 ]
 `;
 
-exports[`SYNTAX_EndTagMaybeNotComplete with mimeType text/html should be reported as error 1`] = `
-Array [
-  "[xmldom error]	end tag name: inner maybe not complete
-@#[line:1,col:6]",
-]
-`;
-
-exports[`SYNTAX_EndTagMaybeNotComplete with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
-Array [
-  "[xmldom error]	end tag name: inner maybe not complete||@#[line:1,col:6]
-    at parse (lib/sax.js:#2)",
-  "[xmldom error]	element parse error: Error: [xmldom error]	end tag name: inner maybe not complete||@#[line:1,col:6]||@#[line:1,col:6]
-    at parse (lib/sax.js:#5)",
-]
-`;
-
 exports[`SYNTAX_EndTagMaybeNotComplete with mimeType text/xml should be reported as error 1`] = `
 Array [
   "[xmldom error]	end tag name: inner maybe not complete
@@ -118,32 +102,32 @@ Array [
 
 exports[`SYNTAX_EndTagNotComplete with mimeType text/html should be reported as error 1`] = `
 Array [
-  "[xmldom error]	end tag name: xml is not complete:xml
+  "[xmldom error]	end tag name: xml is not complete
 @#[line:1,col:1]",
 ]
 `;
 
 exports[`SYNTAX_EndTagNotComplete with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
-  "[xmldom error]	end tag name: xml is not complete:xml||@#[line:1,col:1]
+  "[xmldom error]	end tag name: xml is not complete||@#[line:1,col:1]
     at parse (lib/sax.js:#1)",
-  "[xmldom error]	element parse error: Error: [xmldom error]	end tag name: xml is not complete:xml||@#[line:1,col:1]||@#[line:1,col:1]
+  "[xmldom error]	element parse error: Error: [xmldom error]	end tag name: xml is not complete||@#[line:1,col:1]||@#[line:1,col:1]
     at parse (lib/sax.js:#5)",
 ]
 `;
 
 exports[`SYNTAX_EndTagNotComplete with mimeType text/xml should be reported as error 1`] = `
 Array [
-  "[xmldom error]	end tag name: xml is not complete:xml
+  "[xmldom error]	end tag name: xml is not complete
 @#[line:1,col:1]",
 ]
 `;
 
 exports[`SYNTAX_EndTagNotComplete with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
-  "[xmldom error]	end tag name: xml is not complete:xml||@#[line:1,col:1]
+  "[xmldom error]	end tag name: xml is not complete||@#[line:1,col:1]
     at parse (lib/sax.js:#1)",
-  "[xmldom error]	element parse error: Error: [xmldom error]	end tag name: xml is not complete:xml||@#[line:1,col:1]||@#[line:1,col:1]
+  "[xmldom error]	element parse error: Error: [xmldom error]	end tag name: xml is not complete||@#[line:1,col:1]||@#[line:1,col:1]
     at parse (lib/sax.js:#5)",
 ]
 `;

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -67,6 +67,7 @@ const REPORTED = {
 	SYNTAX_EndTagMaybeNotComplete: {
 		source: '<xml><inner></inner </xml>',
 		level: 'error',
+		skippedInHtml: true,
 		match: (msg) => /end tag name/.test(msg) && /maybe not complete/.test(msg),
 	},
 	/**

--- a/test/parse/__snapshots__/simple.test.js.snap
+++ b/test/parse/__snapshots__/simple.test.js.snap
@@ -29,7 +29,7 @@ Object {
 
 exports[`parse unclosed inner 1`] = `
 Object {
-  "actual": "<r><Page><Label/></Page>  <Page/></r>",
+  "actual": "<r><Page><Label/></Page></r>",
   "error": Array [
     "[xmldom error]	end tag name: Page maybe not complete
 @#[line:1,col:10]",
@@ -41,8 +41,18 @@ exports[`parse unclosed root 1`] = `
 Object {
   "actual": "<Page><Label class=\\"title\\"/></Page>  1",
   "error": Array [
-    "[xmldom error]	end tag name: Page is not complete:Page
+    "[xmldom error]	end tag name: Page is not complete
 @#[line:1,col:20]",
+  ],
+}
+`;
+
+exports[`parse unclosed root followed by another tag 1`] = `
+Object {
+  "actual": "<Page/>",
+  "error": Array [
+    "[xmldom error]	end tag name: Page maybe not complete
+@#[line:1,col:1]",
   ],
 }
 `;

--- a/test/parse/simple.test.js
+++ b/test/parse/simple.test.js
@@ -36,6 +36,16 @@ describe('parse', () => {
 		expect({ actual, ...errors }).toMatchSnapshot()
 	})
 
+	it('unclosed root followed by another tag', () => {
+		const { errors, parser } = getTestParser()
+
+		const actual = parser
+			.parseFromString('<Page></Page  <hello></hello>', 'text/xml')
+			.toString()
+
+		expect({ actual, ...errors }).toMatchSnapshot()
+	})
+
 	it('svg test', () => {
 		const svgCase = [
 			'<svg>',

--- a/test/xmltest/__snapshots__/not-wf.test.js.snap
+++ b/test/xmltest/__snapshots__/not-wf.test.js.snap
@@ -23,8 +23,8 @@ Object {
 exports[`xmltest/not-wellformed standalone should match 002.xml with snapshot 1`] = `
 Object {
   "actual": "<doc>
-&lt;.doc&gt;
-</doc>",
+&lt;.doc&gt;</doc>
+",
   "error": Array [
     "[xmldom error]	element parse error: Error: invalid tagName:.doc
 @#[line:2,col:1]",
@@ -152,7 +152,7 @@ exports[`xmltest/not-wellformed standalone should match 019.xml with snapshot 1`
 Object {
   "actual": "<doc/>",
   "error": Array [
-    "[xmldom error]	end tag name: > is not complete:undefined
+    "[xmldom error]	end tag name: doc is not complete
 @#[line:1,col:1]",
   ],
   "warning": Array [
@@ -193,8 +193,8 @@ Object {
 exports[`xmltest/not-wellformed standalone should match 024.xml with snapshot 1`] = `
 Object {
   "actual": "<doc>
-&lt;123&gt;
-</doc>",
+&lt;123&gt;</doc>
+",
   "error": Array [
     "[xmldom error]	element parse error: Error: invalid tagName:123
 @#[line:2,col:1]",


### PR DESCRIPTION
Previously it was tested as a feature, that tags after incomplete closing tags would be part of the dom. The code responsible for this triggered a CodeQL error suspecting that it could lead to injection of a `script` tag.

BREAKING CHANGE: It no longer reports an error when parsing HTML containing incomplete closing tags, to align the behavior with the one in the browser.

BREAKING CHANGE: If your code relied on not well formed XML to be parsed and include subsequent tags, this will no longer work.

https://github.com/xmldom/xmldom/pull/416