### PR TITLE
test: make `toErrorSnapshot` windows compatible

### DIFF
--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -85,6 +85,6 @@ function toErrorSnapshot(error, libFile) {
 		// see `parseErrorLines` in `./reported.js` for how LINE_TO_ERROR_INDEX is created,
 		// and `./reported.json` (after running the tests) to inspect it.
 		.replace(new RegExp(`${libFile}:\\d+`), (fileAndLine) => {
-			return `${libFile}:#${fileAndLine in LINE_TO_ERROR_INDEX ? LINE_TO_ERROR_INDEX[fileAndLine].index : -1}`;
+			return `${libFile.replace(/\\/g, '/')}:#${fileAndLine in LINE_TO_ERROR_INDEX ? LINE_TO_ERROR_INDEX[fileAndLine].index : -1}`;
 		})}`;
 }

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -85,6 +85,8 @@ function toErrorSnapshot(error, libFile) {
 		// see `parseErrorLines` in `./reported.js` for how LINE_TO_ERROR_INDEX is created,
 		// and `./reported.json` (after running the tests) to inspect it.
 		.replace(new RegExp(`${libFile}:\\d+`), (fileAndLine) => {
-			return `${libFile.replace(/\\/g, '/')}:#${fileAndLine in LINE_TO_ERROR_INDEX ? LINE_TO_ERROR_INDEX[fileAndLine].index : -1}`;
+			return `${libFile.replace(/\\/g, '/')}:#${
+				fileAndLine in LINE_TO_ERROR_INDEX ? LINE_TO_ERROR_INDEX[fileAndLine].index : -1
+			}`;
 		})}`;
 }

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -2,6 +2,7 @@
 // wallaby:file.skip since stacktrace detection is not working in instrumented files
 const { describe, expect, test } = require('@jest/globals');
 
+const path = require('path');
 const { LINE_TO_ERROR_INDEX, REPORTED } = require('./reported');
 const { MIME_TYPE } = require('../../lib/conventions');
 const { DOMParser } = require('../../lib/dom-parser');
@@ -50,7 +51,7 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
 					const { parser } = getTestParser({ onError });
 
 					expect(() => parser.parseFromString(source, mimeType)).toThrow(ParseError);
-					expect(thrown.map((error) => toErrorSnapshot(error, 'lib/sax.js'))).toMatchSnapshot();
+					expect(thrown.map((error) => toErrorSnapshot(error, path.join('lib', 'sax.js')))).toMatchSnapshot();
 					match && expect(match(thrown[0].toString())).toBe(true);
 				});
 			}
@@ -70,7 +71,7 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
  * @returns {string}
  */
 function toErrorSnapshot(error, libFile) {
-	const libFileMatch = new RegExp(`\/.*\/(${libFile})`);
+	const libFileMatch = new RegExp(`[^(]*(${libFile})`);
 	return `${error.message.replace(/([\n\r]+\s*)/g, '||')}\n${error.stack
 		.split(/[\n\r]+/)
 		// find first line that is from lib/sax.js

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -1,5 +1,6 @@
 'use strict';
 const fs = require('fs');
+const path = require('path');
 
 /**
  * @typedef ErrorReport
@@ -263,7 +264,7 @@ const LINE_TO_ERROR_INDEX = {
  */
 function parseErrorLines(fileNameInKey) {
 	let errorIndex = 0;
-	const source = fs.readFileSync(`${__dirname}/../../${fileNameInKey}`, 'utf8').split('\n');
+	const source = fs.readFileSync(path.join(__dirname, '..', '..', fileNameInKey), 'utf8').split('\n');
 	source.forEach((lineFull, lineNumber) => {
 		const line = lineFull.trim();
 		if (/^(\/\/|\/\*|\* ?)/.test(line) || line.length === 0) {
@@ -306,9 +307,9 @@ function parseErrorLines(fileNameInKey) {
 			throw new Error(`line not mapped: ${lineKey} reportedAs $${key}`);
 		}
 	});
-	fs.writeFileSync(`${__dirname}/reported.json`, JSON.stringify(LINE_TO_ERROR_INDEX, null, 2), 'utf8');
+	fs.writeFileSync(path.join(__dirname, 'reported.json'), JSON.stringify(LINE_TO_ERROR_INDEX, null, 2), 'utf8');
 }
-parseErrorLines('lib/sax.js');
+parseErrorLines(path.join('lib', 'sax.js'));
 
 module.exports = {
 	LINE_TO_ERROR_INDEX,


### PR DESCRIPTION
@shunkica [told me in #498](https://github.com/xmldom/xmldom/pull/498#issuecomment-1615221065) that `toErrorSnapshot` doesn't work on windows

- cater for windows backslash in file paths
- handle windows backslash before passing it to regular expressions
- convert to unix delimiter before returning the value for OS independent snapshots
- refactor to use understandable variable names for each step