### PR TITLE
chore: Mark reported-levels.test.js as skipped in wallaby

### DIFF
--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -1,4 +1,5 @@
 'use strict';
+// wallaby:file.skip since stacktrace detection is not working in instrumented files
 
 const { LINE_TO_ERROR_INDEX, REPORTED } = require('./reported');
 const { getTestParser } = require('../get-test-parser');

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,15 +1,16 @@
 'use strict';
 // This is a config file to be able to run as many tests as possible using
 // https://wallabyjs.com/
-// usually it wrks without any config, but on of our tests doesn't, so it is excluded
+// usually it works without any config, but test/error/reported-levels.test.js
+// relies on stacktrace of errors which are not available in instrumented files,
+// so it is marked as skipped
 
 module.exports = {
-	tests: {
-		override: (testPatterns) => {
-			// this test relies on stacktrace of errors which are not available in instrumented files
-			// they are not "visible" for wallaby, would be nicer to mark them as skipped
-			testPatterns.push('!test/error/reported-levels.test.js');
-			return testPatterns;
+	hints: {
+		// https://wallabyjs.com/docs/intro/selected-tests.html#test-file-selection
+		testFileSelection: {
+			include: /wallaby:file\.only/,
+			exclude: /wallaby:file\.skip/,
 		},
 	},
 };


### PR DESCRIPTION
instead of completely excluding it.

wallaby output:
![wallaby output](https://user-images.githubusercontent.com/135657/226258407-d4992035-2089-44a0-8327-f227263c3dc0.png)

jest output:
![image](https://user-images.githubusercontent.com/135657/226258696-f5d5ea4a-e078-4a41-9658-023b7934f109.png)


https://wallabyjs.com/docs/intro/selected-tests.html#test-file-selection