### PR TITLE
chore: Configure jest (correctly) and wallaby

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,194 +1,193 @@
+'use strict';
 // For a detailed explanation regarding each configuration property, visit:
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
-  // All imported modules in your tests should be mocked automatically
-  // automock: false,
+	// All imported modules in your tests should be mocked automatically
+	// automock: false,
 
-  // Stop running tests after `n` failures
-  // bail: 0,
+	// Stop running tests after `n` failures
+	// bail: 0,
 
-  // The directory where Jest should store its cached dependency information
-  // cacheDirectory: "/tmp/jest_rs",
+	// The directory where Jest should store its cached dependency information
+	// cacheDirectory: "/tmp/jest_rs",
 
-  // Automatically clear mock calls and instances between every test
-  clearMocks: true,
+	// Automatically clear mock calls and instances between every test
+	clearMocks: true,
 
-  // Indicates whether the coverage information should be collected while executing the test
-  // collectCoverage: false,
+	// Indicates whether the coverage information should be collected while executing the test
+	// collectCoverage: false,
 
-  // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: undefined,
+	// An array of glob patterns indicating a set of files for which coverage information should be collected
+	// collectCoverageFrom: undefined,
 
-  // The directory where Jest should output its coverage files
-  // coverageDirectory: "coverage",
+	// The directory where Jest should output its coverage files
+	// coverageDirectory: "coverage",
 
-  // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+	// An array of regexp pattern strings used to skip coverage collection
+	// coveragePathIgnorePatterns: [
+	//   "/node_modules/"
+	// ],
 
-  // Indicates which provider should be used to instrument code for coverage
-  // coverageProvider: "v8",
+	// Indicates which provider should be used to instrument code for coverage
+	// coverageProvider: "v8",
 
-  // A list of reporter names that Jest uses when writing coverage reports
-  // coverageReporters: [
-  //   "json",
-  //   "text",
-  //   "lcov",
-  //   "clover"
-  // ],
+	// A list of reporter names that Jest uses when writing coverage reports
+	// coverageReporters: [
+	//   "json",
+	//   "text",
+	//   "lcov",
+	//   "clover"
+	// ],
 
-  // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+	// An object that configures minimum threshold enforcement for coverage results
+	// coverageThreshold: undefined,
 
-  // A path to a custom dependency extractor
-  // dependencyExtractor: undefined,
+	// A path to a custom dependency extractor
+	// dependencyExtractor: undefined,
 
-  // Make calling deprecated APIs throw helpful error messages
-  // errorOnDeprecated: false,
+	// Make calling deprecated APIs throw helpful error messages
+	// errorOnDeprecated: false,
 
-  // Force coverage collection from ignored files using an array of glob patterns
-  // forceCoverageMatch: [],
+	// Force coverage collection from ignored files using an array of glob patterns
+	// forceCoverageMatch: [],
 
-  // A path to a module which exports an async function that is triggered once before all test suites
-  // globalSetup: undefined,
+	// A path to a module which exports an async function that is triggered once before all test suites
+	// globalSetup: undefined,
 
-  // A path to a module which exports an async function that is triggered once after all test suites
-  // globalTeardown: undefined,
+	// A path to a module which exports an async function that is triggered once after all test suites
+	// globalTeardown: undefined,
 
-  // A set of global variables that need to be available in all test environments
-  // globals: {},
+	// A set of global variables that need to be available in all test environments
+	// globals: {},
 
-  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-  // maxWorkers: "50%",
+	// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+	// maxWorkers: "50%",
 
-  // An array of directory names to be searched recursively up from the requiring module's location
-  // moduleDirectories: [
-  //   "node_modules"
-  // ],
+	// An array of directory names to be searched recursively up from the requiring module's location
+	// moduleDirectories: [
+	//   "node_modules"
+	// ],
 
-  // An array of file extensions your modules use
-  // moduleFileExtensions: [
-  //   "js",
-  //   "json",
-  //   "jsx",
-  //   "ts",
-  //   "tsx",
-  //   "node"
-  // ],
+	// An array of file extensions your modules use
+	// moduleFileExtensions: [
+	//   "js",
+	//   "json",
+	//   "jsx",
+	//   "ts",
+	//   "tsx",
+	//   "node"
+	// ],
 
-  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+	// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+	// moduleNameMapper: {},
 
-  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-  // modulePathIgnorePatterns: [],
+	// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+	// modulePathIgnorePatterns: [],
 
-  // Activates notifications for test results
-  // notify: false,
+	// Activates notifications for test results
+	// notify: false,
 
-  // An enum that specifies notification mode. Requires { notify: true }
-  // notifyMode: "failure-change",
+	// An enum that specifies notification mode. Requires { notify: true }
+	// notifyMode: "failure-change",
 
-  // A preset that is used as a base for Jest's configuration
-  // preset: undefined,
+	// A preset that is used as a base for Jest's configuration
+	// preset: undefined,
 
-  // Run tests from one or more projects
-  // projects: undefined,
+	// Run tests from one or more projects
+	// projects: undefined,
 
-  // Use this configuration option to add custom reporters to Jest
-  // reporters: undefined,
+	// Use this configuration option to add custom reporters to Jest
+	// reporters: undefined,
 
-  // Automatically reset mock state between every test
-  // resetMocks: false,
+	// Automatically reset mock state between every test
+	// resetMocks: false,
 
-  // Reset the module registry before running each individual test
-  // resetModules: false,
+	// Reset the module registry before running each individual test
+	// resetModules: false,
 
-  // A path to a custom resolver
-  // resolver: undefined,
+	// A path to a custom resolver
+	// resolver: undefined,
 
-  // Automatically restore mock state between every test
-  // restoreMocks: false,
+	// Automatically restore mock state between every test
+	// restoreMocks: false,
 
-  // The root directory that Jest should scan for tests and modules within
-  // rootDir: undefined,
+	// The root directory that Jest should scan for tests and modules within
+	// rootDir: undefined,
 
-  // A list of paths to directories that Jest should use to search for files in
-  // roots: [
-  //   "<rootDir>"
-  // ],
+	// A list of paths to directories that Jest should use to search for files in
+	// roots: [
+	//   "<rootDir>"
+	// ],
 
-  // Allows you to use a custom runner instead of Jest's default test runner
-  // runner: "jest-runner",
+	// Allows you to use a custom runner instead of Jest's default test runner
+	// runner: "jest-runner",
 
-  // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+	// The paths to modules that run some code to configure or set up the testing environment before each test
+	// setupFiles: [],
 
-  // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+	// A list of paths to modules that run some code to configure or set up the testing framework before each test
+	// setupFilesAfterEnv: [],
 
-  // The number of seconds after which a test is considered as slow and reported as such in the results.
-  // slowTestThreshold: 5,
+	// The number of seconds after which a test is considered as slow and reported as such in the results.
+	// slowTestThreshold: 5,
 
-  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
-  // snapshotSerializers: [],
+	// A list of paths to snapshot serializer modules Jest should use for snapshot testing
+	// snapshotSerializers: [],
 
-  // The test environment that will be used for testing
-  testEnvironment: "node",
+	// The test environment that will be used for testing
+	testEnvironment: 'node',
 
-  // Options that will be passed to the testEnvironment
-  // testEnvironmentOptions: {},
+	// Options that will be passed to the testEnvironment
+	// testEnvironmentOptions: {},
 
-  // Adds a location field to test results
-  // testLocationInResults: false,
+	// Adds a location field to test results
+	// testLocationInResults: false,
 
-  // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.[jt]s?(x)",
-  //   "**/?(*.)+(spec|test).[tj]s?(x)"
-  // ],
+	// The glob patterns Jest uses to detect test files
+	// testMatch: [
+	//   "**/__tests__/**/*.[jt]s?(x)",
+	//   "**/?(*.)+(spec|test).[tj]s?(x)"
+	// ],
 
-  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+	// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+	// testPathIgnorePatterns: [
+	//   "/node_modules/"
+	// ],
 
-  // The regexp pattern or array of patterns that Jest uses to detect test files
-  testRegex: [
-  	/\.test\.js?$/
-	],
+	// The regexp pattern or array of patterns that Jest uses to detect test files
+	// testRegex: ['test/**/*.test.js$'],
 
-  // This option allows the use of a custom results processor
-  // testResultsProcessor: undefined,
+	// This option allows the use of a custom results processor
+	// testResultsProcessor: undefined,
 
-  // This option allows use of a custom test runner
-  // testRunner: "jasmine2",
+	// This option allows use of a custom test runner
+	// testRunner: "jasmine2",
 
-  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
-  // testURL: "http://localhost",
+	// This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+	// testURL: "http://localhost",
 
-  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
-  // timers: "real",
+	// Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+	// timers: "real",
 
-  // A map from regular expressions to paths to transformers
-  // transform: undefined,
+	// A map from regular expressions to paths to transformers
+	// transform: undefined,
 
-  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  // transformIgnorePatterns: [
-  //   "/node_modules/",
-  //   "\\.pnp\\.[^\\/]+$"
-  // ],
+	// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+	// transformIgnorePatterns: [
+	//   "/node_modules/",
+	//   "\\.pnp\\.[^\\/]+$"
+	// ],
 
-  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-  // unmockedModulePathPatterns: undefined,
+	// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+	// unmockedModulePathPatterns: undefined,
 
-  // Indicates whether each individual test should be reported during the run
-  // verbose: undefined,
+	// Indicates whether each individual test should be reported during the run
+	// verbose: undefined,
 
-  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-  // watchPathIgnorePatterns: [],
+	// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+	// watchPathIgnorePatterns: [],
 
-  // Whether to use watchman for file crawling
-  // watchman: true,
+	// Whether to use watchman for file crawling
+	// watchman: true,
 };

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,15 @@
+'use strict';
+// This is a config file to be able to run as many tests as possible using
+// https://wallabyjs.com/
+// usually it wrks without any config, but on of our tests doesn't, so it is excluded
+
+module.exports = {
+	tests: {
+		override: (testPatterns) => {
+			// this test relies on stacktrace of errors which are not available in instrumented files
+			// they are not "visible" for wallaby, would be nicer to mark them as skipped
+			testPatterns.push('!test/error/reported-levels.test.js');
+			return testPatterns;
+		},
+	},
+};


### PR DESCRIPTION
the current jest config was causing wallaby to fail, because `testRegex` is supposed to be a string but was a RegExp.
The config for wallaby excludes the test file that is based on stacktrace of errors, since it doesn't work in instrumented files.