### PR TITLE
test: reduce output by using `getTestWrapper` 

### DIFF
--- a/test/parse/__snapshots__/parse-element.test.js.snap
+++ b/test/parse/__snapshots__/parse-element.test.js.snap
@@ -9,10 +9,37 @@ Object {
 }
 `;
 
+exports[`XML Node Parse closing tag with unquoted value following / 1`] = `
+Object {
+  "warning": Array [
+    "[xmldom warning]	attribute \\"lazy\\" missed quot(\\")!
+@#[line:3,col:3]",
+  ],
+}
+`;
+
+exports[`XML Node Parse closing tag with unquoted value following space and / 1`] = `
+Object {
+  "warning": Array [
+    "[xmldom warning]	attribute \\"lazy\\" missed quot(\\")!!
+@#[line:3,col:3]",
+  ],
+}
+`;
+
 exports[`XML Node Parse closing tag with unquoted value including /  followed by space / 1`] = `
 Object {
   "warning": Array [
     "[xmldom warning]	attribute \\"lazy/\\" missed quot(\\")!!
+@#[line:3,col:3]",
+  ],
+}
+`;
+
+exports[`XML Node Parse closing tag without attribute value 1`] = `
+Object {
+  "warning": Array [
+    "[xmldom warning]	attribute \\"lazy\\" missed value!! \\"lazy\\" instead!!
 @#[line:3,col:3]",
   ],
 }

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -40,7 +40,8 @@ describe('XML Node Parse', () => {
 	});
 
 	it('closing tag without attribute value', () => {
-		const actual = new DOMParser()
+		const { errors, parser } = getTestParser();
+		const actual = parser
 			.parseFromString(
 				`<template>
 	<view>
@@ -51,6 +52,7 @@ describe('XML Node Parse', () => {
 				'text/xml'
 			)
 			.toString();
+		expect(errors).toMatchSnapshot();
 		expect(actual).toBe(
 			`<template>
 	<view>
@@ -61,7 +63,8 @@ describe('XML Node Parse', () => {
 		);
 	});
 	it('closing tag with unquoted value following /', () => {
-		const actual = new DOMParser()
+		const { errors, parser } = getTestParser();
+		const actual = parser
 			.parseFromString(
 				`<template>
 	<view>
@@ -72,6 +75,7 @@ describe('XML Node Parse', () => {
 				'text/xml'
 			)
 			.toString();
+		expect(errors).toMatchSnapshot();
 		expect(actual).toBe(
 			`<template>
 	<view>
@@ -82,7 +86,8 @@ describe('XML Node Parse', () => {
 		);
 	});
 	it('closing tag with unquoted value following space and /', () => {
-		const actual = new DOMParser()
+		const { errors, parser } = getTestParser();
+		const actual = parser
 			.parseFromString(
 				`<template>
 	<view>
@@ -93,6 +98,7 @@ describe('XML Node Parse', () => {
 				'text/xml'
 			)
 			.toString();
+		expect(errors).toMatchSnapshot();
 		expect(actual).toBe(
 			`<template>
 	<view>


### PR DESCRIPTION
and adding snapshots for warnings

The additional output was introduced by the new tests in #485 

![image](https://user-images.githubusercontent.com/135657/229351721-46c8f243-305b-40ee-89b1-a0c2baa55f6a.png)
