### PR TITLE
feat: Add compareDocumentPosition method from level 3 spec.

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -656,49 +656,51 @@ Node.prototype = {
 		return prefix == null;
 	},
 	// Introduced in DOM Level 3:
-        /**
-         * Compares the reference node with a node with regard to their position
-         * in the document and according to the document order.
-         *
-         * @param {Node} other The node to compare the reference node to.
-         * @return {number} Returns how the node is positioned relatively to the
-         *    reference node according to the bitmask. 0 if reference node and
-         *    given node are the same.
-         * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
-         */
+	/**
+	 * Compares the reference node with a node with regard to their position
+	 * in the document and according to the document order.
+	 *
+	 * @param {Node} other The node to compare the reference node to.
+	 * @return {number} Returns how the node is positioned relatively to the
+	 *    reference node according to the bitmask. 0 if reference node and
+	 *    given node are the same.
+	 * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
+	 */
 	compareDocumentPosition: function (other) {
 		if (this === other) return 0;
-                var node1 = other;
-                var node2 = this;
-                var attr1 = null;
-                var attr2 = null;
-                if (node1 instanceof Attr) {
-                        attr1 = node1;
-                        node1 = attr1.ownerElement;
-                }
-                if (node2 instanceof Attr) {
-                        attr2 = node2;
-                        node2 = attr2.ownerElement;
-                        if (attr1 && node1 && node2 === node1) {
-                                for (var i = 0, attr; attr =  node2.attributes[i]; i++) {
-                                        if (attr === attr1) return  DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + DOCUMENT_POSITION_PRECEDING;
-                                        if (attr === attr2) return  DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + DOCUMENT_POSITION_FOLLOWING;
-                                }
-                        }
-                }
+		var node1 = other;
+		var node2 = this;
+		var attr1 = null;
+		var attr2 = null;
+		if (node1 instanceof Attr) {
+			attr1 = node1;
+			node1 = attr1.ownerElement;
+		}
+		if (node2 instanceof Attr) {
+			attr2 = node2;
+			node2 = attr2.ownerElement;
+			if (attr1 && node1 && node2 === node1) {
+				for (var i = 0, attr; (attr = node2.attributes[i]); i++) {
+					if (attr === attr1) return DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + DOCUMENT_POSITION_PRECEDING;
+					if (attr === attr2) return DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + DOCUMENT_POSITION_FOLLOWING;
+				}
+			}
+		}
 		if (!node1 || !node2 || node2.ownerDocument !== node1.ownerDocument) {
-			return DOCUMENT_POSITION_DISCONNECTED +
-			        DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
-			        (docGUID(node2.ownerDocument) > docGUID(node1.ownerDocument) ? DOCUMENT_POSITION_FOLLOWING : DOCUMENT_POSITION_PRECEDING);
-                }
-		const chain1 = parentChain(node1);
-		const chain2 = parentChain(node2);
-	        if ((!attr1 && chain2.indexOf(node1) >= 0) || (attr2 && node1 === node2)) {
-                        return DOCUMENT_POSITION_CONTAINS + DOCUMENT_POSITION_PRECEDING;
-                }
+			return (
+				DOCUMENT_POSITION_DISCONNECTED +
+				DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
+				(docGUID(node2.ownerDocument) > docGUID(node1.ownerDocument) ? DOCUMENT_POSITION_FOLLOWING : DOCUMENT_POSITION_PRECEDING)
+			);
+		}
+		var chain1 = parentChain(node1);
+		var chain2 = parentChain(node2);
+		if ((!attr1 && chain2.indexOf(node1) >= 0) || (attr2 && node1 === node2)) {
+			return DOCUMENT_POSITION_CONTAINS + DOCUMENT_POSITION_PRECEDING;
+		}
 		if ((!attr2 && chain1.indexOf(node2) >= 0) || (attr1 && node1 === node2)) {
-                        return DOCUMENT_POSITION_CONTAINED_BY + DOCUMENT_POSITION_FOLLOWING;
-                }
+			return DOCUMENT_POSITION_CONTAINED_BY + DOCUMENT_POSITION_FOLLOWING;
+		}
 		var ca = commonAncestor(chain2, chain1);
 		for (var n in ca.childNodes) {
 			var child = ca.childNodes[n];

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var conventions = require('./conventions');
+var crypto = require('crypto');
 var find = conventions.find;
 var isHTMLRawTextElement = conventions.isHTMLRawTextElement;
 var isHTMLVoidElement = conventions.isHTMLVoidElement;
@@ -171,25 +172,13 @@ function commonAncestor(a, b) {
 }
 
 /**
- * Computes a new guid.
- * @return {string} A new guid.
- */
-function guid() {
-	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-		var r = (Math.random() * 16) | 0;
-		var v = c === 'x' ? r : (r & 0x3) | 0x8;
-		return v.toString(16);
-	});
-}
-
-/**
  * Comparing unrelated nodes must be consistent, so we assign a guid to the
  * compared docs for further reference.
  * @param {Document} doc The document.
  * @return {string} The document's guid.
  */
 function docGUID(doc) {
-	if (!doc.guid) doc.guid = guid();
+	if (!doc.guid) doc.guid = crypto.randomUUID();
 	return doc.guid;
 }
 //-- end of helper functions
@@ -668,25 +657,52 @@ Node.prototype = {
 		return prefix == null;
 	},
 	// Introduced in DOM Level 3:
-	compareDocumentPosition: function (o) {
-		if (this === o) return 0;
-		if (this.ownerDocument !== o.ownerDocument)
-			return (
-				DOCUMENT_POSITION_DISCONNECTED |
-				DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC |
-				(docGUID(this.ownerDocument) > docGUID(o.ownerDocument) ? DOCUMENT_POSITION_FOLLOWING : DOCUMENT_POSITION_PRECEDING)
-			);
-		var aa = parentChain(this);
-		var ab = parentChain(o);
-		if (aa.indexOf(o) >= 0) return DOCUMENT_POSITION_CONTAINS;
-		if (ab.indexOf(this) >= 0) return DOCUMENT_POSITION_CONTAINED_BY;
-		var ca = commonAncestor(aa, ab);
+        /**
+         * Compares the reference node with a node with regard to their position
+         * in the document and according to the document order.
+         *
+         * @param {Node} other The node to compare the reference node to.
+         * @return {number} Returns how the node is positioned relatively to the
+         *    reference node according to the bitmask. 0 if reference node and
+         *    given node are the same.
+         * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
+         */
+	compareDocumentPosition: function (other) {
+		if (this === other) return 0;
+                var node1 = other;
+                var node2 = this;
+                var attr1 = null;
+                var attr2 = null;
+                if (node1 instanceof Attr) {
+                        attr1 = node1;
+                        node1 = attr1.ownerElement;
+                }
+                if (node2 instanceof Attr) {
+                        attr2 = node2;
+                        node2 = attr2.ownerElement;
+                        if (attr1 && node1 && node2 === node1) {
+                                for (var i = 0, attr; attr =  node2.attributes[i]; i++) {
+                                        if (attr === attr1) return  DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + DOCUMENT_POSITION_PRECEDING;
+                                        if (attr === attr2) return  DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + DOCUMENT_POSITION_FOLLOWING;
+                                }
+                        }
+                }
+		if (!node1 || !node2 || // Orphan attribute case.
+                    node2.ownerDocument !== node1.ownerDocument)
+			return DOCUMENT_POSITION_DISCONNECTED +
+			DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
+			(docGUID(node2.ownerDocument) > docGUID(node1.ownerDocument) ? DOCUMENT_POSITION_FOLLOWING : DOCUMENT_POSITION_PRECEDING);
+		const chain1 = parentChain(node1);
+		const chain2 = parentChain(node2);
+		if (chain2.indexOf(node1) >= 0) return DOCUMENT_POSITION_CONTAINS;
+		if (chain1.indexOf(node2) >= 0) return DOCUMENT_POSITION_CONTAINED_BY;
+		var ca = commonAncestor(chain2, chain1);
 		for (var n in ca.childNodes) {
 			var child = ca.childNodes[n];
-			if (child === this) return DOCUMENT_POSITION_FOLLOWING;
-			if (child === o) return DOCUMENT_POSITION_PRECEDING;
-			if (aa.indexOf(child) >= 0) return DOCUMENT_POSITION_FOLLOWING;
-			if (ab.indexOf(child) >= 0) return DOCUMENT_POSITION_PRECEDING;
+			if (child === node2) return DOCUMENT_POSITION_FOLLOWING;
+			if (child === node1) return DOCUMENT_POSITION_PRECEDING;
+			if (chain2.indexOf(child) >= 0) return DOCUMENT_POSITION_FOLLOWING;
+			if (chain1.indexOf(child) >= 0) return DOCUMENT_POSITION_PRECEDING;
 		}
 		return 0;
 	},

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -130,6 +130,70 @@ var INVALID_MODIFICATION_ERR = (ExceptionCode.INVALID_MODIFICATION_ERR = ((Excep
 var NAMESPACE_ERR = (ExceptionCode.NAMESPACE_ERR = ((ExceptionMessage[14] = 'Invalid namespace'), 14));
 var INVALID_ACCESS_ERR = (ExceptionCode.INVALID_ACCESS_ERR = ((ExceptionMessage[15] = 'Invalid access'), 15));
 
+// compareDocumentPosition bitmask results
+var DOCUMENT_POSITION_DISCONNECTED = 1;
+var DOCUMENT_POSITION_PRECEDING = 2;
+var DOCUMENT_POSITION_FOLLOWING = 4;
+var DOCUMENT_POSITION_CONTAINS = 8;
+var DOCUMENT_POSITION_CONTAINED_BY = 16;
+var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32;
+
+//helper functions for compareDocumentPosition
+/**
+ * Construct a parent chain for a node.
+ * @param {Node} node The start node.
+ * @return {Node[]} The parent chain.
+ */
+//TODO: this can be members
+function parentChain(node) {
+	var chain = [];
+	while (node.parentNode || node.ownerElement) {
+		node = node.parentNode || node.ownerElement;
+		chain.unshift(node);
+	}
+	return chain;
+}
+
+/**
+ * Find the common ancestor in two parent chains.
+ * @param {Node[]} a A parent chain.
+ * @param {Node[]} b A parent chain.
+ * @return {Node} The common ancestor if it exists.
+ */
+function commonAncestor(a, b) {
+	if (b.length < a.length) return commonAncestor(b, a);
+	var c = null;
+	for (var n in a) {
+		if (a[n] !== b[n]) return c;
+		c = a[n];
+	}
+	return c;
+}
+
+/**
+ * Computes a new guid.
+ * @return {string} A new guid.
+ */
+function guid() {
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+		var r = (Math.random() * 16) | 0;
+		var v = c === 'x' ? r : (r & 0x3) | 0x8;
+		return v.toString(16);
+	});
+}
+
+/**
+ * Comparing unrelated nodes must be consistent, so we assign a guid to the
+ * compared docs for further reference.
+ * @param {Document} doc The document.
+ * @return {string} The document's guid.
+ */
+function docGUID(doc) {
+	if (!doc.guid) doc.guid = guid();
+	return doc.guid;
+}
+//-- end of helper functions
+
 /**
  * DOM Level 2
  * Object DOMException
@@ -602,6 +666,29 @@ Node.prototype = {
 	isDefaultNamespace: function (namespaceURI) {
 		var prefix = this.lookupPrefix(namespaceURI);
 		return prefix == null;
+	},
+	// Introduced in DOM Level 3:
+	compareDocumentPosition: function (o) {
+		if (this === o) return 0;
+		if (this.ownerDocument !== o.ownerDocument)
+			return (
+				DOCUMENT_POSITION_DISCONNECTED |
+				DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC |
+				(docGUID(this.ownerDocument) > docGUID(o.ownerDocument) ? DOCUMENT_POSITION_FOLLOWING : DOCUMENT_POSITION_PRECEDING)
+			);
+		var aa = parentChain(this);
+		var ab = parentChain(o);
+		if (aa.indexOf(o) >= 0) return DOCUMENT_POSITION_CONTAINS;
+		if (ab.indexOf(this) >= 0) return DOCUMENT_POSITION_CONTAINED_BY;
+		var ca = commonAncestor(aa, ab);
+		for (var n in ca.childNodes) {
+			var child = ca.childNodes[n];
+			if (child === this) return DOCUMENT_POSITION_FOLLOWING;
+			if (child === o) return DOCUMENT_POSITION_PRECEDING;
+			if (aa.indexOf(child) >= 0) return DOCUMENT_POSITION_FOLLOWING;
+			if (ab.indexOf(child) >= 0) return DOCUMENT_POSITION_PRECEDING;
+		}
+		return 0;
 	},
 };
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var conventions = require('./conventions');
-var crypto = require('crypto');
 var find = conventions.find;
 var isHTMLRawTextElement = conventions.isHTMLRawTextElement;
 var isHTMLVoidElement = conventions.isHTMLVoidElement;
@@ -178,7 +177,7 @@ function commonAncestor(a, b) {
  * @return {string} The document's guid.
  */
 function docGUID(doc) {
-	if (!doc.guid) doc.guid = crypto.randomUUID();
+	if (!doc.guid) doc.guid = Math.random();
 	return doc.guid;
 }
 //-- end of helper functions
@@ -687,15 +686,19 @@ Node.prototype = {
                                 }
                         }
                 }
-		if (!node1 || !node2 || // Orphan attribute case.
-                    node2.ownerDocument !== node1.ownerDocument)
+		if (!node1 || !node2 || node2.ownerDocument !== node1.ownerDocument) {
 			return DOCUMENT_POSITION_DISCONNECTED +
-			DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
-			(docGUID(node2.ownerDocument) > docGUID(node1.ownerDocument) ? DOCUMENT_POSITION_FOLLOWING : DOCUMENT_POSITION_PRECEDING);
+			        DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC +
+			        (docGUID(node2.ownerDocument) > docGUID(node1.ownerDocument) ? DOCUMENT_POSITION_FOLLOWING : DOCUMENT_POSITION_PRECEDING);
+                }
 		const chain1 = parentChain(node1);
 		const chain2 = parentChain(node2);
-		if (chain2.indexOf(node1) >= 0) return DOCUMENT_POSITION_CONTAINS;
-		if (chain1.indexOf(node2) >= 0) return DOCUMENT_POSITION_CONTAINED_BY;
+	        if ((!attr1 && chain2.indexOf(node1) >= 0) || (attr2 && node1 === node2)) {
+                        return DOCUMENT_POSITION_CONTAINS + DOCUMENT_POSITION_PRECEDING;
+                }
+		if ((!attr2 && chain1.indexOf(node2) >= 0) || (attr1 && node1 === node2)) {
+                        return DOCUMENT_POSITION_CONTAINED_BY + DOCUMENT_POSITION_FOLLOWING;
+                }
 		var ca = commonAncestor(chain2, chain1);
 		for (var n in ca.childNodes) {
 			var child = ca.childNodes[n];

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -131,12 +131,13 @@ var NAMESPACE_ERR = (ExceptionCode.NAMESPACE_ERR = ((ExceptionMessage[14] = 'Inv
 var INVALID_ACCESS_ERR = (ExceptionCode.INVALID_ACCESS_ERR = ((ExceptionMessage[15] = 'Invalid access'), 15));
 
 // compareDocumentPosition bitmask results
-var DOCUMENT_POSITION_DISCONNECTED = 1;
-var DOCUMENT_POSITION_PRECEDING = 2;
-var DOCUMENT_POSITION_FOLLOWING = 4;
-var DOCUMENT_POSITION_CONTAINS = 8;
-var DOCUMENT_POSITION_CONTAINED_BY = 16;
-var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32;
+var DocumentPosition = {};
+var DOCUMENT_POSITION_DISCONNECTED = (DocumentPosition.DOCUMENT_POSITION_DISCONNECTED = 1);
+var DOCUMENT_POSITION_PRECEDING = (DocumentPosition.DOCUMENT_POSITION_PRECEDING = 2);
+var DOCUMENT_POSITION_FOLLOWING = (DocumentPosition.DOCUMENT_POSITION_FOLLOWING = 4);
+var DOCUMENT_POSITION_CONTAINS = (DocumentPosition.DOCUMENT_POSITION_CONTAINS = 8);
+var DOCUMENT_POSITION_CONTAINED_BY = (DocumentPosition.DOCUMENT_POSITION_CONTAINED_BY = 16);
+var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = (DocumentPosition.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32);
 
 //helper functions for compareDocumentPosition
 /**
@@ -144,7 +145,6 @@ var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32;
  * @param {Node} node The start node.
  * @return {Node[]} The parent chain.
  */
-//TODO: this can be members
 function parentChain(node) {
 	var chain = [];
 	while (node.parentNode || node.ownerElement) {
@@ -719,6 +719,8 @@ function _xmlEncoder(c) {
 
 copy(NodeType, Node);
 copy(NodeType, Node.prototype);
+copy(DocumentPosition, Node);
+copy(DocumentPosition, Node.prototype);
 
 /**
  * @param callback return true for continue,false for break

--- a/test/dom/dom-comparison.test.js
+++ b/test/dom/dom-comparison.test.js
@@ -5,86 +5,88 @@ const { DOMException } = require('../../lib/dom');
 // Tests following for steps in the specification
 // https://dom.spec.whatwg.org/#dom-node-comparedocumentposition
 describe('DOM position comparison', () => {
-        const dp = new DOMParser();
-        const x0 = dp.parseFromString(
-                '<x0 foo="a" bar="b">' +
-                        '<x1 foo="a" bar="b">' +
-                        '<x2 foo="a" bar="b">c</x2>' +
-                        '<y2 foo="a" bar="b">d</y2>' +
-                        '</x1>' +
-                        '<y1 foo="a" bar="b">' +
-                        '<z2 foo="a" bar="b">e</z2>' +
-                        '</y1></x0>', 'text/xml').documentElement;
-        const x1 = x0.childNodes[0];
-        const y1 = x0.childNodes[1];
-        const x2 = x1.childNodes[0];
-        const y2 = x1.childNodes[1];
-        const z2 = y1.childNodes[0];
-        const foo = x0.attributes[0];
-        const bar = x0.attributes[1];
-        let text = x2.childNodes[0];
-        it('Step 1', () => {
-                expect(x0.compareDocumentPosition(x0)).toBe(0);
-                expect(x1.compareDocumentPosition(x1)).toBe(0);
-                expect(foo.compareDocumentPosition(foo)).toBe(0);
-                expect(text.compareDocumentPosition(text));
-        });
+	const dp = new DOMParser();
+	const x0 = dp.parseFromString(
+		'<x0 foo="a" bar="b">' +
+			'<x1 foo="a" bar="b">' +
+			'<x2 foo="a" bar="b">c</x2>' +
+			'<y2 foo="a" bar="b">d</y2>' +
+			'</x1>' +
+			'<y1 foo="a" bar="b">' +
+			'<z2 foo="a" bar="b">e</z2>' +
+			'</y1></x0>',
+		'text/xml'
+	).documentElement;
+	const x1 = x0.childNodes[0];
+	const y1 = x0.childNodes[1];
+	const x2 = x1.childNodes[0];
+	const y2 = x1.childNodes[1];
+	const z2 = y1.childNodes[0];
+	const foo = x0.attributes[0];
+	const bar = x0.attributes[1];
+	let text = x2.childNodes[0];
+	it('Step 1', () => {
+		expect(x0.compareDocumentPosition(x0)).toBe(0);
+		expect(x1.compareDocumentPosition(x1)).toBe(0);
+		expect(foo.compareDocumentPosition(foo)).toBe(0);
+		expect(text.compareDocumentPosition(text));
+	});
 	it('Step 5 2 1 1', async () => {
-                let result = x0.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + x0.DOCUMENT_POSITION_PRECEDING;
-                expect(bar.compareDocumentPosition(foo)).toBe(result);
-        });
+		let result = x0.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + x0.DOCUMENT_POSITION_PRECEDING;
+		expect(bar.compareDocumentPosition(foo)).toBe(result);
+	});
 	it('Step 5 2 1 2', async () => {
-                let result = x0.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + x0.DOCUMENT_POSITION_FOLLOWING;
-                expect(foo.compareDocumentPosition(bar)).toBe(result);
-        });
+		let result = x0.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + x0.DOCUMENT_POSITION_FOLLOWING;
+		expect(foo.compareDocumentPosition(bar)).toBe(result);
+	});
 	it('Step 6', () => {
-                let result = x0.DOCUMENT_POSITION_DISCONNECTED + x0.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
-                let resPre = result + x0.DOCUMENT_POSITION_PRECEDING;
-                let resFol = result + x0.DOCUMENT_POSITION_FOLLOWING;
-	        const root = dp.parseFromString('<xml><baz abaz="y"></baz></xml>', 'text/xml').documentElement;
-                const baz = root.childNodes[0];
-                const abaz = baz.attributes[0];
-                // This ensures the comparison is stable.
-                let comp = x0.compareDocumentPosition(root) === resPre;
-                expect(x0.compareDocumentPosition(root)).toBe(comp ? resPre : resFol);
-                expect(root.compareDocumentPosition(x0)).toBe(comp ? resFol : resPre);
-                expect(x1.compareDocumentPosition(baz)).toBe(comp ? resPre : resFol);
-                expect(baz.compareDocumentPosition(x1)).toBe(comp ? resFol : resPre);
-                expect(foo.compareDocumentPosition(abaz)).toBe(comp ? resPre : resFol);
-                expect(abaz.compareDocumentPosition(foo)).toBe(comp ? resFol : resPre);
-        });
-        it('Step 7', () => {
-                let result = x0.DOCUMENT_POSITION_CONTAINS + x0.DOCUMENT_POSITION_PRECEDING;
-                expect(x1.compareDocumentPosition(x0)).toBe(result);
-                expect(x2.compareDocumentPosition(x0)).toBe(result);
-                expect(x2.compareDocumentPosition(x1)).toBe(result);
-                expect(foo.compareDocumentPosition(x0)).toBe(result);
-        });
-        it('Step 8', () => {
-                let result = x0.DOCUMENT_POSITION_CONTAINED_BY + x0.DOCUMENT_POSITION_FOLLOWING;
-                expect(x0.compareDocumentPosition(x1)).toBe(20);
-                expect(x0.compareDocumentPosition(x2)).toBe(20);
-                expect(x1.compareDocumentPosition(x2)).toBe(20);
-                expect(x0.compareDocumentPosition(foo)).toBe(20);
-        });
-        it('Step 9', () => {
-                let result = x0.DOCUMENT_POSITION_PRECEDING;
-                expect(y1.compareDocumentPosition(x1)).toBe(result);
-                expect(y1.compareDocumentPosition(x2)).toBe(result);
-                expect(z2.compareDocumentPosition(x2)).toBe(result);
-                expect(z2.compareDocumentPosition(x1)).toBe(result);
-                expect(y1.compareDocumentPosition(x1.attributes[0])).toBe(result);
-                expect(x1.attributes[0].compareDocumentPosition(foo)).toBe(result);
-                expect(y1.attributes[0].compareDocumentPosition(foo)).toBe(result);
-        });
-        it('Step 10', () => {
-                let result = x0.DOCUMENT_POSITION_FOLLOWING;
-                expect(x1.compareDocumentPosition(y1)).toBe(result);
-                expect(x2.compareDocumentPosition(y1)).toBe(result);
-                expect(x2.compareDocumentPosition(z2)).toBe(result);
-                expect(x1.compareDocumentPosition(z2)).toBe(result);
-                expect(x1.attributes[0].compareDocumentPosition(y1)).toBe(result);
-                expect(foo.compareDocumentPosition(x1.attributes[0])).toBe(result);
-                expect(foo.compareDocumentPosition(y1.attributes[0])).toBe(result);
-        });
+		let result = x0.DOCUMENT_POSITION_DISCONNECTED + x0.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+		let resPre = result + x0.DOCUMENT_POSITION_PRECEDING;
+		let resFol = result + x0.DOCUMENT_POSITION_FOLLOWING;
+		const root = dp.parseFromString('<xml><baz abaz="y"></baz></xml>', 'text/xml').documentElement;
+		const baz = root.childNodes[0];
+		const abaz = baz.attributes[0];
+		// This ensures the comparison is stable.
+		let comp = x0.compareDocumentPosition(root) === resPre;
+		expect(x0.compareDocumentPosition(root)).toBe(comp ? resPre : resFol);
+		expect(root.compareDocumentPosition(x0)).toBe(comp ? resFol : resPre);
+		expect(x1.compareDocumentPosition(baz)).toBe(comp ? resPre : resFol);
+		expect(baz.compareDocumentPosition(x1)).toBe(comp ? resFol : resPre);
+		expect(foo.compareDocumentPosition(abaz)).toBe(comp ? resPre : resFol);
+		expect(abaz.compareDocumentPosition(foo)).toBe(comp ? resFol : resPre);
+	});
+	it('Step 7', () => {
+		let result = x0.DOCUMENT_POSITION_CONTAINS + x0.DOCUMENT_POSITION_PRECEDING;
+		expect(x1.compareDocumentPosition(x0)).toBe(result);
+		expect(x2.compareDocumentPosition(x0)).toBe(result);
+		expect(x2.compareDocumentPosition(x1)).toBe(result);
+		expect(foo.compareDocumentPosition(x0)).toBe(result);
+	});
+	it('Step 8', () => {
+		let result = x0.DOCUMENT_POSITION_CONTAINED_BY + x0.DOCUMENT_POSITION_FOLLOWING;
+		expect(x0.compareDocumentPosition(x1)).toBe(20);
+		expect(x0.compareDocumentPosition(x2)).toBe(20);
+		expect(x1.compareDocumentPosition(x2)).toBe(20);
+		expect(x0.compareDocumentPosition(foo)).toBe(20);
+	});
+	it('Step 9', () => {
+		let result = x0.DOCUMENT_POSITION_PRECEDING;
+		expect(y1.compareDocumentPosition(x1)).toBe(result);
+		expect(y1.compareDocumentPosition(x2)).toBe(result);
+		expect(z2.compareDocumentPosition(x2)).toBe(result);
+		expect(z2.compareDocumentPosition(x1)).toBe(result);
+		expect(y1.compareDocumentPosition(x1.attributes[0])).toBe(result);
+		expect(x1.attributes[0].compareDocumentPosition(foo)).toBe(result);
+		expect(y1.attributes[0].compareDocumentPosition(foo)).toBe(result);
+	});
+	it('Step 10', () => {
+		let result = x0.DOCUMENT_POSITION_FOLLOWING;
+		expect(x1.compareDocumentPosition(y1)).toBe(result);
+		expect(x2.compareDocumentPosition(y1)).toBe(result);
+		expect(x2.compareDocumentPosition(z2)).toBe(result);
+		expect(x1.compareDocumentPosition(z2)).toBe(result);
+		expect(x1.attributes[0].compareDocumentPosition(y1)).toBe(result);
+		expect(foo.compareDocumentPosition(x1.attributes[0])).toBe(result);
+		expect(foo.compareDocumentPosition(y1.attributes[0])).toBe(result);
+	});
 });

--- a/test/dom/dom-comparison.test.js
+++ b/test/dom/dom-comparison.test.js
@@ -30,52 +30,61 @@ describe('DOM position comparison', () => {
                 expect(text.compareDocumentPosition(text));
         });
 	it('Step 5 2 1 1', async () => {
-                expect(bar.compareDocumentPosition(foo)).toBe(34);
+                let result = x0.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + x0.DOCUMENT_POSITION_PRECEDING;
+                expect(bar.compareDocumentPosition(foo)).toBe(result);
         });
 	it('Step 5 2 1 2', async () => {
-                expect(foo.compareDocumentPosition(bar)).toBe(36);
+                let result = x0.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC + x0.DOCUMENT_POSITION_FOLLOWING;
+                expect(foo.compareDocumentPosition(bar)).toBe(result);
         });
 	it('Step 6', () => {
+                let result = x0.DOCUMENT_POSITION_DISCONNECTED + x0.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+                let resPre = result + x0.DOCUMENT_POSITION_PRECEDING;
+                let resFol = result + x0.DOCUMENT_POSITION_FOLLOWING;
 	        const root = dp.parseFromString('<xml><baz abaz="y"></baz></xml>', 'text/xml').documentElement;
                 const baz = root.childNodes[0];
                 const abaz = baz.attributes[0];
                 // This ensures the comparison is stable.
-                let comp = x0.compareDocumentPosition(root) === 35;
-                expect(x0.compareDocumentPosition(root)).toBe(comp ? 35 : 37);
-                expect(root.compareDocumentPosition(x0)).toBe(comp ? 37 : 35);
-                expect(x1.compareDocumentPosition(baz)).toBe(comp ? 35 : 37);
-                expect(baz.compareDocumentPosition(x1)).toBe(comp ? 37 : 35);
-                expect(foo.compareDocumentPosition(abaz)).toBe(comp ? 35 : 37);
-                expect(abaz.compareDocumentPosition(foo)).toBe(comp ? 37 : 35);
+                let comp = x0.compareDocumentPosition(root) === resPre;
+                expect(x0.compareDocumentPosition(root)).toBe(comp ? resPre : resFol);
+                expect(root.compareDocumentPosition(x0)).toBe(comp ? resFol : resPre);
+                expect(x1.compareDocumentPosition(baz)).toBe(comp ? resPre : resFol);
+                expect(baz.compareDocumentPosition(x1)).toBe(comp ? resFol : resPre);
+                expect(foo.compareDocumentPosition(abaz)).toBe(comp ? resPre : resFol);
+                expect(abaz.compareDocumentPosition(foo)).toBe(comp ? resFol : resPre);
         });
         it('Step 7', () => {
-                expect(x1.compareDocumentPosition(x0)).toBe(10);
-                expect(x2.compareDocumentPosition(x0)).toBe(10);
-                expect(x2.compareDocumentPosition(x1)).toBe(10);
-                expect(foo.compareDocumentPosition(x0)).toBe(10);
+                let result = x0.DOCUMENT_POSITION_CONTAINS + x0.DOCUMENT_POSITION_PRECEDING;
+                expect(x1.compareDocumentPosition(x0)).toBe(result);
+                expect(x2.compareDocumentPosition(x0)).toBe(result);
+                expect(x2.compareDocumentPosition(x1)).toBe(result);
+                expect(foo.compareDocumentPosition(x0)).toBe(result);
         });
         it('Step 8', () => {
+                let result = x0.DOCUMENT_POSITION_CONTAINED_BY + x0.DOCUMENT_POSITION_FOLLOWING;
                 expect(x0.compareDocumentPosition(x1)).toBe(20);
                 expect(x0.compareDocumentPosition(x2)).toBe(20);
                 expect(x1.compareDocumentPosition(x2)).toBe(20);
                 expect(x0.compareDocumentPosition(foo)).toBe(20);
         });
         it('Step 9', () => {
-                expect(y1.compareDocumentPosition(x1)).toBe(2);
-                expect(y1.compareDocumentPosition(x2)).toBe(2);
-                expect(z2.compareDocumentPosition(x2)).toBe(2);
-                expect(z2.compareDocumentPosition(x1)).toBe(2);
-                expect(y1.compareDocumentPosition(x1.attributes[0])).toBe(2);
-                expect(x1.attributes[0].compareDocumentPosition(foo)).toBe(2);
-                expect(y1.attributes[0].compareDocumentPosition(foo)).toBe(2);
+                let result = x0.DOCUMENT_POSITION_PRECEDING;
+                expect(y1.compareDocumentPosition(x1)).toBe(result);
+                expect(y1.compareDocumentPosition(x2)).toBe(result);
+                expect(z2.compareDocumentPosition(x2)).toBe(result);
+                expect(z2.compareDocumentPosition(x1)).toBe(result);
+                expect(y1.compareDocumentPosition(x1.attributes[0])).toBe(result);
+                expect(x1.attributes[0].compareDocumentPosition(foo)).toBe(result);
+                expect(y1.attributes[0].compareDocumentPosition(foo)).toBe(result);
         });
         it('Step 10', () => {
-                expect(x1.compareDocumentPosition(y1)).toBe(4);
-                expect(x2.compareDocumentPosition(y1)).toBe(4);
-                expect(x2.compareDocumentPosition(z2)).toBe(4);
-                expect(x1.compareDocumentPosition(z2)).toBe(4);
-                expect(x1.attributes[0].compareDocumentPosition(y1)).toBe(4);
-                expect(foo.compareDocumentPosition(x1.attributes[0])).toBe(4);
-                expect(foo.compareDocumentPosition(y1.attributes[0])).toBe(4);
+                let result = x0.DOCUMENT_POSITION_FOLLOWING;
+                expect(x1.compareDocumentPosition(y1)).toBe(result);
+                expect(x2.compareDocumentPosition(y1)).toBe(result);
+                expect(x2.compareDocumentPosition(z2)).toBe(result);
+                expect(x1.compareDocumentPosition(z2)).toBe(result);
+                expect(x1.attributes[0].compareDocumentPosition(y1)).toBe(result);
+                expect(foo.compareDocumentPosition(x1.attributes[0])).toBe(result);
+                expect(foo.compareDocumentPosition(y1.attributes[0])).toBe(result);
         });
 });

--- a/test/dom/dom-comparison.test.js
+++ b/test/dom/dom-comparison.test.js
@@ -1,0 +1,81 @@
+'use strict';
+const { DOMParser } = require('../../lib');
+const { DOMException } = require('../../lib/dom');
+
+// Tests following for steps in the specification
+// https://dom.spec.whatwg.org/#dom-node-comparedocumentposition
+describe('DOM position comparison', () => {
+        const dp = new DOMParser();
+        const x0 = dp.parseFromString(
+                '<x0 foo="a" bar="b">' +
+                        '<x1 foo="a" bar="b">' +
+                        '<x2 foo="a" bar="b">c</x2>' +
+                        '<y2 foo="a" bar="b">d</y2>' +
+                        '</x1>' +
+                        '<y1 foo="a" bar="b">' +
+                        '<z2 foo="a" bar="b">e</z2>' +
+                        '</y1></x0>', 'text/xml').documentElement;
+        const x1 = x0.childNodes[0];
+        const y1 = x0.childNodes[1];
+        const x2 = x1.childNodes[0];
+        const y2 = x1.childNodes[1];
+        const z2 = y1.childNodes[0];
+        const foo = x0.attributes[0];
+        const bar = x0.attributes[1];
+        let text = x2.childNodes[0];
+        it('Step 1', () => {
+                expect(x0.compareDocumentPosition(x0)).toBe(0);
+                expect(x1.compareDocumentPosition(x1)).toBe(0);
+                expect(foo.compareDocumentPosition(foo)).toBe(0);
+                expect(text.compareDocumentPosition(text));
+        });
+	it('Step 5 2 1 1', async () => {
+                expect(bar.compareDocumentPosition(foo)).toBe(34);
+        });
+	it('Step 5 2 1 2', async () => {
+                expect(foo.compareDocumentPosition(bar)).toBe(36);
+        });
+	it('Step 6', () => {
+	        const root = dp.parseFromString('<xml><baz abaz="y"></baz></xml>', 'text/xml').documentElement;
+                const baz = root.childNodes[0];
+                const abaz = baz.attributes[0];
+                // This ensures the comparison is stable.
+                let comp = x0.compareDocumentPosition(root) === 35;
+                expect(x0.compareDocumentPosition(root)).toBe(comp ? 35 : 37);
+                expect(root.compareDocumentPosition(x0)).toBe(comp ? 37 : 35);
+                expect(x1.compareDocumentPosition(baz)).toBe(comp ? 35 : 37);
+                expect(baz.compareDocumentPosition(x1)).toBe(comp ? 37 : 35);
+                expect(foo.compareDocumentPosition(abaz)).toBe(comp ? 35 : 37);
+                expect(abaz.compareDocumentPosition(foo)).toBe(comp ? 37 : 35);
+        });
+        it('Step 7', () => {
+                expect(x1.compareDocumentPosition(x0)).toBe(10);
+                expect(x2.compareDocumentPosition(x0)).toBe(10);
+                expect(x2.compareDocumentPosition(x1)).toBe(10);
+                expect(foo.compareDocumentPosition(x0)).toBe(10);
+        });
+        it('Step 8', () => {
+                expect(x0.compareDocumentPosition(x1)).toBe(20);
+                expect(x0.compareDocumentPosition(x2)).toBe(20);
+                expect(x1.compareDocumentPosition(x2)).toBe(20);
+                expect(x0.compareDocumentPosition(foo)).toBe(20);
+        });
+        it('Step 9', () => {
+                expect(y1.compareDocumentPosition(x1)).toBe(2);
+                expect(y1.compareDocumentPosition(x2)).toBe(2);
+                expect(z2.compareDocumentPosition(x2)).toBe(2);
+                expect(z2.compareDocumentPosition(x1)).toBe(2);
+                expect(y1.compareDocumentPosition(x1.attributes[0])).toBe(2);
+                expect(x1.attributes[0].compareDocumentPosition(foo)).toBe(2);
+                expect(y1.attributes[0].compareDocumentPosition(foo)).toBe(2);
+        });
+        it('Step 10', () => {
+                expect(x1.compareDocumentPosition(y1)).toBe(4);
+                expect(x2.compareDocumentPosition(y1)).toBe(4);
+                expect(x2.compareDocumentPosition(z2)).toBe(4);
+                expect(x1.compareDocumentPosition(z2)).toBe(4);
+                expect(x1.attributes[0].compareDocumentPosition(y1)).toBe(4);
+                expect(foo.compareDocumentPosition(x1.attributes[0])).toBe(4);
+                expect(foo.compareDocumentPosition(y1.attributes[0])).toBe(4);
+        });
+});


### PR DESCRIPTION
The PR adds an implementation of level 3 method [`compareDocumentPosition`](https://dom.spec.whatwg.org/#dom-node-comparedocumentposition). This is an updated version of the code suggested in https://github.com/jindw/xmldom/pull/113

The code ran for many years error-free in [Speech Rule Engine](https://github.com/speech-rule-engine/speech-rule-engine) together with  [wicked-good-xpath](https://github.com/google/wicked-good-xpath).