### PR TITLE
fix: `getAttribute` and `getAttributeNS` should return `null`

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1370,7 +1370,7 @@ Element.prototype = {
 	},
 	getAttribute: function (name) {
 		var attr = this.getAttributeNode(name);
-		return (attr && attr.value) || ((attr && attr.value) === undefined ? null : '');
+		return attr ? attr.value : null;
 	},
 	getAttributeNode: function (name) {
 		if (this._isInHTMLDocumentAndNamespace()) {
@@ -1420,7 +1420,7 @@ Element.prototype = {
 	},
 	getAttributeNS: function (namespaceURI, localName) {
 		var attr = this.getAttributeNodeNS(namespaceURI, localName);
-		return (attr && attr.value) || ((attr && attr.value) === undefined ? null : '');
+		return attr ? attr.value : null;
 	},
 	setAttributeNS: function (namespaceURI, qualifiedName, value) {
 		var attr = this.ownerDocument.createAttributeNS(namespaceURI, qualifiedName);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1370,7 +1370,7 @@ Element.prototype = {
 	},
 	getAttribute: function (name) {
 		var attr = this.getAttributeNode(name);
-		return (attr && attr.value) || '';
+		return (attr && attr.value) || null;
 	},
 	getAttributeNode: function (name) {
 		if (this._isInHTMLDocumentAndNamespace()) {
@@ -1420,7 +1420,7 @@ Element.prototype = {
 	},
 	getAttributeNS: function (namespaceURI, localName) {
 		var attr = this.getAttributeNodeNS(namespaceURI, localName);
-		return (attr && attr.value) || '';
+		return (attr && attr.value) || null;
 	},
 	setAttributeNS: function (namespaceURI, qualifiedName, value) {
 		var attr = this.ownerDocument.createAttributeNS(namespaceURI, qualifiedName);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1370,7 +1370,7 @@ Element.prototype = {
 	},
 	getAttribute: function (name) {
 		var attr = this.getAttributeNode(name);
-		return (attr && attr.value) || null;
+		return (attr && attr.value) || ((attr && attr.value) === undefined ? null : '');
 	},
 	getAttributeNode: function (name) {
 		if (this._isInHTMLDocumentAndNamespace()) {
@@ -1420,7 +1420,7 @@ Element.prototype = {
 	},
 	getAttributeNS: function (namespaceURI, localName) {
 		var attr = this.getAttributeNodeNS(namespaceURI, localName);
-		return (attr && attr.value) || null;
+		return (attr && attr.value) || ((attr && attr.value) === undefined ? null : '');
 	},
 	setAttributeNS: function (namespaceURI, qualifiedName, value) {
 		var attr = this.ownerDocument.createAttributeNS(namespaceURI, qualifiedName);

--- a/test/dom/element.test.js
+++ b/test/dom/element.test.js
@@ -121,13 +121,14 @@ describe('Document', () => {
 	it('supports getElementById', () => {
 		const doc = new DOMParser().parseFromString(
 			'<xml xmlns="http://test.com" id="root">' +
-				'<child id="a1" title="1"><child id="a2"  title="2"/></child>' +
+				'<child id="a1" title="1"><child id="a2"  title="2" empty-title=""/></child>' +
 				'<child id="a1"   title="3"/></xml>',
 			'text/xml'
 		);
 		expect(doc.getElementById('root')).not.toBeNull();
 		expect(doc.getElementById('a1').getAttribute('title')).toBe('1');
 		expect(doc.getElementById('a2').getAttribute('title')).toBe('2');
+		expect(doc.getElementById('a2').getAttribute('empty-title')).toBe('');
 		expect(doc.getElementById('a2').getAttribute('title2')).toBe(null);
 	});
 

--- a/test/dom/element.test.js
+++ b/test/dom/element.test.js
@@ -128,7 +128,7 @@ describe('Document', () => {
 		expect(doc.getElementById('root')).not.toBeNull();
 		expect(doc.getElementById('a1').getAttribute('title')).toBe('1');
 		expect(doc.getElementById('a2').getAttribute('title')).toBe('2');
-		expect(doc.getElementById('a2').getAttribute('title2')).toBe('');
+		expect(doc.getElementById('a2').getAttribute('title2')).toBe(null);
 	});
 
 	it('can properly append exist child', () => {


### PR DESCRIPTION
BREAKING CHANGE: `Element.getAttribute` and `Element.getAttributeNS` return `null` if the attribute doesn't exist

closes #46
https://dom.spec.whatwg.org/#dom-element-getattribute