### PR TITLE
chore: use prettier plugin for jsdoc

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -4,7 +4,9 @@ trailingComma: es5
 singleQuote: true
 plugins:
   - '@homer0/prettier-plugin-jsdoc'
-jsdocUseColumns: false
+# plugin specific options
+jsdocAllowAccessTag: false
+jsdocPrintWidth: 95
 jsdocTagsOrder:
   - deprecated
   - type
@@ -45,4 +47,4 @@ jsdocTagsOrder:
   - see
   - other
   - todo
-jsdocAllowAccessTag: false
+jsdocUseColumns: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -2,5 +2,3 @@ useTabs: true
 semi: true
 trailingComma: es5
 singleQuote: true
-plugins:
-  - prettier-plugin-jsdoc

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -2,3 +2,5 @@ useTabs: true
 semi: true
 trailingComma: es5
 singleQuote: true
+plugins:
+  - prettier-plugin-jsdoc

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -4,3 +4,4 @@ trailingComma: es5
 singleQuote: true
 plugins:
   - '@homer0/prettier-plugin-jsdoc'
+jsdocUseColumns: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -2,3 +2,5 @@ useTabs: true
 semi: true
 trailingComma: es5
 singleQuote: true
+plugins:
+  - '@homer0/prettier-plugin-jsdoc'

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -5,3 +5,43 @@ singleQuote: true
 plugins:
   - '@homer0/prettier-plugin-jsdoc'
 jsdocUseColumns: false
+jsdocTagsOrder:
+  - deprecated
+  - type
+  - typedef
+  - callback
+  - function
+  - method
+  - class
+  - file
+  - constant
+  - description
+  - classdesc
+  - example
+  - param
+  - property
+  - returns
+  - template
+  - augments
+  - extends
+  - throws
+  - yields
+  - fires
+  - listens
+  - async
+  - abstract
+  - override
+  - private
+  - protected
+  - public
+  - access
+  - author
+  - version
+  - since
+  - member
+  - memberof
+  - category
+  - external
+  - see
+  - other
+  - todo

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -45,3 +45,4 @@ jsdocTagsOrder:
   - see
   - other
   - todo
+jsdocAllowAccessTag: false

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ declare module '@xmldom/xmldom' {
 	 *      MDN
 	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparsersupportedtype
 	 *   WHATWG HTML Spec
-	 * @see DOMParser.prototype.parseFromString.
+	 * @see {@link DOMParser.prototype.parseFromString}
 	 */
 	enum MIME_TYPE {
 		/**
@@ -377,7 +377,7 @@ declare module '@xmldom/xmldom' {
 	 * A method that prevents any further parsing when an `error`
 	 * with level `error` is reported during parsing.
 	 *
-	 * @see {@link DOMParserOptions.onError.
+	 * @see {@link DOMParserOptions.onError}
 	 * @see {@link onWarningStopParsing}
 	 */
 	function onErrorStopParsing(): void | never;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,12 +6,12 @@ declare module '@xmldom/xmldom' {
 	 * Since xmldom can not rely on `Object.assign`,
 	 * it uses/provides a simplified version that is sufficient for its needs.
 	 *
-	 * @throws TypeError if target is not an object
-	 *
+	 * @throws {TypeError}
+	 * If target is not an object.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 	 * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
 	 */
-	function assign<T, S>(target:T, source:S): T & S;
+	function assign<T, S>(target: T, source: S): T & S;
 	/**
 	 * Only returns true if `value` matches MIME_TYPE.HTML, which indicates an HTML document.
 	 *
@@ -29,9 +29,11 @@ declare module '@xmldom/xmldom' {
 	/**
 	 * All mime types that are allowed as input to `DOMParser.parseFromString`
 	 *
-	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02 MDN
-	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparsersupportedtype WHATWG HTML Spec
-	 * @see DOMParser.prototype.parseFromString
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02
+	 *      MDN
+	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparsersupportedtype
+	 *   WHATWG HTML Spec
+	 * @see DOMParser.prototype.parseFromString.
 	 */
 	enum MIME_TYPE {
 		/**
@@ -40,13 +42,15 @@ declare module '@xmldom/xmldom' {
 		 * @see https://www.iana.org/assignments/media-types/text/html IANA MimeType registration
 		 * @see https://en.wikipedia.org/wiki/HTML Wikipedia
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString MDN
-		 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring WHATWG HTML Spec
+		 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring
+		 *   WHATWG HTML Spec
 		 */
 		HTML = 'text/html',
 		/**
 		 * `application/xml`, the standard mime type for XML documents.
 		 *
-		 * @see https://www.iana.org/assignments/media-types/application/xml IANA MimeType registration
+		 * @see https://www.iana.org/assignments/media-types/application/xml IANA MimeType
+		 *      registration
 		 * @see https://tools.ietf.org/html/rfc7303#section-9.1 RFC 7303
 		 * @see https://en.wikipedia.org/wiki/XML_and_MIME Wikipedia
 		 */
@@ -63,7 +67,8 @@ declare module '@xmldom/xmldom' {
 		 * `application/xhtml+xml`, indicates an XML document that has the default HTML namespace,
 		 * but is parsed as an XML document.
 		 *
-		 * @see https://www.iana.org/assignments/media-types/application/xhtml+xml IANA MimeType registration
+		 * @see https://www.iana.org/assignments/media-types/application/xhtml+xml IANA MimeType
+		 *      registration
 		 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument WHATWG DOM Spec
 		 * @see https://en.wikipedia.org/wiki/XHTML Wikipedia
 		 */
@@ -103,7 +108,7 @@ declare module '@xmldom/xmldom' {
 		XML = 'http://www.w3.org/XML/1998/namespace',
 
 		/**
-		 * The `xmlns:` namespace
+		 * The `xmlns:` namespace.
 		 *
 		 * @see https://www.w3.org/2000/xmlns/
 		 */
@@ -114,13 +119,14 @@ declare module '@xmldom/xmldom' {
 	 * A custom error that will not be caught by XMLReader aka the SAX parser.
 	 */
 	class ParseError extends Error {
-		constructor(message:string, locator?:any);
+		constructor(message: string, locator?: any);
 	}
 	// END ./lib/conventions.js
 
 	// START ./lib/dom.js
 	/**
 	 * The error class for errors reported by the DOM API.
+	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMException
 	 * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/ecma-script-binding.html
 	 * @see http://www.w3.org/TR/REC-DOM-Level-1/ecma-script-language-binding.html
@@ -131,17 +137,16 @@ declare module '@xmldom/xmldom' {
 
 	interface DOMImplementation {
 		/**
-		 * The DOMImplementation interface represents an object providing methods
-		 * which are not dependent on any particular document.
+		 * The DOMImplementation interface represents an object providing methods which are not
+		 * dependent on any particular document.
 		 * Such an object is returned by the `Document.implementation` property.
 		 *
-		 * __The individual methods describe the differences compared to the specs.__
+		 * __The individual methods describe the differences compared to the specs.__.
 		 *
-		 * @constructor
-		 *
+		 * @class
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation MDN
-		 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-102161490 DOM Level 1 Core
-		 *   (Initial)
+		 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-102161490 DOM Level 1
+		 *      Core (Initial)
 		 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-102161490 DOM Level 2 Core
 		 * @see https://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-102161490 DOM Level 3 Core
 		 * @see https://dom.spec.whatwg.org/#domimplementation DOM Living Standard
@@ -156,14 +161,12 @@ declare module '@xmldom/xmldom' {
 		 * `type` set to `'xml'`).
 		 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 		 *
-		 * @returns {Document} the XML document
-		 *
-		 * @see DOMImplementation.createHTMLDocument
-		 *
+		 * @returns {Document} The XML document.
+		 * @see {@link DOMImplementation.createHTMLDocument}
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
 		 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM
-		 *   Level 2 Core (initial)
-		 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument  DOM Level 2 Core
+		 *      Level 2 Core (initial)
+		 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument DOM Level 2 Core
 		 */
 		createDocument(
 			namespaceURI: string | null,
@@ -178,15 +181,14 @@ declare module '@xmldom/xmldom' {
 		 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 		 *
 		 * @returns {DocumentType} which can either be used with `DOMImplementation.createDocument`
-		 *   upon document creation or can be put into the document via methods like
-		 *   `Node.insertBefore()` or `Node.replaceChild()`
-		 *
+		 *                         upon document creation or can be put into the document via methods
+		 *                         like `Node.insertBefore()` or `Node.replaceChild()`
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType
-		 *   MDN
+		 *      MDN
 		 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocType DOM
-		 *   Level 2 Core
+		 *      Level 2 Core
 		 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype DOM Living
-		 *   Standard
+		 *      Standard
 		 */
 		createDocumentType(
 			qualifiedName: string,
@@ -202,8 +204,7 @@ declare module '@xmldom/xmldom' {
 		 * omitted)
 		 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 		 *
-		 * @see DOMImplementation.createDocument
-		 *
+		 * @see {@link DOMImplementation.createDocument}
 		 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 		 * @see https://dom.spec.whatwg.org/#html-document
 		 */
@@ -211,14 +212,15 @@ declare module '@xmldom/xmldom' {
 
 		/**
 		 * The DOMImplementation.hasFeature() method returns a Boolean flag indicating if a given
-		 * feature is supported. The different implementations fairly diverged in what kind of features
-		 * were reported. The latest version of the spec settled to force this method to always return
-		 * true, where the functionality was accurate and in use.
+		 * feature is supported. The different implementations fairly diverged in what kind of
+		 * features were reported. The latest version of the spec settled to force this method to
+		 * always return true, where the functionality was accurate and in use.
 		 *
-		 * @deprecated It is deprecated and modern browsers return true in all cases.
-		 *
+		 * @deprecated
+		 * It is deprecated and modern browsers return true in all cases.
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
-		 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
+		 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1
+		 *      Core
 		 * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
 		 */
 		hasFeature(feature: string, version?: string): true;
@@ -234,15 +236,14 @@ declare module '@xmldom/xmldom' {
 	var DOMParser: DOMParserStatic;
 	interface DOMParserStatic {
 		/**
-		 * The DOMParser interface provides the ability to parse XML or HTML source code
-		 * from a string into a DOM `Document`.
+		 * The DOMParser interface provides the ability to parse XML or HTML source code from a
+		 * string into a DOM `Document`.
 		 *
 		 * _xmldom is different from the spec in that it allows an `options` parameter,
-		 * to control the behavior._
+		 * to control the behavior._.
 		 *
+		 * @class
 		 * @param {DOMParserOptions} [options]
-		 * @constructor
-		 *
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
 		 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
 		 */
@@ -250,37 +251,41 @@ declare module '@xmldom/xmldom' {
 	}
 
 	/**
-	 * The DOMParser interface provides the ability to parse XML or HTML source code
-	 * from a string into a DOM `Document`.
+	 * The DOMParser interface provides the ability to parse XML or HTML source code from a string
+	 * into a DOM `Document`.
 	 *
 	 * _xmldom is different from the spec in that it allows an `options` parameter,
-	 * to control the behavior._
+	 * to control the behavior._.
 	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
 	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
 	 */
 	interface DOMParser {
 		/**
-		 * Parses `source` using the options in the way configured by the `DOMParserOptions` of `this`
+		 * Parses `source` using the options in the way configured by the `DOMParserOptions` of
+		 * `this`
 		 * `DOMParser`. If `mimeType` is `text/html` an HTML `Document` is created, otherwise an XML
 		 * `Document` is created.
 		 *
 		 * __It behaves different from the description in the living standard__:
-		 * - Uses the `options` passed to the `DOMParser` constructor to modify the
-		 *   behavior.
-		 * - Any unexpected input is reported to `onError` with either a `warning`, `error` or `fatalError` level.
-		 *   - Any `fatalError` throws a `ParseError` which prevents further processing.
-		 *   - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing
-		 * - If no `Document` was created during parsing it is reported as a `fatalError`.
+		 * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior.
+		 * - Any unexpected input is reported to `onError` with either a `warning`, `error` or
+		 * `fatalError` level.
+		 * - Any `fatalError` throws a `ParseError` which prevents further processing.
+		 * - Any error thrown by `onError` is converted to a `ParseError` which prevents further
+		 * processing - If no `Document` was created during parsing it is reported as a `fatalError`.
 		 *
-		 * @throws ParseError for any `fatalError` or anything that is thrown by `onError`
-		 * @throws TypeError for any invalid `mimeType`
-		 * @returns the `Document` node
-		 *
+		 * @returns The `Document` node.
+		 * @throws {ParseError}
+		 * for any `fatalError` or anything that is thrown by `onError`
+		 * @throws {TypeError} for any invalid `mimeType`
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
 		 * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
 		 */
-		parseFromString(source: string, mimeType: MIME_TYPE = MIME_TYPE.XML_TEXT): Document;
+		parseFromString(
+			source: string,
+			mimeType: MIME_TYPE = MIME_TYPE.XML_TEXT
+		): Document;
 	}
 
 	interface XMLSerializer {
@@ -293,14 +298,14 @@ declare module '@xmldom/xmldom' {
 		 * which is used to copy values from the options before they are used for parsing.
 		 *
 		 * @private
-		 * @see conventions.assign
+		 * @see {@link conventions.assign}
 		 */
 		readonly assign?: typeof Object.assign;
 		/**
 		 * For internal testing: The class for creating an instance for handling events from the SAX
 		 * parser.
-		 * __**Warning: By configuring a faulty implementation,
-		 * the specified behavior can completely be broken.**__
+		 * *****Warning: By configuring a faulty implementation,
+		 * the specified behavior can completely be broken*****.
 		 *
 		 * @private
 		 */
@@ -312,8 +317,9 @@ declare module '@xmldom/xmldom' {
 		 * For backwards compatibility:
 		 * If it is a function, it will be used as a value for `onError`,
 		 * but it receives different argument types than before 0.9.0.
-		 * @throws If it is an object.
+		 *
 		 * @deprecated
+		 * @throws {TypeError} If it is an object.
 		 */
 		readonly errorHandler?: ErrorHandlerFunction;
 
@@ -339,15 +345,17 @@ declare module '@xmldom/xmldom' {
 		 * If the provided method throws, a `ParserError` is thrown,
 		 * which prevents any further processing.
 		 *
-		 * Be aware that many `warning`s are considered an error
-		 * that prevents further processing in most implementations.
+		 * Be aware that many `warning`s are considered an error that prevents further processing in
+		 * most implementations.
 		 *
-		 * @param level the error level as reported by the SAXParser
-		 * @param message the error message
-		 * @param context the DOMHandler instance used for parsing
-		 *
-		 * @see onErrorStopParsing
-		 * @see onWarningStopParsing
+		 * @param level
+		 * The error level as reported by the SAXParser.
+		 * @param message
+		 * The error message.
+		 * @param context
+		 * The DOMHandler instance used for parsing.
+		 * @see {@link onErrorStopParsing}
+		 * @see {@link onWarningStopParsing}
 		 */
 		readonly onError?: ErrorHandlerFunction;
 
@@ -369,16 +377,16 @@ declare module '@xmldom/xmldom' {
 	 * A method that prevents any further parsing when an `error`
 	 * with level `error` is reported during parsing.
 	 *
-	 * @see DOMParserOptions.onError
-	 * @see onWarningStopParsing
+	 * @see {@link DOMParserOptions.onError.
+	 * @see {@link onWarningStopParsing}
 	 */
 	function onErrorStopParsing(): void | never;
 	/**
 	 * A method that prevents any further parsing when an `error`
 	 * with any level is reported during parsing.
 	 *
-	 * @see DOMParserOptions.onError
-	 * @see onErrorStopParsing
+	 * @see {@link DOMParserOptions.onError}
+	 * @see {@link onErrorStopParsing}
 	 */
 	function onWarningStopParsing(): never;
 	// END ./lib/dom-parser.js

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -5,13 +5,13 @@
  *
  * Works with anything that has a `length` property and index access properties, including NodeList.
  *
- * @template {unknown} T
- * @param {Array<T> | ({length:number, [number]: T})} list
- * @param {function (item: T, index: number, list:Array<T> | ({length:number, [number]: T})):boolean} predicate
- * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac `Array.prototype` by default,
- * 				allows injecting a custom implementation in tests
+ * @param {T[] | { length: number; [number]: T }} list
+ * @param {function (item: T, index: number, list:T[] | ({length:number, [number]: T})):boolean} predicate
+ * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac
+ * `Array.prototype` by default,
+ * allows injecting a custom implementation in tests.
  * @returns {T | undefined}
- *
+ * @template {unknown} T
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
  * @see https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.find
  */
@@ -39,12 +39,13 @@ function find(list, predicate, ac) {
  *
  * Is used to create "enum like" objects.
  *
- * @template T
- * @param {T} object the object to freeze
- * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object] `Object` by default,
- * 				allows to inject custom object constructor for tests
+ * @param {T} object
+ * The object to freeze.
+ * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object]
+ * `Object` by default,
+ * allows to inject custom object constructor for tests.
  * @returns {Readonly<T>}
- *
+ * @template T
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
  */
 function freeze(object, oc) {
@@ -60,10 +61,9 @@ function freeze(object, oc) {
  *
  * @param {Object} target
  * @param {Object | null | undefined} source
- *
- * @returns {Object} target
- * @throws TypeError if target is not an object
- *
+ * @returns {Object} Target.
+ * @throws
+ * TypeError if target is not an object.
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
  */
@@ -84,8 +84,8 @@ function assign(target, source) {
  * The presence of a boolean attribute on an element represents the `true` value,
  * and the absence of the attribute represents the `false` value.
  *
- * If the attribute is present, its value must either be the empty string
- * or a value that is an ASCII case-insensitive match for the attribute's canonical name,
+ * If the attribute is present, its value must either be the empty string or a value that is an ASCII case-insensitive match for
+ * the attribute's canonical name,
  * with no leading or trailing whitespace.
  *
  * Note: The values `"true"` and `"false"` are not allowed on boolean attributes.
@@ -126,8 +126,8 @@ var HTML_BOOLEAN_ATTRIBUTES = freeze({
  * This method doesn't check if such attributes are allowed in the context of the current document/parsing.
  *
  * @param {string} name
- * @return {boolean}
- * @see HTML_BOOLEAN_ATTRIBUTES
+ * @returns {boolean}
+ * @see HTML_BOOLEAN_ATTRIBUTES.
  * @see https://html.spec.whatwg.org/#boolean-attributes
  * @see https://html.spec.whatwg.org/#attributes-3
  */
@@ -138,13 +138,28 @@ function isHTMLBooleanAttribute(name) {
 /**
  * Void elements only have a start tag; end tags must not be specified for void elements.
  * These elements should be written as self closing like this: `<area />`.
- * This should not be confused with optional tags that HTML allows to omit the end tag for
- * (like `li`, `tr` and others), which can have content after them,
+ * This should not be confused with optional tags that HTML allows to omit the end tag for (like `li`, `tr` and others), which can
+ * have content after them,
  * so they can not be written as self closing.
  * xmldom does not have any logic for optional end tags cases and will report them as a warning.
  * Content that would go into the unopened element will instead be added as a sibling text node.
  *
- * @type {Readonly<{area: boolean, col: boolean, img: boolean, wbr: boolean, link: boolean, hr: boolean, source: boolean, br: boolean, input: boolean, param: boolean, meta: boolean, embed: boolean, track: boolean, base: boolean}>}
+ * @type {Readonly<{
+ * 	area: boolean;
+ * 	col: boolean;
+ * 	img: boolean;
+ * 	wbr: boolean;
+ * 	link: boolean;
+ * 	hr: boolean;
+ * 	source: boolean;
+ * 	br: boolean;
+ * 	input: boolean;
+ * 	param: boolean;
+ * 	meta: boolean;
+ * 	embed: boolean;
+ * 	track: boolean;
+ * 	base: boolean;
+ * }>}
  * @see https://html.spec.whatwg.org/#void-elements
  * @see https://html.spec.whatwg.org/#optional-tags
  */
@@ -167,12 +182,11 @@ var HTML_VOID_ELEMENTS = freeze({
 
 /**
  * Check if `tagName` is matching one of the HTML void element names.
- * This method doesn't check if such tags are allowed
- * in the context of the current document/parsing.
+ * This method doesn't check if such tags are allowed in the context of the current document/parsing.
  *
  * @param {string} tagName
- * @return {boolean}
- * @see HTML_VOID_ELEMENTS
+ * @returns {boolean}
+ * @see HTML_VOID_ELEMENTS.
  * @see https://html.spec.whatwg.org/#void-elements
  */
 function isHTMLVoidElement(tagName) {
@@ -183,8 +197,8 @@ function isHTMLVoidElement(tagName) {
  * Tag names that are raw text elements according to HTML spec.
  * The value denotes whether they are escapable or not.
  *
- * @see isHTMLEscapableRawTextElement
- * @see isHTMLRawTextElement
+ * @see IsHTMLEscapableRawTextElement.
+ * @see IsHTMLRawTextElement.
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -197,13 +211,12 @@ var HTML_RAW_TEXT_ELEMENTS = freeze({
 
 /**
  * Check if `tagName` is matching one of the HTML raw text element names.
- * This method doesn't check if such tags are allowed
- * in the context of the current document/parsing.
+ * This method doesn't check if such tags are allowed in the context of the current document/parsing.
  *
  * @param {string} tagName
- * @return {boolean}
- * @see isHTMLEscapableRawTextElement
- * @see HTML_RAW_TEXT_ELEMENTS
+ * @returns {boolean}
+ * @see IsHTMLEscapableRawTextElement.
+ * @see HTML_RAW_TEXT_ELEMENTS.
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -213,13 +226,12 @@ function isHTMLRawTextElement(tagName) {
 }
 /**
  * Check if `tagName` is matching one of the HTML escapable raw text element names.
- * This method doesn't check if such tags are allowed
- * in the context of the current document/parsing.
+ * This method doesn't check if such tags are allowed in the context of the current document/parsing.
  *
  * @param {string} tagName
- * @return {boolean}
- * @see isHTMLRawTextElement
- * @see HTML_RAW_TEXT_ELEMENTS
+ * @returns {boolean}
+ * @see IsHTMLRawTextElement.
+ * @see HTML_RAW_TEXT_ELEMENTS.
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -232,7 +244,6 @@ function isHTMLEscapableRawTextElement(tagName) {
  *
  * @param {string} mimeType
  * @returns {mimeType is 'text/html'}
- *
  * @see https://www.iana.org/assignments/media-types/text/html
  * @see https://en.wikipedia.org/wiki/HTML
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
@@ -242,12 +253,11 @@ function isHTMLMimeType(mimeType) {
 	return mimeType === MIME_TYPE.HTML;
 }
 /**
- * For both the `text/html` and the `application/xhtml+xml` namespace
- * the spec defines that the HTML namespace is provided as the default.
+ * For both the `text/html` and the `application/xhtml+xml` namespace the spec defines that the HTML namespace is provided as the
+ * default.
  *
  * @param {string} mimeType
  * @returns {boolean}
- *
  * @see https://dom.spec.whatwg.org/#dom-document-createelement
  * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument
  * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
@@ -261,7 +271,7 @@ function hasDefaultHTMLNamespace(mimeType) {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02 MDN
  * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparsersupportedtype WHATWG HTML Spec
- * @see DOMParser.prototype.parseFromString
+ * @see DOMParser.prototype.parseFromString.
  */
 var MIME_TYPE = freeze({
 	/**
@@ -312,11 +322,11 @@ var MIME_TYPE = freeze({
 	XML_SVG_IMAGE: 'image/svg+xml',
 });
 /**
- * @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' |  'text/html' | 'text/xml'} MimeType
+ * @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' | 'text/html' | 'text/xml'} MimeType
  */
 /**
  * @type {MimeType[]}
- * @private
+ * @access private
  */
 var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 	return MIME_TYPE[key];
@@ -324,6 +334,7 @@ var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 
 /**
  * Only returns true if `mimeType` is one of the allowed values for `DOMParser.parseFromString`.
+ *
  * @param {string} mimeType
  * @returns {mimeType is 'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' |  'text/html' | 'text/xml'}
  */
@@ -358,7 +369,7 @@ var NAMESPACE = freeze({
 	XML: 'http://www.w3.org/XML/1998/namespace',
 
 	/**
-	 * The `xmlns:` namespace
+	 * The `xmlns:` namespace.
 	 *
 	 * @see https://www.w3.org/2000/xmlns/
 	 */
@@ -368,9 +379,10 @@ var NAMESPACE = freeze({
 /**
  * Creates an error that will not be caught by XMLReader aka the SAX parser.
  *
+ * @class
  * @param {string} message
- * @param {any?} locator Optional, can provide details about the location in the source
- * @constructor
+ * @param {any?} locator
+ * Optional, can provide details about the location in the source.
  */
 function ParseError(message, locator) {
 	this.message = message;

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -5,12 +5,12 @@
  *
  * Works with anything that has a `length` property and index access properties, including NodeList.
  *
+ * @template {unknown} T
  * @param {T[] | { length: number; [number]: T }} list
  * @param {function (item: T, index: number, list:(T)[] | ({length:number, [number]: T})):boolean} predicate
- * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac
- * `Array.prototype` by default, allows injecting a custom implementation in tests.
+ * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac `Array.prototype` by default, allows injecting a custom
+ *   implementation in tests
  * @returns {T | undefined}
- * @template {unknown} T
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
  * @see https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.find
  */
@@ -37,11 +37,11 @@ function find(list, predicate, ac) {
  *
  * Is used to create "enum like" objects.
  *
- * @param {T}                                 object       The object to freeze.
- * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object]  `Object` by default, allows to inject custom object constructor for
- *                                                         tests. Default is `Object`
- * @returns {Readonly<T>}
  * @template T
+ * @param {T} object The object to freeze
+ * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object] `Object` by default, allows to inject custom object constructor for
+ *   tests. Default is `Object`
+ * @returns {Readonly<T>}
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
  */
 function freeze(object, oc) {
@@ -54,10 +54,10 @@ function freeze(object, oc) {
 /**
  * Since xmldom can not rely on `Object.assign`, it uses/provides a simplified version that is sufficient for its needs.
  *
- * @param {Object}                    target
+ * @param {Object} target
  * @param {Object | null | undefined} source
- * @returns {Object} Target.
- * @throws TypeError if target is not an object.
+ * @returns {Object} Target
+ * @throws TypeError if target is not an object
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
  */
@@ -119,7 +119,7 @@ var HTML_BOOLEAN_ATTRIBUTES = freeze({
  *
  * @param {string} name
  * @returns {boolean}
- * @see HTML_BOOLEAN_ATTRIBUTES.
+ * @see HTML_BOOLEAN_ATTRIBUTES
  * @see https://html.spec.whatwg.org/#boolean-attributes
  * @see https://html.spec.whatwg.org/#attributes-3
  */
@@ -176,7 +176,7 @@ var HTML_VOID_ELEMENTS = freeze({
  *
  * @param {string} tagName
  * @returns {boolean}
- * @see HTML_VOID_ELEMENTS.
+ * @see HTML_VOID_ELEMENTS
  * @see https://html.spec.whatwg.org/#void-elements
  */
 function isHTMLVoidElement(tagName) {
@@ -186,8 +186,8 @@ function isHTMLVoidElement(tagName) {
 /**
  * Tag names that are raw text elements according to HTML spec. The value denotes whether they are escapable or not.
  *
- * @see IsHTMLEscapableRawTextElement.
- * @see IsHTMLRawTextElement.
+ * @see isHTMLEscapableRawTextElement
+ * @see isHTMLRawTextElement
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -204,8 +204,8 @@ var HTML_RAW_TEXT_ELEMENTS = freeze({
  *
  * @param {string} tagName
  * @returns {boolean}
- * @see IsHTMLEscapableRawTextElement.
- * @see HTML_RAW_TEXT_ELEMENTS.
+ * @see isHTMLEscapableRawTextElement
+ * @see HTML_RAW_TEXT_ELEMENTS
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -219,8 +219,8 @@ function isHTMLRawTextElement(tagName) {
  *
  * @param {string} tagName
  * @returns {boolean}
- * @see IsHTMLRawTextElement.
- * @see HTML_RAW_TEXT_ELEMENTS.
+ * @see isHTMLRawTextElement
+ * @see HTML_RAW_TEXT_ELEMENTS
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -260,7 +260,7 @@ function hasDefaultHTMLNamespace(mimeType) {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02 MDN
  * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparsersupportedtype WHATWG HTML Spec
- * @see DOMParser.prototype.parseFromString.
+ * @see DOMParser.prototype.parseFromString
  */
 var MIME_TYPE = freeze({
 	/**
@@ -309,12 +309,10 @@ var MIME_TYPE = freeze({
 	 */
 	XML_SVG_IMAGE: 'image/svg+xml',
 });
+/** @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' | 'text/html' | 'text/xml'} MimeType */
 /**
- * @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' | 'text/html' | 'text/xml'} MimeType
- */
-/**
+ * @private
  * @type {MimeType[]}
- * @access private
  */
 var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 	return MIME_TYPE[key];
@@ -357,7 +355,7 @@ var NAMESPACE = freeze({
 	XML: 'http://www.w3.org/XML/1998/namespace',
 
 	/**
-	 * The `xmlns:` namespace.
+	 * The `xmlns:` namespace
 	 *
 	 * @see https://www.w3.org/2000/xmlns/
 	 */
@@ -368,8 +366,8 @@ var NAMESPACE = freeze({
  * Creates an error that will not be caught by XMLReader aka the SAX parser.
  *
  * @class
- * @param {string}     message
- * @param {any | null} locator  Optional, can provide details about the location in the source.
+ * @param {string} message
+ * @param {any | null} locator Optional, can provide details about the location in the source
  */
 function ParseError(message, locator) {
 	this.message = message;

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -5,12 +5,12 @@
  *
  * Works with anything that has a `length` property and index access properties, including NodeList.
  *
- * @template {unknown} T
  * @param {T[] | { length: number; [number]: T }} list
  * @param {function (item: T, index: number, list:(T)[] | ({length:number, [number]: T})):boolean} predicate
- * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac `Array.prototype` by default, allows injecting a custom
- *   implementation in tests
+ * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac
+ * `Array.prototype` by default, allows injecting a custom implementation in tests.
  * @returns {T | undefined}
+ * @template {unknown} T
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
  * @see https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.find
  */
@@ -37,11 +37,11 @@ function find(list, predicate, ac) {
  *
  * Is used to create "enum like" objects.
  *
- * @template T
- * @param {T} object The object to freeze
- * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object] `Object` by default, allows to inject custom object constructor for
- *   tests. Default is `Object`
+ * @param {T}                                 object       The object to freeze.
+ * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object]  `Object` by default, allows to inject custom object constructor for
+ *                                                         tests. Default is `Object`
  * @returns {Readonly<T>}
+ * @template T
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
  */
 function freeze(object, oc) {
@@ -54,10 +54,10 @@ function freeze(object, oc) {
 /**
  * Since xmldom can not rely on `Object.assign`, it uses/provides a simplified version that is sufficient for its needs.
  *
- * @param {Object} target
+ * @param {Object}                    target
  * @param {Object | null | undefined} source
- * @returns {Object} Target
- * @throws TypeError if target is not an object
+ * @returns {Object} Target.
+ * @throws TypeError if target is not an object.
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
  */
@@ -119,7 +119,7 @@ var HTML_BOOLEAN_ATTRIBUTES = freeze({
  *
  * @param {string} name
  * @returns {boolean}
- * @see HTML_BOOLEAN_ATTRIBUTES
+ * @see HTML_BOOLEAN_ATTRIBUTES.
  * @see https://html.spec.whatwg.org/#boolean-attributes
  * @see https://html.spec.whatwg.org/#attributes-3
  */
@@ -176,7 +176,7 @@ var HTML_VOID_ELEMENTS = freeze({
  *
  * @param {string} tagName
  * @returns {boolean}
- * @see HTML_VOID_ELEMENTS
+ * @see HTML_VOID_ELEMENTS.
  * @see https://html.spec.whatwg.org/#void-elements
  */
 function isHTMLVoidElement(tagName) {
@@ -186,8 +186,8 @@ function isHTMLVoidElement(tagName) {
 /**
  * Tag names that are raw text elements according to HTML spec. The value denotes whether they are escapable or not.
  *
- * @see isHTMLEscapableRawTextElement
- * @see isHTMLRawTextElement
+ * @see IsHTMLEscapableRawTextElement.
+ * @see IsHTMLRawTextElement.
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -204,8 +204,8 @@ var HTML_RAW_TEXT_ELEMENTS = freeze({
  *
  * @param {string} tagName
  * @returns {boolean}
- * @see isHTMLEscapableRawTextElement
- * @see HTML_RAW_TEXT_ELEMENTS
+ * @see IsHTMLEscapableRawTextElement.
+ * @see HTML_RAW_TEXT_ELEMENTS.
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -219,8 +219,8 @@ function isHTMLRawTextElement(tagName) {
  *
  * @param {string} tagName
  * @returns {boolean}
- * @see isHTMLRawTextElement
- * @see HTML_RAW_TEXT_ELEMENTS
+ * @see IsHTMLRawTextElement.
+ * @see HTML_RAW_TEXT_ELEMENTS.
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -260,7 +260,7 @@ function hasDefaultHTMLNamespace(mimeType) {
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02 MDN
  * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparsersupportedtype WHATWG HTML Spec
- * @see DOMParser.prototype.parseFromString
+ * @see DOMParser.prototype.parseFromString.
  */
 var MIME_TYPE = freeze({
 	/**
@@ -309,10 +309,12 @@ var MIME_TYPE = freeze({
 	 */
 	XML_SVG_IMAGE: 'image/svg+xml',
 });
-/** @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' | 'text/html' | 'text/xml'} MimeType */
 /**
- * @private
+ * @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' | 'text/html' | 'text/xml'} MimeType
+ */
+/**
  * @type {MimeType[]}
+ * @access private
  */
 var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 	return MIME_TYPE[key];
@@ -355,7 +357,7 @@ var NAMESPACE = freeze({
 	XML: 'http://www.w3.org/XML/1998/namespace',
 
 	/**
-	 * The `xmlns:` namespace
+	 * The `xmlns:` namespace.
 	 *
 	 * @see https://www.w3.org/2000/xmlns/
 	 */
@@ -366,8 +368,8 @@ var NAMESPACE = freeze({
  * Creates an error that will not be caught by XMLReader aka the SAX parser.
  *
  * @class
- * @param {string} message
- * @param {any | null} locator Optional, can provide details about the location in the source
+ * @param {string}     message
+ * @param {any | null} locator  Optional, can provide details about the location in the source.
  */
 function ParseError(message, locator) {
 	this.message = message;

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -6,12 +6,11 @@
  * Works with anything that has a `length` property and index access properties, including NodeList.
  *
  * @template {unknown} T
- * @param {Array<T> | ({length:number, [number]: T})} list
- * @param {function (item: T, index: number, list:Array<T> | ({length:number, [number]: T})):boolean} predicate
- * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac `Array.prototype` by default,
- * 				allows injecting a custom implementation in tests
+ * @param {T[] | { length: number; [number]: T }} list
+ * @param {function (item: T, index: number, list:(T)[] | ({length:number, [number]: T})):boolean} predicate
+ * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac `Array.prototype` by default, allows injecting a custom
+ *   implementation in tests
  * @returns {T | undefined}
- *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
  * @see https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.find
  */
@@ -33,18 +32,16 @@ function find(list, predicate, ac) {
 }
 
 /**
- * "Shallow freezes" an object to render it immutable.
- * Uses `Object.freeze` if available,
- * otherwise the immutability is only in the type.
+ * "Shallow freezes" an object to render it immutable. Uses `Object.freeze` if available, otherwise the immutability is only in
+ * the type.
  *
  * Is used to create "enum like" objects.
  *
  * @template T
- * @param {T} object the object to freeze
- * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object] `Object` by default,
- * 				allows to inject custom object constructor for tests
+ * @param {T} object The object to freeze
+ * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object] `Object` by default, allows to inject custom object constructor for
+ *   tests. Default is `Object`
  * @returns {Readonly<T>}
- *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
  */
 function freeze(object, oc) {
@@ -55,15 +52,12 @@ function freeze(object, oc) {
 }
 
 /**
- * Since xmldom can not rely on `Object.assign`,
- * it uses/provides a simplified version that is sufficient for its needs.
+ * Since xmldom can not rely on `Object.assign`, it uses/provides a simplified version that is sufficient for its needs.
  *
  * @param {Object} target
  * @param {Object | null | undefined} source
- *
- * @returns {Object} target
+ * @returns {Object} Target
  * @throws TypeError if target is not an object
- *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
  */
@@ -80,16 +74,14 @@ function assign(target, source) {
 }
 
 /**
- * A number of attributes are boolean attributes.
- * The presence of a boolean attribute on an element represents the `true` value,
+ * A number of attributes are boolean attributes. The presence of a boolean attribute on an element represents the `true` value,
  * and the absence of the attribute represents the `false` value.
  *
- * If the attribute is present, its value must either be the empty string
- * or a value that is an ASCII case-insensitive match for the attribute's canonical name,
- * with no leading or trailing whitespace.
+ * If the attribute is present, its value must either be the empty string or a value that is an ASCII case-insensitive match for
+ * the attribute's canonical name, with no leading or trailing whitespace.
  *
- * Note: The values `"true"` and `"false"` are not allowed on boolean attributes.
- * To represent a `false` value, the attribute has to be omitted altogether.
+ * Note: The values `"true"` and `"false"` are not allowed on boolean attributes. To represent a `false` value, the attribute has
+ * to be omitted altogether.
  *
  * @see https://html.spec.whatwg.org/#boolean-attributes
  * @see https://html.spec.whatwg.org/#attributes-3
@@ -122,11 +114,11 @@ var HTML_BOOLEAN_ATTRIBUTES = freeze({
 });
 
 /**
- * Check if `name` is matching one of the HTML boolean attribute names.
- * This method doesn't check if such attributes are allowed in the context of the current document/parsing.
+ * Check if `name` is matching one of the HTML boolean attribute names. This method doesn't check if such attributes are allowed
+ * in the context of the current document/parsing.
  *
  * @param {string} name
- * @return {boolean}
+ * @returns {boolean}
  * @see HTML_BOOLEAN_ATTRIBUTES
  * @see https://html.spec.whatwg.org/#boolean-attributes
  * @see https://html.spec.whatwg.org/#attributes-3
@@ -136,15 +128,28 @@ function isHTMLBooleanAttribute(name) {
 }
 
 /**
- * Void elements only have a start tag; end tags must not be specified for void elements.
- * These elements should be written as self closing like this: `<area />`.
- * This should not be confused with optional tags that HTML allows to omit the end tag for
- * (like `li`, `tr` and others), which can have content after them,
- * so they can not be written as self closing.
- * xmldom does not have any logic for optional end tags cases and will report them as a warning.
- * Content that would go into the unopened element will instead be added as a sibling text node.
+ * Void elements only have a start tag; end tags must not be specified for void elements. These elements should be written as self
+ * closing like this: `<area />`. This should not be confused with optional tags that HTML allows to omit the end tag for (like
+ * `li`, `tr` and others), which can have content after them, so they can not be written as self closing. xmldom does not have any
+ * logic for optional end tags cases and will report them as a warning. Content that would go into the unopened element will
+ * instead be added as a sibling text node.
  *
- * @type {Readonly<{area: boolean, col: boolean, img: boolean, wbr: boolean, link: boolean, hr: boolean, source: boolean, br: boolean, input: boolean, param: boolean, meta: boolean, embed: boolean, track: boolean, base: boolean}>}
+ * @type {Readonly<{
+ * 	area: boolean;
+ * 	col: boolean;
+ * 	img: boolean;
+ * 	wbr: boolean;
+ * 	link: boolean;
+ * 	hr: boolean;
+ * 	source: boolean;
+ * 	br: boolean;
+ * 	input: boolean;
+ * 	param: boolean;
+ * 	meta: boolean;
+ * 	embed: boolean;
+ * 	track: boolean;
+ * 	base: boolean;
+ * }>}
  * @see https://html.spec.whatwg.org/#void-elements
  * @see https://html.spec.whatwg.org/#optional-tags
  */
@@ -166,12 +171,11 @@ var HTML_VOID_ELEMENTS = freeze({
 });
 
 /**
- * Check if `tagName` is matching one of the HTML void element names.
- * This method doesn't check if such tags are allowed
- * in the context of the current document/parsing.
+ * Check if `tagName` is matching one of the HTML void element names. This method doesn't check if such tags are allowed in the
+ * context of the current document/parsing.
  *
  * @param {string} tagName
- * @return {boolean}
+ * @returns {boolean}
  * @see HTML_VOID_ELEMENTS
  * @see https://html.spec.whatwg.org/#void-elements
  */
@@ -180,8 +184,7 @@ function isHTMLVoidElement(tagName) {
 }
 
 /**
- * Tag names that are raw text elements according to HTML spec.
- * The value denotes whether they are escapable or not.
+ * Tag names that are raw text elements according to HTML spec. The value denotes whether they are escapable or not.
  *
  * @see isHTMLEscapableRawTextElement
  * @see isHTMLRawTextElement
@@ -196,12 +199,11 @@ var HTML_RAW_TEXT_ELEMENTS = freeze({
 });
 
 /**
- * Check if `tagName` is matching one of the HTML raw text element names.
- * This method doesn't check if such tags are allowed
- * in the context of the current document/parsing.
+ * Check if `tagName` is matching one of the HTML raw text element names. This method doesn't check if such tags are allowed in
+ * the context of the current document/parsing.
  *
  * @param {string} tagName
- * @return {boolean}
+ * @returns {boolean}
  * @see isHTMLEscapableRawTextElement
  * @see HTML_RAW_TEXT_ELEMENTS
  * @see https://html.spec.whatwg.org/#raw-text-elements
@@ -212,12 +214,11 @@ function isHTMLRawTextElement(tagName) {
 	return HTML_RAW_TEXT_ELEMENTS.hasOwnProperty(key) && !HTML_RAW_TEXT_ELEMENTS[key];
 }
 /**
- * Check if `tagName` is matching one of the HTML escapable raw text element names.
- * This method doesn't check if such tags are allowed
- * in the context of the current document/parsing.
+ * Check if `tagName` is matching one of the HTML escapable raw text element names. This method doesn't check if such tags are
+ * allowed in the context of the current document/parsing.
  *
  * @param {string} tagName
- * @return {boolean}
+ * @returns {boolean}
  * @see isHTMLRawTextElement
  * @see HTML_RAW_TEXT_ELEMENTS
  * @see https://html.spec.whatwg.org/#raw-text-elements
@@ -232,7 +233,6 @@ function isHTMLEscapableRawTextElement(tagName) {
  *
  * @param {string} mimeType
  * @returns {mimeType is 'text/html'}
- *
  * @see https://www.iana.org/assignments/media-types/text/html
  * @see https://en.wikipedia.org/wiki/HTML
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
@@ -242,12 +242,11 @@ function isHTMLMimeType(mimeType) {
 	return mimeType === MIME_TYPE.HTML;
 }
 /**
- * For both the `text/html` and the `application/xhtml+xml` namespace
- * the spec defines that the HTML namespace is provided as the default.
+ * For both the `text/html` and the `application/xhtml+xml` namespace the spec defines that the HTML namespace is provided as the
+ * default.
  *
  * @param {string} mimeType
  * @returns {boolean}
- *
  * @see https://dom.spec.whatwg.org/#dom-document-createelement
  * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument
  * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
@@ -293,8 +292,7 @@ var MIME_TYPE = freeze({
 	XML_TEXT: 'text/xml',
 
 	/**
-	 * `application/xhtml+xml`, indicates an XML document that has the default HTML namespace,
-	 * but is parsed as an XML document.
+	 * `application/xhtml+xml`, indicates an XML document that has the default HTML namespace, but is parsed as an XML document.
 	 *
 	 * @see https://www.iana.org/assignments/media-types/application/xhtml+xml IANA MimeType registration
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument WHATWG DOM Spec
@@ -311,12 +309,10 @@ var MIME_TYPE = freeze({
 	 */
 	XML_SVG_IMAGE: 'image/svg+xml',
 });
+/** @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' | 'text/html' | 'text/xml'} MimeType */
 /**
- * @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' |  'text/html' | 'text/xml'} MimeType
- */
-/**
- * @type {MimeType[]}
  * @private
+ * @type {MimeType[]}
  */
 var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 	return MIME_TYPE[key];
@@ -324,6 +320,7 @@ var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 
 /**
  * Only returns true if `mimeType` is one of the allowed values for `DOMParser.parseFromString`.
+ *
  * @param {string} mimeType
  * @returns {mimeType is 'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' |  'text/html' | 'text/xml'}
  */
@@ -368,9 +365,9 @@ var NAMESPACE = freeze({
 /**
  * Creates an error that will not be caught by XMLReader aka the SAX parser.
  *
+ * @class
  * @param {string} message
- * @param {any?} locator Optional, can provide details about the location in the source
- * @constructor
+ * @param {any | null} locator Optional, can provide details about the location in the source
  */
 function ParseError(message, locator) {
 	this.message = message;

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -62,8 +62,8 @@ function freeze(object, oc) {
  * @param {Object} target
  * @param {Object | null | undefined} source
  * @returns {Object} Target.
- * @throws
- * TypeError if target is not an object.
+ * @throws {TypeError}
+ * If target is not an object.
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
  */

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -37,9 +37,10 @@ function find(list, predicate, ac) {
  *
  * Is used to create "enum like" objects.
  *
- * @param {T}                                 object       The object to freeze.
- * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object]  `Object` by default, allows to inject custom object constructor for
- *                                                         tests. Default is `Object`
+ * @param {T} object
+ * The object to freeze.
+ * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object]
+ * `Object` by default, allows to inject custom object constructor for tests. Default is `Object`
  * @returns {Readonly<T>}
  * @template T
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
@@ -54,10 +55,11 @@ function freeze(object, oc) {
 /**
  * Since xmldom can not rely on `Object.assign`, it uses/provides a simplified version that is sufficient for its needs.
  *
- * @param {Object}                    target
+ * @param {Object} target
  * @param {Object | null | undefined} source
  * @returns {Object} Target.
- * @throws TypeError if target is not an object.
+ * @throws
+ * TypeError if target is not an object.
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
  */
@@ -368,8 +370,9 @@ var NAMESPACE = freeze({
  * Creates an error that will not be caught by XMLReader aka the SAX parser.
  *
  * @class
- * @param {string}     message
- * @param {any | null} locator  Optional, can provide details about the location in the source.
+ * @param {string} message
+ * @param {any | null} locator
+ * Optional, can provide details about the location in the source.
  */
 function ParseError(message, locator) {
 	this.message = message;

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -326,7 +326,7 @@ var MIME_TYPE = freeze({
  */
 /**
  * @type {MimeType[]}
- * @access private
+ * @private
  */
 var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 	return MIME_TYPE[key];

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -37,10 +37,9 @@ function find(list, predicate, ac) {
  *
  * Is used to create "enum like" objects.
  *
- * @param {T} object
- * The object to freeze.
- * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object]
- * `Object` by default, allows to inject custom object constructor for tests. Default is `Object`
+ * @param {T}                                 object       The object to freeze.
+ * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object]  `Object` by default, allows to inject custom object constructor for
+ *                                                         tests. Default is `Object`
  * @returns {Readonly<T>}
  * @template T
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
@@ -55,11 +54,10 @@ function freeze(object, oc) {
 /**
  * Since xmldom can not rely on `Object.assign`, it uses/provides a simplified version that is sufficient for its needs.
  *
- * @param {Object} target
+ * @param {Object}                    target
  * @param {Object | null | undefined} source
  * @returns {Object} Target.
- * @throws
- * TypeError if target is not an object.
+ * @throws TypeError if target is not an object.
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
  */
@@ -370,9 +368,8 @@ var NAMESPACE = freeze({
  * Creates an error that will not be caught by XMLReader aka the SAX parser.
  *
  * @class
- * @param {string} message
- * @param {any | null} locator
- * Optional, can provide details about the location in the source.
+ * @param {string}     message
+ * @param {any | null} locator  Optional, can provide details about the location in the source.
  */
 function ParseError(message, locator) {
 	this.message = message;

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -3,13 +3,13 @@
 /**
  * Ponyfill for `Array.prototype.find` which is only available in ES6 runtimes.
  *
- * Works with anything that has a `length` property and index access properties, including NodeList.
+ * Works with anything that has a `length` property and index access properties,
+ * including NodeList.
  *
  * @param {T[] | { length: number; [number]: T }} list
- * @param {function (item: T, index: number, list:T[] | ({length:number, [number]: T})):boolean} predicate
+ * @param {function (item: T, index: number, list:T[]):boolean} predicate
  * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac
- * `Array.prototype` by default,
- * allows injecting a custom implementation in tests.
+ * Allows injecting a custom implementation in tests (`Array.prototype` by default).
  * @returns {T | undefined}
  * @template {unknown} T
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
@@ -45,7 +45,7 @@ function find(list, predicate, ac) {
  * `Object` by default,
  * allows to inject custom object constructor for tests.
  * @returns {Readonly<T>}
- * @template T
+ * @template {Object} T
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
  */
 function freeze(object, oc) {
@@ -61,7 +61,7 @@ function freeze(object, oc) {
  *
  * @param {Object} target
  * @param {Object | null | undefined} source
- * @returns {Object} Target.
+ * @returns {Object} The target with the merged/overridden properties.
  * @throws {TypeError}
  * If target is not an object.
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
@@ -84,8 +84,8 @@ function assign(target, source) {
  * The presence of a boolean attribute on an element represents the `true` value,
  * and the absence of the attribute represents the `false` value.
  *
- * If the attribute is present, its value must either be the empty string or a value that is an ASCII case-insensitive match for
- * the attribute's canonical name,
+ * If the attribute is present, its value must either be the empty string, or a value that is
+ * an ASCII case-insensitive match for the attribute's canonical name,
  * with no leading or trailing whitespace.
  *
  * Note: The values `"true"` and `"false"` are not allowed on boolean attributes.
@@ -123,11 +123,12 @@ var HTML_BOOLEAN_ATTRIBUTES = freeze({
 
 /**
  * Check if `name` is matching one of the HTML boolean attribute names.
- * This method doesn't check if such attributes are allowed in the context of the current document/parsing.
+ * This method doesn't check if such attributes are allowed in the context of the current
+ * document/parsing.
  *
  * @param {string} name
  * @returns {boolean}
- * @see HTML_BOOLEAN_ATTRIBUTES.
+ * @see {@link HTML_BOOLEAN_ATTRIBUTES}
  * @see https://html.spec.whatwg.org/#boolean-attributes
  * @see https://html.spec.whatwg.org/#attributes-3
  */
@@ -137,12 +138,14 @@ function isHTMLBooleanAttribute(name) {
 
 /**
  * Void elements only have a start tag; end tags must not be specified for void elements.
- * These elements should be written as self closing like this: `<area />`.
- * This should not be confused with optional tags that HTML allows to omit the end tag for (like `li`, `tr` and others), which can
- * have content after them,
- * so they can not be written as self closing.
- * xmldom does not have any logic for optional end tags cases and will report them as a warning.
- * Content that would go into the unopened element will instead be added as a sibling text node.
+ * These elements should be written as self-closing like this: `<area />`.
+ * This should not be confused with optional tags that HTML allows to omit the end tag for
+ * (like `li`, `tr` and others), which can have content after them,
+ * so they can not be written as self-closing.
+ * xmldom does not have any logic for optional end tags cases,
+ * and will report them as a warning.
+ * Content that would go into the unopened element,
+ * will instead be added as a sibling text node.
  *
  * @type {Readonly<{
  * 	area: boolean;
@@ -182,11 +185,12 @@ var HTML_VOID_ELEMENTS = freeze({
 
 /**
  * Check if `tagName` is matching one of the HTML void element names.
- * This method doesn't check if such tags are allowed in the context of the current document/parsing.
+ * This method doesn't check if such tags are allowed in the context of the current
+ * document/parsing.
  *
  * @param {string} tagName
  * @returns {boolean}
- * @see HTML_VOID_ELEMENTS.
+ * @see {@link HTML_VOID_ELEMENTS}
  * @see https://html.spec.whatwg.org/#void-elements
  */
 function isHTMLVoidElement(tagName) {
@@ -197,8 +201,8 @@ function isHTMLVoidElement(tagName) {
  * Tag names that are raw text elements according to HTML spec.
  * The value denotes whether they are escapable or not.
  *
- * @see IsHTMLEscapableRawTextElement.
- * @see IsHTMLRawTextElement.
+ * @see {@link isHTMLEscapableRawTextElement}
+ * @see {@link isHTMLRawTextElement}
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -211,12 +215,13 @@ var HTML_RAW_TEXT_ELEMENTS = freeze({
 
 /**
  * Check if `tagName` is matching one of the HTML raw text element names.
- * This method doesn't check if such tags are allowed in the context of the current document/parsing.
+ * This method doesn't check if such tags are allowed in the context of the current
+ * document/parsing.
  *
  * @param {string} tagName
  * @returns {boolean}
- * @see IsHTMLEscapableRawTextElement.
- * @see HTML_RAW_TEXT_ELEMENTS.
+ * @see {@link isHTMLEscapableRawTextElement}
+ * @see {@link HTML_RAW_TEXT_ELEMENTS}
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -226,12 +231,13 @@ function isHTMLRawTextElement(tagName) {
 }
 /**
  * Check if `tagName` is matching one of the HTML escapable raw text element names.
- * This method doesn't check if such tags are allowed in the context of the current document/parsing.
+ * This method doesn't check if such tags are allowed in the context of the current
+ * document/parsing.
  *
  * @param {string} tagName
  * @returns {boolean}
- * @see IsHTMLRawTextElement.
- * @see HTML_RAW_TEXT_ELEMENTS.
+ * @see {@link isHTMLRawTextElement}
+ * @see {@link HTML_RAW_TEXT_ELEMENTS}
  * @see https://html.spec.whatwg.org/#raw-text-elements
  * @see https://html.spec.whatwg.org/#escapable-raw-text-elements
  */
@@ -253,8 +259,8 @@ function isHTMLMimeType(mimeType) {
 	return mimeType === MIME_TYPE.HTML;
 }
 /**
- * For both the `text/html` and the `application/xhtml+xml` namespace the spec defines that the HTML namespace is provided as the
- * default.
+ * For both the `text/html` and the `application/xhtml+xml` namespace the spec defines that the
+ * HTML namespace is provided as the default.
  *
  * @param {string} mimeType
  * @returns {boolean}
@@ -269,9 +275,11 @@ function hasDefaultHTMLNamespace(mimeType) {
 /**
  * All mime types that are allowed as input to `DOMParser.parseFromString`
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02 MDN
- * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparsersupportedtype WHATWG HTML Spec
- * @see DOMParser.prototype.parseFromString.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString#Argument02
+ *      MDN
+ * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#domparsersupportedtype
+ *      WHATWG HTML Spec
+ * @see {@link DOMParser.prototype.parseFromString}
  */
 var MIME_TYPE = freeze({
 	/**
@@ -280,14 +288,16 @@ var MIME_TYPE = freeze({
 	 * @see https://www.iana.org/assignments/media-types/text/html IANA MimeType registration
 	 * @see https://en.wikipedia.org/wiki/HTML Wikipedia
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString MDN
-	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring WHATWG HTML Spec
+	 * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-domparser-parsefromstring
+	 *      WHATWG HTML Spec
 	 */
 	HTML: 'text/html',
 
 	/**
 	 * `application/xml`, the standard mime type for XML documents.
 	 *
-	 * @see https://www.iana.org/assignments/media-types/application/xml IANA MimeType registration
+	 * @see https://www.iana.org/assignments/media-types/application/xml IANA MimeType
+	 *      registration
 	 * @see https://tools.ietf.org/html/rfc7303#section-9.1 RFC 7303
 	 * @see https://en.wikipedia.org/wiki/XML_and_MIME Wikipedia
 	 */
@@ -306,7 +316,8 @@ var MIME_TYPE = freeze({
 	 * `application/xhtml+xml`, indicates an XML document that has the default HTML namespace,
 	 * but is parsed as an XML document.
 	 *
-	 * @see https://www.iana.org/assignments/media-types/application/xhtml+xml IANA MimeType registration
+	 * @see https://www.iana.org/assignments/media-types/application/xhtml+xml IANA MimeType
+	 *      registration
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument WHATWG DOM Spec
 	 * @see https://en.wikipedia.org/wiki/XHTML Wikipedia
 	 */
@@ -322,7 +333,8 @@ var MIME_TYPE = freeze({
 	XML_SVG_IMAGE: 'image/svg+xml',
 });
 /**
- * @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' | 'text/html' | 'text/xml'} MimeType
+ * @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' | 'text/html' | 'text/xml'}
+ * MimeType
  */
 /**
  * @type {MimeType[]}
@@ -333,10 +345,12 @@ var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 });
 
 /**
- * Only returns true if `mimeType` is one of the allowed values for `DOMParser.parseFromString`.
+ * Only returns true if `mimeType` is one of the allowed values for
+ * `DOMParser.parseFromString`.
  *
  * @param {string} mimeType
  * @returns {mimeType is 'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' |  'text/html' | 'text/xml'}
+ *
  */
 function isValidMimeType(mimeType) {
 	return _MIME_TYPES.indexOf(mimeType) > -1;

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -381,7 +381,7 @@ var NAMESPACE = freeze({
  *
  * @class
  * @param {string} message
- * @param {any?} locator
+ * @param {any} [locator]
  * Optional, can provide details about the location in the source.
  */
 function ParseError(message, locator) {

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -6,11 +6,12 @@
  * Works with anything that has a `length` property and index access properties, including NodeList.
  *
  * @template {unknown} T
- * @param {T[] | { length: number; [number]: T }} list
- * @param {function (item: T, index: number, list:(T)[] | ({length:number, [number]: T})):boolean} predicate
- * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac `Array.prototype` by default, allows injecting a custom
- *   implementation in tests
+ * @param {Array<T> | ({length:number, [number]: T})} list
+ * @param {function (item: T, index: number, list:Array<T> | ({length:number, [number]: T})):boolean} predicate
+ * @param {Partial<Pick<ArrayConstructor['prototype'], 'find'>>?} ac `Array.prototype` by default,
+ * 				allows injecting a custom implementation in tests
  * @returns {T | undefined}
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
  * @see https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.find
  */
@@ -32,16 +33,18 @@ function find(list, predicate, ac) {
 }
 
 /**
- * "Shallow freezes" an object to render it immutable. Uses `Object.freeze` if available, otherwise the immutability is only in
- * the type.
+ * "Shallow freezes" an object to render it immutable.
+ * Uses `Object.freeze` if available,
+ * otherwise the immutability is only in the type.
  *
  * Is used to create "enum like" objects.
  *
  * @template T
- * @param {T} object The object to freeze
- * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object] `Object` by default, allows to inject custom object constructor for
- *   tests. Default is `Object`
+ * @param {T} object the object to freeze
+ * @param {Pick<ObjectConstructor, 'freeze'>} [oc=Object] `Object` by default,
+ * 				allows to inject custom object constructor for tests
  * @returns {Readonly<T>}
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
  */
 function freeze(object, oc) {
@@ -52,12 +55,15 @@ function freeze(object, oc) {
 }
 
 /**
- * Since xmldom can not rely on `Object.assign`, it uses/provides a simplified version that is sufficient for its needs.
+ * Since xmldom can not rely on `Object.assign`,
+ * it uses/provides a simplified version that is sufficient for its needs.
  *
  * @param {Object} target
  * @param {Object | null | undefined} source
- * @returns {Object} Target
+ *
+ * @returns {Object} target
  * @throws TypeError if target is not an object
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  * @see https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign
  */
@@ -74,14 +80,16 @@ function assign(target, source) {
 }
 
 /**
- * A number of attributes are boolean attributes. The presence of a boolean attribute on an element represents the `true` value,
+ * A number of attributes are boolean attributes.
+ * The presence of a boolean attribute on an element represents the `true` value,
  * and the absence of the attribute represents the `false` value.
  *
- * If the attribute is present, its value must either be the empty string or a value that is an ASCII case-insensitive match for
- * the attribute's canonical name, with no leading or trailing whitespace.
+ * If the attribute is present, its value must either be the empty string
+ * or a value that is an ASCII case-insensitive match for the attribute's canonical name,
+ * with no leading or trailing whitespace.
  *
- * Note: The values `"true"` and `"false"` are not allowed on boolean attributes. To represent a `false` value, the attribute has
- * to be omitted altogether.
+ * Note: The values `"true"` and `"false"` are not allowed on boolean attributes.
+ * To represent a `false` value, the attribute has to be omitted altogether.
  *
  * @see https://html.spec.whatwg.org/#boolean-attributes
  * @see https://html.spec.whatwg.org/#attributes-3
@@ -114,11 +122,11 @@ var HTML_BOOLEAN_ATTRIBUTES = freeze({
 });
 
 /**
- * Check if `name` is matching one of the HTML boolean attribute names. This method doesn't check if such attributes are allowed
- * in the context of the current document/parsing.
+ * Check if `name` is matching one of the HTML boolean attribute names.
+ * This method doesn't check if such attributes are allowed in the context of the current document/parsing.
  *
  * @param {string} name
- * @returns {boolean}
+ * @return {boolean}
  * @see HTML_BOOLEAN_ATTRIBUTES
  * @see https://html.spec.whatwg.org/#boolean-attributes
  * @see https://html.spec.whatwg.org/#attributes-3
@@ -128,28 +136,15 @@ function isHTMLBooleanAttribute(name) {
 }
 
 /**
- * Void elements only have a start tag; end tags must not be specified for void elements. These elements should be written as self
- * closing like this: `<area />`. This should not be confused with optional tags that HTML allows to omit the end tag for (like
- * `li`, `tr` and others), which can have content after them, so they can not be written as self closing. xmldom does not have any
- * logic for optional end tags cases and will report them as a warning. Content that would go into the unopened element will
- * instead be added as a sibling text node.
+ * Void elements only have a start tag; end tags must not be specified for void elements.
+ * These elements should be written as self closing like this: `<area />`.
+ * This should not be confused with optional tags that HTML allows to omit the end tag for
+ * (like `li`, `tr` and others), which can have content after them,
+ * so they can not be written as self closing.
+ * xmldom does not have any logic for optional end tags cases and will report them as a warning.
+ * Content that would go into the unopened element will instead be added as a sibling text node.
  *
- * @type {Readonly<{
- * 	area: boolean;
- * 	col: boolean;
- * 	img: boolean;
- * 	wbr: boolean;
- * 	link: boolean;
- * 	hr: boolean;
- * 	source: boolean;
- * 	br: boolean;
- * 	input: boolean;
- * 	param: boolean;
- * 	meta: boolean;
- * 	embed: boolean;
- * 	track: boolean;
- * 	base: boolean;
- * }>}
+ * @type {Readonly<{area: boolean, col: boolean, img: boolean, wbr: boolean, link: boolean, hr: boolean, source: boolean, br: boolean, input: boolean, param: boolean, meta: boolean, embed: boolean, track: boolean, base: boolean}>}
  * @see https://html.spec.whatwg.org/#void-elements
  * @see https://html.spec.whatwg.org/#optional-tags
  */
@@ -171,11 +166,12 @@ var HTML_VOID_ELEMENTS = freeze({
 });
 
 /**
- * Check if `tagName` is matching one of the HTML void element names. This method doesn't check if such tags are allowed in the
- * context of the current document/parsing.
+ * Check if `tagName` is matching one of the HTML void element names.
+ * This method doesn't check if such tags are allowed
+ * in the context of the current document/parsing.
  *
  * @param {string} tagName
- * @returns {boolean}
+ * @return {boolean}
  * @see HTML_VOID_ELEMENTS
  * @see https://html.spec.whatwg.org/#void-elements
  */
@@ -184,7 +180,8 @@ function isHTMLVoidElement(tagName) {
 }
 
 /**
- * Tag names that are raw text elements according to HTML spec. The value denotes whether they are escapable or not.
+ * Tag names that are raw text elements according to HTML spec.
+ * The value denotes whether they are escapable or not.
  *
  * @see isHTMLEscapableRawTextElement
  * @see isHTMLRawTextElement
@@ -199,11 +196,12 @@ var HTML_RAW_TEXT_ELEMENTS = freeze({
 });
 
 /**
- * Check if `tagName` is matching one of the HTML raw text element names. This method doesn't check if such tags are allowed in
- * the context of the current document/parsing.
+ * Check if `tagName` is matching one of the HTML raw text element names.
+ * This method doesn't check if such tags are allowed
+ * in the context of the current document/parsing.
  *
  * @param {string} tagName
- * @returns {boolean}
+ * @return {boolean}
  * @see isHTMLEscapableRawTextElement
  * @see HTML_RAW_TEXT_ELEMENTS
  * @see https://html.spec.whatwg.org/#raw-text-elements
@@ -214,11 +212,12 @@ function isHTMLRawTextElement(tagName) {
 	return HTML_RAW_TEXT_ELEMENTS.hasOwnProperty(key) && !HTML_RAW_TEXT_ELEMENTS[key];
 }
 /**
- * Check if `tagName` is matching one of the HTML escapable raw text element names. This method doesn't check if such tags are
- * allowed in the context of the current document/parsing.
+ * Check if `tagName` is matching one of the HTML escapable raw text element names.
+ * This method doesn't check if such tags are allowed
+ * in the context of the current document/parsing.
  *
  * @param {string} tagName
- * @returns {boolean}
+ * @return {boolean}
  * @see isHTMLRawTextElement
  * @see HTML_RAW_TEXT_ELEMENTS
  * @see https://html.spec.whatwg.org/#raw-text-elements
@@ -233,6 +232,7 @@ function isHTMLEscapableRawTextElement(tagName) {
  *
  * @param {string} mimeType
  * @returns {mimeType is 'text/html'}
+ *
  * @see https://www.iana.org/assignments/media-types/text/html
  * @see https://en.wikipedia.org/wiki/HTML
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
@@ -242,11 +242,12 @@ function isHTMLMimeType(mimeType) {
 	return mimeType === MIME_TYPE.HTML;
 }
 /**
- * For both the `text/html` and the `application/xhtml+xml` namespace the spec defines that the HTML namespace is provided as the
- * default.
+ * For both the `text/html` and the `application/xhtml+xml` namespace
+ * the spec defines that the HTML namespace is provided as the default.
  *
  * @param {string} mimeType
  * @returns {boolean}
+ *
  * @see https://dom.spec.whatwg.org/#dom-document-createelement
  * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument
  * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
@@ -292,7 +293,8 @@ var MIME_TYPE = freeze({
 	XML_TEXT: 'text/xml',
 
 	/**
-	 * `application/xhtml+xml`, indicates an XML document that has the default HTML namespace, but is parsed as an XML document.
+	 * `application/xhtml+xml`, indicates an XML document that has the default HTML namespace,
+	 * but is parsed as an XML document.
 	 *
 	 * @see https://www.iana.org/assignments/media-types/application/xhtml+xml IANA MimeType registration
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument WHATWG DOM Spec
@@ -309,10 +311,12 @@ var MIME_TYPE = freeze({
 	 */
 	XML_SVG_IMAGE: 'image/svg+xml',
 });
-/** @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' | 'text/html' | 'text/xml'} MimeType */
 /**
- * @private
+ * @typedef {'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' |  'text/html' | 'text/xml'} MimeType
+ */
+/**
  * @type {MimeType[]}
+ * @private
  */
 var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 	return MIME_TYPE[key];
@@ -320,7 +324,6 @@ var _MIME_TYPES = Object.keys(MIME_TYPE).map(function (key) {
 
 /**
  * Only returns true if `mimeType` is one of the allowed values for `DOMParser.parseFromString`.
- *
  * @param {string} mimeType
  * @returns {mimeType is 'application/xhtml+xml' | 'application/xml' | 'image/svg+xml' |  'text/html' | 'text/xml'}
  */
@@ -365,9 +368,9 @@ var NAMESPACE = freeze({
 /**
  * Creates an error that will not be caught by XMLReader aka the SAX parser.
  *
- * @class
  * @param {string} message
- * @param {any | null} locator Optional, can provide details about the location in the source
+ * @param {any?} locator Optional, can provide details about the location in the source
+ * @constructor
  */
 function ParseError(message, locator) {
 	this.message = message;

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -99,7 +99,7 @@ function DOMParser(options) {
 	 * parsing.
 	 *
 	 * @type {conventions.assign}
-	 * @access private
+	 * @private
 	 * @see {@link conventions.assign}
 	 * @readonly
 	 */
@@ -110,7 +110,7 @@ function DOMParser(options) {
 	 * __**Warning: By configuring a faulty implementation, the specified behavior can completely be broken.**__.
 	 *
 	 * @type {typeof DOMHandler}
-	 * @access private
+	 * @private
 	 * @readonly
 	 */
 	this.domHandler = options.domHandler || DOMHandler;
@@ -271,14 +271,14 @@ function DOMHandler(options) {
 	 * the HTML namespace needs to be the default namespace.
 	 *
 	 * @type {string | null}
-	 * @access private
+	 * @private
 	 * @readonly
 	 */
 	this.defaultNamespace = opt.defaultNamespace || null;
 
 	/**
 	 * @type {boolean}
-	 * @access private
+	 * @private
 	 */
 	this.cdata = false;
 
@@ -289,7 +289,7 @@ function DOMHandler(options) {
 	 * Note: The sax parser currently sets it to white space text nodes between tags.
 	 *
 	 * @type {Element | Node | undefined}
-	 * @access private
+	 * @private
 	 */
 	this.currentElement = undefined;
 
@@ -309,7 +309,7 @@ function DOMHandler(options) {
 	 * on the DOM nodes.
 	 *
 	 * @type {Readonly<Locator> | undefined}
-	 * @access private
+	 * @private
 	 * @readonly (the
 	 * sax parser currently sometimes set's it)
 	 */

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -127,8 +127,8 @@ function DOMParser(options) {
 	 * Be aware that many `warning`s are considered an error that prevents further processing in most implementations.
 	 *
 	 * @type {function(level:ErrorLevel, message:string, context: DOMHandler):void}
-	 * @see OnErrorStopParsing.
-	 * @see OnWarningStopParsing.
+	 * @see {@link onErrorStopParsing}
+	 * @see {@link onWarningStopParsing}
 	 */
 	this.onError = options.onError || options.errorHandler;
 	if (options.errorHandler && typeof options.errorHandler !== 'function') {
@@ -534,7 +534,7 @@ function appendElement(handler, node) {
  * with level `error` is reported during parsing.
  *
  * @see DOMParserOptions.onError.
- * @see OnWarningStopParsing.
+ * @see {@link onWarningStopParsing}
  */
 function onErrorStopParsing(level) {
 	if (level === 'error') throw 'onErrorStopParsing';
@@ -544,7 +544,7 @@ function onErrorStopParsing(level) {
  * A method that prevents any further parsing when any `error` is reported during parsing.
  *
  * @see DOMParserOptions.onError.
- * @see OnErrorStopParsing.
+ * @see {@link onErrorStopParsing}
  */
 function onWarningStopParsing() {
 	throw 'onWarningStopParsing';

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -21,17 +21,22 @@ var XMLReader = sax.XMLReader;
  *
  * > XML parsed entities are often stored in computer files which,
  * > for editing convenience, are organized into lines.
- * > These lines are typically separated by some combination > of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
+ * > These lines are typically separated by some combination
+ * > of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
  * >
- * > To simplify the tasks of applications, the XML processor must behave > as if it normalized all line breaks in external parsed
- * entities (including the document entity)
+ * > To simplify the tasks of applications, the XML processor must behave
+ * > as if it normalized all line breaks in external parsed entities (including the document entity)
  * > on input, before parsing, by translating all of the following to a single #xA character:
  * >
- * > 1. the two-character sequence #xD #xA > 2. the two-character sequence #xD #x85 > 3. the single character #x85 > 4. the single
- * character #x2028 > 5. any #xD character that is not immediately followed by #xA or #x85.
+ * > 1. the two-character sequence #xD #xA,
+ * > 2. the two-character sequence #xD #x85,
+ * > 3. the single character #x85,
+ * > 4. the single character #x2028,
+ * > 5. any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}
+ * @prettierignore
  */
 function normalizeLineEndings(input) {
 	return input.replace(/\r[\n\u0085]/g, '\n').replace(/[\r\u0085\u2028]/g, '\n');
@@ -46,15 +51,17 @@ function normalizeLineEndings(input) {
 /**
  * @typedef DOMParserOptions
  * @property {typeof assign} [assign]
- * The method to use instead of `conventions.assign`, which is used to copy values from `options` before they are used for
- * parsing.
+ * The method to use instead of `conventions.assign`, which is used to copy values from
+ * `options` before they are used for parsing.
  * @property {typeof DOMHandler} [domHandler]
- * For internal testing: The class for creating an instance for handling events from the SAX parser.
- * __**Warning: By configuring a faulty implementation,
- * the specified behavior can completely be broken.**__.
+ * For internal testing: The class for creating an instance for handling events from the SAX
+ * parser.
+ * *****Warning: By configuring a faulty implementation, the specified behavior can completely
+ * be broken.*****.
  * @property {Function} [errorHandler]
  * DEPRECATED! use `onError` instead.
- * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]
+ * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void}
+ * [onError]
  * A function that is invoked for every error that occurs during parsing.
  *
  * If it is not provided, all errors are reported to `console.error`
@@ -63,11 +70,11 @@ function normalizeLineEndings(input) {
  * If the provided method throws, a `ParserError` is thrown,
  * which prevents any further processing.
  *
- * Be aware that many `warning`s are considered an error that prevents further processing in most implementations.
- * .
+ * Be aware that many `warning`s are considered an error that prevents further processing in
+ * most implementations.
  * @property {boolean} [locator=true]
- * Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber` attribute describing their
- * location in the XML string.
+ * Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber`
+ * attribute describing their location in the XML string.
  * Default is true.
  * @property {(string) => string} [normalizeLineEndings]
  * used to replace line endings before parsing, defaults to `normalizeLineEndings`
@@ -77,14 +84,15 @@ function normalizeLineEndings(input) {
  * When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`,
  * the default namespace that will be used,
  * will be overridden according to the specification.
- * @see NormalizeLineEndings.
+ * @see {@link normalizeLineEndings}
  */
 
 /**
- * The DOMParser interface provides the ability to parse XML or HTML source code from a string into a DOM `Document`.
+ * The DOMParser interface provides the ability to parse XML or HTML source code from a string
+ * into a DOM `Document`.
  *
- * _xmldom is different from the spec in that it allows an `options` parameter,
- * to control the behavior._.
+ * ***xmldom is different from the spec in that it allows an `options` parameter,
+ * to control the behavior***.
  *
  * @class
  * @param {DOMParserOptions} [options]
@@ -95,8 +103,9 @@ function DOMParser(options) {
 	options = options || { locator: true };
 
 	/**
-	 * The method to use instead of `conventions.assign`, which is used to copy values from `options` before they are used for
-	 * parsing.
+	 * The method to use instead of `conventions.assign`, which is used to copy values from
+	 * `options`
+	 * before they are used for parsing.
 	 *
 	 * @type {conventions.assign}
 	 * @private
@@ -106,8 +115,10 @@ function DOMParser(options) {
 	this.assign = options.assign || conventions.assign;
 
 	/**
-	 * For internal testing: The class for creating an instance for handling events from the SAX parser.
-	 * __**Warning: By configuring a faulty implementation, the specified behavior can completely be broken.**__.
+	 * For internal testing: The class for creating an instance for handling events from the SAX
+	 * parser.
+	 * *****Warning: By configuring a faulty implementation, the specified behavior can completely
+	 * be broken*****.
 	 *
 	 * @type {typeof DOMHandler}
 	 * @private
@@ -124,7 +135,8 @@ function DOMParser(options) {
 	 * If the provided method throws, a `ParserError` is thrown,
 	 * which prevents any further processing.
 	 *
-	 * Be aware that many `warning`s are considered an error that prevents further processing in most implementations.
+	 * Be aware that many `warning`s are considered an error that prevents further processing in
+	 * most implementations.
 	 *
 	 * @type {function(level:ErrorLevel, message:string, context: DOMHandler):void}
 	 * @see {@link onErrorStopParsing}
@@ -146,8 +158,9 @@ function DOMParser(options) {
 	this.normalizeLineEndings = options.normalizeLineEndings || normalizeLineEndings;
 
 	/**
-	 * Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber` attribute describing their
-	 * location in the XML string.
+	 * Configures if the nodes created during parsing will have a `lineNumber` and a
+	 * `columnNumber`
+	 * attribute describing their location in the XML string.
 	 * Default is true.
 	 *
 	 * @type {boolean}
@@ -169,21 +182,24 @@ function DOMParser(options) {
 
 /**
  * Parses `source` using the options in the way configured by the `DOMParserOptions` of `this`
- * `DOMParser`. If `mimeType` is `text/html` an HTML `Document` is created, otherwise an XML `Document` is created.
+ * `DOMParser`. If `mimeType` is `text/html` an HTML `Document` is created,
+ * otherwise an XML `Document` is created.
  *
  * __It behaves different from the description in the living standard__:
  * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior.
- * - Any unexpected input is reported to `onError` with either a `warning`, `error` or `fatalError` level.
+ * - Any unexpected input is reported to `onError` with either a `warning`,
+ * `error` or `fatalError` level.
  * - Any `fatalError` throws a `ParseError` which prevents further processing.
- * - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing - If no `Document` was created
- * during parsing it is reported as a `fatalError`.
- * __**Warning: By configuring a faulty DOMHandler implementation,
- * the specified behavior can completely be broken.**__.
+ * - Any error thrown by `onError` is converted to a `ParseError` which prevents further
+ * processing - If no `Document` was created during parsing it is reported as a `fatalError`.
+ * *****Warning: By configuring a faulty DOMHandler implementation,
+ * the specified behavior can completely be broken*****.
  *
  * @param {string} source
  * The XML mime type only allows string input!
  * @param {string} [mimeType='application/xml']
- * the mimeType or contentType of the document to be created determines the `type` of document created (XML or HTML)
+ * the mimeType or contentType of the document to be created determines the `type` of document
+ * created (XML or HTML)
  * @returns The `Document` node.
  * @throws
  * ParseError for any `fatalError` or anything that is thrown by `onError`
@@ -238,7 +254,8 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
  * @property {string | null} [defaultNamespace=null]
  */
 /**
- * The class that is used to handle events from the SAX parser to create the related DOM elements.
+ * The class that is used to handle events from the SAX parser to create the related DOM
+ * elements.
  *
  * Some methods are only implemented as an empty function,
  * since they are (at least currently) not relevant for xmldom.
@@ -255,7 +272,7 @@ function DOMHandler(options) {
 	 * It defaults to MIME_TYPE.XML_APPLICATION.
 	 *
 	 * @type {string}
-	 * @see MIME_TYPE.
+	 * @see {@link MIME_TYPE}
 	 * @readonly
 	 */
 	this.mimeType = opt.mimeType || MIME_TYPE.XML_APPLICATION;
@@ -264,8 +281,10 @@ function DOMHandler(options) {
 	 * The namespace to use to create an XML document.
 	 * For the following reasons this is required:
 	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace,
-	 * since at that point there is no way for the parser to know what the default namespace from the document will be.
-	 * - When creating using `DOMImplementation.createDocument` it is required to pass a namespace,
+	 * since at that point there is no way for the parser to know what the default namespace from
+	 * the document will be.
+	 * - When creating using `DOMImplementation.createDocument` it is required to pass a
+	 * namespace,
 	 * to determine the correct `Document.contentType`, which should match `this.mimeType`.
 	 * - When parsing an XML document with the `application/xhtml+xml` mimeType,
 	 * the HTML namespace needs to be the default namespace.
@@ -533,7 +552,7 @@ function appendElement(handler, node) {
  * A method that prevents any further parsing when an `error`
  * with level `error` is reported during parsing.
  *
- * @see DOMParserOptions.onError.
+ * @see {@link DOMParserOptions.onError}
  * @see {@link onWarningStopParsing}
  */
 function onErrorStopParsing(level) {
@@ -543,7 +562,7 @@ function onErrorStopParsing(level) {
 /**
  * A method that prevents any further parsing when any `error` is reported during parsing.
  *
- * @see DOMParserOptions.onError.
+ * @see {@link DOMParserOptions.onError}
  * @see {@link onErrorStopParsing}
  */
 function onWarningStopParsing() {

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -17,17 +17,22 @@ var ParseError = conventions.ParseError;
 var XMLReader = sax.XMLReader;
 
 /**
- * Normalizes line ending according to [https://www.w3.org/TR/xml11/#sec-line-ends](https://www.w3.org/TR/xml11/#sec-line-ends):
- * XML parsed entities are often stored in computer files which, for editing convenience, are organized into lines. These lines
- * Are typically separated by some combination of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA). To simplify the tasks
- * of applications, the XML processor must behave as if it normalized all line breaks in external parsed Entities (including the
- * document entity) on input, before parsing, by translating all of the following to a single #xA Character:
+ * Normalizes line ending according to <https://www.w3.org/TR/xml11/#sec-line-ends>:
  *
- * 1. The two-character sequence #xD #xA
- * 2. The two-character sequence #xD #x85
- * 3. The single character #x85
- * 4. The Single character * #x2028
- * 5. Any #xD character that is not immediately followed by #xA or #x85.
+ * > XML parsed entities are often stored in computer files which,
+ * > for editing convenience, are organized into lines.
+ * > These lines are typically separated by some combination
+ * > of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
+ * >
+ * > To simplify the tasks of applications, the XML processor must behave
+ * > as if it normalized all line breaks in external parsed entities (including the document entity)
+ * > on input, before parsing, by translating all of the following to a single #xA character:
+ * >
+ * > 1. the two-character sequence #xD #xA
+ * > 2. the two-character sequence #xD #x85
+ * > 3. the single character #x85
+ * > 4. the single character #x2028
+ * > 5. any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}
@@ -44,37 +49,55 @@ function normalizeLineEndings(input) {
 
 /**
  * @typedef DOMParserOptions
- * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign] The method to use instead of `Object.assign`
- *   (or if not available `conventions.assign`), which is used to copy values from the options before they are used for parsing.
- *   Default is `Object.assign || conventions.assign`
- * @property {typeof DOMHandler} [domHandler] For internal testing: The class for creating an instance for handling events from
- *   the SAX parser. ****Warning: By configuring a faulty implementation, the specified behavior can completely be broken.****
- * @property {Function} [errorHandler] DEPRECATED! use `onError` instead.
- * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError] A function that is invoked for every
- *   error that occurs during parsing.
+ * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign]
+ * The method to use instead of `Object.assign` (or if not available `conventions.assign`),
+ * which is used to copy values from the options before they are used for parsing.
+ * @property {typeof DOMHandler} [domHandler]
+ * For internal testing: The class for creating an instance for handling events from the SAX parser.
+ * __**Warning: By configuring a faulty implementation,
+ * the specified behavior can completely be broken.**__
  *
- *   If it is not provided, all errors are reported to `console.error` and only `fatalError`s are thrown as a `ParseError`, which
- *   prevents any further processing. If the provided method throws, a `ParserError` is thrown, which prevents any further
- *   processing.
+ * @property {Function} [errorHandler]
+ * DEPRECATED! use `onError` instead.
+ * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]
+ * A function that is invoked for every error that occurs during parsing.
  *
- *   Be aware that many `warning`s are considered an error that prevents further processing in most implementations. .
- * @property {boolean} [locator=true] Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber`
- *   attribute describing their location in the XML string. Default is true. Default is `true`
- * @property {(string) => string} [normalizeLineEndings] Used to replace line endings before parsing, defaults to
- *   `normalizeLineEndings`
- * @property {object} [xmlns] The XML namespaces that should be assumed when parsing. The default namespace can be provided by the
- *   key that is the empty string. When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`, the default
- *   namespace that will be used, will be overridden according to the specification.
+ * If it is not provided, all errors are reported to `console.error`
+ * and only `fatalError`s are thrown as a `ParseError`,
+ * which prevents any further processing.
+ * If the provided method throws, a `ParserError` is thrown,
+ * which prevents any further processing.
+ *
+ * Be aware that many `warning`s are considered an error
+ * that prevents further processing in most implementations.
+ *.
+ * @property {boolean} [locator=true]
+ * Configures if the nodes created during parsing
+ * will have a `lineNumber` and a `columnNumber` attribute
+ * describing their location in the XML string.
+ * Default is true.
+ * @property {(string) => string} [normalizeLineEndings]
+ * used to replace line endings before parsing, defaults to `normalizeLineEndings`
+ * @property {object} [xmlns]
+ * The XML namespaces that should be assumed when parsing.
+ * The default namespace can be provided by the key that is the empty string.
+ * When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`,
+ * the default namespace that will be used,
+ * will be overridden according to the specification.
+ *
  * @see normalizeLineEndings
  */
 
 /**
- * The DOMParser interface provides the ability to parse XML or HTML source code from a string into a DOM `Document`.
+ * The DOMParser interface provides the ability to parse XML or HTML source code
+ * from a string into a DOM `Document`.
  *
- * _xmldom is different from the spec in that it allows an `options` parameter, to control the behavior._
+ * _xmldom is different from the spec in that it allows an `options` parameter,
+ * to control the behavior._
  *
- * @class
  * @param {DOMParserOptions} [options]
+ * @constructor
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
  * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
  */
@@ -82,36 +105,40 @@ function DOMParser(options) {
 	options = options || { locator: true };
 
 	/**
-	 * The method to use instead of `Object.assign` (defaults to or `conventions.assign`), which is used to copy values from the
-	 * options before they are used for parsing.
+	 * The method to use instead of `Object.assign` (defaults to or `conventions.assign`),
+	 * which is used to copy values from the options before they are used for parsing.
 	 *
-	 * @private
 	 * @type {function (target: object, source: object | null | undefined): object}
 	 * @readonly
+	 * @private
 	 * @see conventions.assign
 	 */
 	this.assign = options.assign || conventions.assign;
 
 	/**
-	 * For internal testing: The class for creating an instance for handling events from the SAX parser. ****Warning: By configuring
-	 * a faulty implementation, the specified behavior can completely be broken.****
+	 * For internal testing: The class for creating an instance for handling events from the SAX parser.
+	 * __**Warning: By configuring a faulty implementation, the specified behavior can completely be broken.**__
 	 *
-	 * @private
 	 * @type {typeof DOMHandler}
 	 * @readonly
+	 * @private
 	 */
 	this.domHandler = options.domHandler || DOMHandler;
 
 	/**
 	 * A function that is invoked for every error that occurs during parsing.
 	 *
-	 * If it is not provided, all errors are reported to `console.error` and only `fatalError`s are thrown as a `ParseError`, which
-	 * prevents any further processing. If the provided method throws, a `ParserError` is thrown, which prevents any further
-	 * processing.
+	 * If it is not provided, all errors are reported to `console.error`
+	 * and only `fatalError`s are thrown as a `ParseError`,
+	 * which prevents any further processing.
+	 * If the provided method throws, a `ParserError` is thrown,
+	 * which prevents any further processing.
 	 *
-	 * Be aware that many `warning`s are considered an error that prevents further processing in most implementations.
+	 * Be aware that many `warning`s are considered an error
+	 * that prevents further processing in most implementations.
 	 *
 	 * @type {function(level:ErrorLevel, message:string, context: DOMHandler):void}
+	 *
 	 * @see onErrorStopParsing
 	 * @see onWarningStopParsing
 	 */
@@ -123,7 +150,7 @@ function DOMParser(options) {
 	}
 
 	/**
-	 * Used to replace line endings before parsing, defaults to `normalizeLineEndings`
+	 * used to replace line endings before parsing, defaults to `normalizeLineEndings`
 	 *
 	 * @type {(string) => string}
 	 * @readonly
@@ -131,18 +158,20 @@ function DOMParser(options) {
 	this.normalizeLineEndings = options.normalizeLineEndings || normalizeLineEndings;
 
 	/**
-	 * Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber` attribute describing their
-	 * location in the XML string. Default is true.
-	 *
+	 * Configures if the nodes created during parsing
+	 * will have a `lineNumber` and a `columnNumber` attribute
+	 * describing their location in the XML string.
+	 * Default is true.
 	 * @type {boolean}
 	 * @readonly
 	 */
 	this.locator = !!options.locator;
 
 	/**
-	 * The default namespace can be provided by the key that is the empty string. When the `mimeType` for HTML, XHTML or SVG are
-	 * passed to `parseFromString`, the default namespace that will be used, will be overridden according to the specification.
-	 *
+	 * The default namespace can be provided by the key that is the empty string.
+	 * When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`,
+	 * the default namespace that will be used,
+	 * will be overridden according to the specification.
 	 * @type {Readonly<object>}
 	 * @readonly
 	 */
@@ -150,25 +179,29 @@ function DOMParser(options) {
 }
 
 /**
- * Parses `source` using the options in the way configured by the `DOMParserOptions` of `this` `DOMParser`. If `mimeType` is
- * `text/html` an HTML `Document` is created, otherwise an XML `Document` is created.
+ * Parses `source` using the options in the way configured by the `DOMParserOptions` of `this`
+ * `DOMParser`. If `mimeType` is `text/html` an HTML `Document` is created, otherwise an XML
+ * `Document` is created.
  *
- * **It behaves different from the description in the living standard**:
- *
- * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior.
+ * __It behaves different from the description in the living standard__:
+ * - Uses the `options` passed to the `DOMParser` constructor to modify the
+ *   behavior.
  * - Any unexpected input is reported to `onError` with either a `warning`, `error` or `fatalError` level.
- *
  *   - Any `fatalError` throws a `ParseError` which prevents further processing.
  *   - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing
- * - If no `Document` was created during parsing it is reported as a `fatalError`. ****Warning: By configuring a faulty DOMHandler
- *   implementation, the specified behavior can completely be broken.****
+ * - If no `Document` was created during parsing it is reported as a `fatalError`.
+ * __**Warning: By configuring a faulty DOMHandler implementation,
+ * the specified behavior can completely be broken.**__
  *
  * @param {string} source The XML mime type only allows string input!
- * @param {string} [mimeType='application/xml'] The mimeType or contentType of the document to be created determines the `type` of
- *   document created (XML or HTML). Default is `'application/xml'`
- * @returns The `Document` node
+ * @param {string} [mimeType='application/xml']
+ *        the mimeType or contentType of the document to be created
+ *        determines the `type` of document created (XML or HTML)
+ *
  * @throws ParseError for any `fatalError` or anything that is thrown by `onError`
  * @throws TypeError for any invalid `mimeType`
+ * @returns the `Document` node
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
  * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
  */
@@ -214,23 +247,25 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 
 /**
  * @typedef DOMHandlerOptions
- * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION] Default is `MIME_TYPE.XML_APPLICATION`
- * @property {string | null} [defaultNamespace=null] Default is `null`
+ * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION]
+ * @property {string|null} [defaultNamespace=null]
  */
 /**
  * The class that is used to handle events from the SAX parser to create the related DOM elements.
  *
- * Some methods are only implemented as an empty function, since they are (at least currently) not relevant for xmldom.
+ * Some methods are only implemented as an empty function,
+ * since they are (at least currently) not relevant for xmldom.
  *
- * @class
+ * @constructor
  * @param {DOMHandlerOptions} [options]
  * @see http://www.saxproject.org/apidoc/org/xml/sax/ext/DefaultHandler2.html
  */
 function DOMHandler(options) {
 	var opt = options || {};
 	/**
-	 * The mime type is used to determine if the DOM handler will create an XML or HTML document. Only if it is set to `text/html`
-	 * it will create an HTML document. It defaults to MIME_TYPE.XML_APPLICATION.
+	 * The mime type is used to determine if the DOM handler will create an XML or HTML document.
+	 * Only if it is set to `text/html` it will create an HTML document.
+	 * It defaults to MIME_TYPE.XML_APPLICATION.
 	 *
 	 * @type {string}
 	 * @readonly
@@ -239,17 +274,18 @@ function DOMHandler(options) {
 	this.mimeType = opt.mimeType || MIME_TYPE.XML_APPLICATION;
 
 	/**
-	 * The namespace to use to create an XML document. For the following reasons this is required:
+	 * The namespace to use to create an XML document.
+	 * For the following reasons this is required:
+	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace,
+	 *   since at that point there is no way for the parser to know what the default namespace from the document will be.
+	 * - When creating using `DOMImplementation.createDocument` it is required to pass a namespace,
+	 *   to determine the correct `Document.contentType`, which should match `this.mimeType`.
+	 * - When parsing an XML document with the `application/xhtml+xml` mimeType,
+	 *   the HTML namespace needs to be the default namespace.
 	 *
-	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace, since at that point there is no way for the parser
-	 *   to know what the default namespace from the document will be.
-	 * - When creating using `DOMImplementation.createDocument` it is required to pass a namespace, to determine the correct
-	 *   `Document.contentType`, which should match `this.mimeType`.
-	 * - When parsing an XML document with the `application/xhtml+xml` mimeType, the HTML namespace needs to be the default namespace.
-	 *
-	 * @private
-	 * @type {string | null}
+	 * @type {string|null}
 	 * @readonly
+	 * @private
 	 */
 	this.defaultNamespace = opt.defaultNamespace || null;
 
@@ -260,17 +296,19 @@ function DOMHandler(options) {
 	this.cdata = false;
 
 	/**
-	 * The last `Element` that was created by `startElement`. `endElement` sets it to the `currentElement.parentNode`.
+	 * The last `Element` that was created by `startElement`.
+	 * `endElement` sets it to the `currentElement.parentNode`.
 	 *
 	 * Note: The sax parser currently sets it to white space text nodes between tags.
 	 *
-	 * @private
 	 * @type {Element | Node | undefined}
+	 * @private
 	 */
 	this.currentElement = undefined;
 
 	/**
-	 * The Document that is created as part of `startDocument`, and returned by `DOMParser.parseFromString`.
+	 * The Document that is created as part of `startDocument`,
+	 * and returned by `DOMParser.parseFromString`.
 	 *
 	 * @type {Document | undefined}
 	 * @readonly
@@ -278,12 +316,15 @@ function DOMHandler(options) {
 	this.doc = undefined;
 
 	/**
-	 * The locator is stored as part of setDocumentLocator. It is controlled and mutated by the SAX parser to store the current
-	 * parsing position. It is used by DOMHandler to set `columnNumber` and `lineNumber` on the DOM nodes.
+	 * The locator is stored as part of setDocumentLocator.
+	 * It is controlled and mutated by the SAX parser
+	 * to store the current parsing position.
+	 * It is used by DOMHandler to set `columnNumber` and `lineNumber`
+	 * on the DOM nodes.
 	 *
-	 * @private
 	 * @type {Readonly<Locator> | undefined}
 	 * @readonly (the sax parser currently sometimes set's it)
+	 * @private
 	 */
 	this.locator = undefined;
 	/**
@@ -300,11 +341,12 @@ function position(locator, node) {
 
 DOMHandler.prototype = {
 	/**
-	 * Either creates an XML or an HTML document and stores it under `this.doc`. If it is an XML document, `this.defaultNamespace`
-	 * is used to create it, and it will not contain any `childNodes`. If it is an HTML document, it will be created without any
-	 * `childNodes`.
+	 * Either creates an XML or an HTML document and stores it under `this.doc`.
+	 * If it is an XML document, `this.defaultNamespace` is used to create it,
+	 * and it will not contain any `childNodes`.
+	 * If it is an HTML document, it will be created without any `childNodes`.
 	 *
-	 * @see http://www.saxproject.org/apidoc/org/xml/sax/ContentHandler.html
+	 * @see  http://www.saxproject.org/apidoc/org/xml/sax/ContentHandler.html
 	 */
 	startDocument: function () {
 		var impl = new DOMImplementation();
@@ -362,7 +404,8 @@ DOMHandler.prototype = {
 		this.doc.normalize();
 	},
 	/**
-	 * Stores the locator to be able to set the `columnNumber` and `lineNumber` on the created DOM nodes.
+	 * Stores the locator to be able to set the `columnNumber` and `lineNumber`
+	 * on the created DOM nodes.
 	 *
 	 * @param {Locator} locator
 	 */
@@ -408,7 +451,9 @@ DOMHandler.prototype = {
 			console.error('[xmldom ' + level + ']\t' + message, _locator(this.locator));
 		}
 	},
-	/** @see http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html */
+	/**
+	 * @see http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
+	 */
 	warning: function (message) {
 		this.reportError('warning', message);
 	},
@@ -496,7 +541,8 @@ function appendElement(handler, node) {
 }
 
 /**
- * A method that prevents any further parsing when an `error` with level `error` is reported during parsing.
+ * A method that prevents any further parsing when an `error`
+ * with level `error` is reported during parsing.
  *
  * @see DOMParserOptions.onError
  * @see onWarningStopParsing

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -21,18 +21,14 @@ var XMLReader = sax.XMLReader;
  *
  * > XML parsed entities are often stored in computer files which,
  * > for editing convenience, are organized into lines.
- * > These lines are typically separated by some combination
- * > of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
+ * > These lines are typically separated by some combination > of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
  * >
- * > To simplify the tasks of applications, the XML processor must behave
- * > as if it normalized all line breaks in external parsed entities (including the document entity)
+ * > To simplify the tasks of applications, the XML processor must behave > as if it normalized all line breaks in external parsed
+ * entities (including the document entity)
  * > on input, before parsing, by translating all of the following to a single #xA character:
  * >
- * > 1. the two-character sequence #xD #xA
- * > 2. the two-character sequence #xD #x85
- * > 3. the single character #x85
- * > 4. the single character #x2028
- * > 5. any #xD character that is not immediately followed by #xA or #x85.
+ * > 1. the two-character sequence #xD #xA > 2. the two-character sequence #xD #x85 > 3. the single character #x85 > 4. the single
+ * character #x2028 > 5. any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}
@@ -55,8 +51,7 @@ function normalizeLineEndings(input) {
  * @property {typeof DOMHandler} [domHandler]
  * For internal testing: The class for creating an instance for handling events from the SAX parser.
  * __**Warning: By configuring a faulty implementation,
- * the specified behavior can completely be broken.**__
- *
+ * the specified behavior can completely be broken.**__.
  * @property {Function} [errorHandler]
  * DEPRECATED! use `onError` instead.
  * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]
@@ -68,36 +63,31 @@ function normalizeLineEndings(input) {
  * If the provided method throws, a `ParserError` is thrown,
  * which prevents any further processing.
  *
- * Be aware that many `warning`s are considered an error
- * that prevents further processing in most implementations.
- *.
+ * Be aware that many `warning`s are considered an error that prevents further processing in most implementations.
+ * .
  * @property {boolean} [locator=true]
- * Configures if the nodes created during parsing
- * will have a `lineNumber` and a `columnNumber` attribute
- * describing their location in the XML string.
+ * Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber` attribute describing their
+ * location in the XML string.
  * Default is true.
  * @property {(string) => string} [normalizeLineEndings]
  * used to replace line endings before parsing, defaults to `normalizeLineEndings`
- * @property {object} [xmlns]
+ * @property {Object} [xmlns]
  * The XML namespaces that should be assumed when parsing.
  * The default namespace can be provided by the key that is the empty string.
  * When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`,
  * the default namespace that will be used,
  * will be overridden according to the specification.
- *
- * @see normalizeLineEndings
+ * @see NormalizeLineEndings.
  */
 
 /**
- * The DOMParser interface provides the ability to parse XML or HTML source code
- * from a string into a DOM `Document`.
+ * The DOMParser interface provides the ability to parse XML or HTML source code from a string into a DOM `Document`.
  *
  * _xmldom is different from the spec in that it allows an `options` parameter,
- * to control the behavior._
+ * to control the behavior._.
  *
+ * @class
  * @param {DOMParserOptions} [options]
- * @constructor
- *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
  * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
  */
@@ -108,20 +98,20 @@ function DOMParser(options) {
 	 * The method to use instead of `Object.assign` (defaults to or `conventions.assign`),
 	 * which is used to copy values from the options before they are used for parsing.
 	 *
-	 * @type {function (target: object, source: object | null | undefined): object}
+	 * @type {function (target: Object, source: Object | null | undefined): Object}
+	 * @access private
+	 * @see Conventions.assign.
 	 * @readonly
-	 * @private
-	 * @see conventions.assign
 	 */
 	this.assign = options.assign || conventions.assign;
 
 	/**
 	 * For internal testing: The class for creating an instance for handling events from the SAX parser.
-	 * __**Warning: By configuring a faulty implementation, the specified behavior can completely be broken.**__
+	 * __**Warning: By configuring a faulty implementation, the specified behavior can completely be broken.**__.
 	 *
 	 * @type {typeof DOMHandler}
+	 * @access private
 	 * @readonly
-	 * @private
 	 */
 	this.domHandler = options.domHandler || DOMHandler;
 
@@ -134,13 +124,11 @@ function DOMParser(options) {
 	 * If the provided method throws, a `ParserError` is thrown,
 	 * which prevents any further processing.
 	 *
-	 * Be aware that many `warning`s are considered an error
-	 * that prevents further processing in most implementations.
+	 * Be aware that many `warning`s are considered an error that prevents further processing in most implementations.
 	 *
 	 * @type {function(level:ErrorLevel, message:string, context: DOMHandler):void}
-	 *
-	 * @see onErrorStopParsing
-	 * @see onWarningStopParsing
+	 * @see OnErrorStopParsing.
+	 * @see OnWarningStopParsing.
 	 */
 	this.onError = options.onError || options.errorHandler;
 	if (options.errorHandler && typeof options.errorHandler !== 'function') {
@@ -158,10 +146,10 @@ function DOMParser(options) {
 	this.normalizeLineEndings = options.normalizeLineEndings || normalizeLineEndings;
 
 	/**
-	 * Configures if the nodes created during parsing
-	 * will have a `lineNumber` and a `columnNumber` attribute
-	 * describing their location in the XML string.
+	 * Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber` attribute describing their
+	 * location in the XML string.
 	 * Default is true.
+	 *
 	 * @type {boolean}
 	 * @readonly
 	 */
@@ -172,7 +160,8 @@ function DOMParser(options) {
 	 * When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`,
 	 * the default namespace that will be used,
 	 * will be overridden according to the specification.
-	 * @type {Readonly<object>}
+	 *
+	 * @type {Readonly<Object>}
 	 * @readonly
 	 */
 	this.xmlns = options.xmlns || {};
@@ -180,28 +169,26 @@ function DOMParser(options) {
 
 /**
  * Parses `source` using the options in the way configured by the `DOMParserOptions` of `this`
- * `DOMParser`. If `mimeType` is `text/html` an HTML `Document` is created, otherwise an XML
- * `Document` is created.
+ * `DOMParser`. If `mimeType` is `text/html` an HTML `Document` is created, otherwise an XML `Document` is created.
  *
  * __It behaves different from the description in the living standard__:
- * - Uses the `options` passed to the `DOMParser` constructor to modify the
- *   behavior.
+ * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior.
  * - Any unexpected input is reported to `onError` with either a `warning`, `error` or `fatalError` level.
- *   - Any `fatalError` throws a `ParseError` which prevents further processing.
- *   - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing
- * - If no `Document` was created during parsing it is reported as a `fatalError`.
+ * - Any `fatalError` throws a `ParseError` which prevents further processing.
+ * - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing - If no `Document` was created
+ * during parsing it is reported as a `fatalError`.
  * __**Warning: By configuring a faulty DOMHandler implementation,
- * the specified behavior can completely be broken.**__
+ * the specified behavior can completely be broken.**__.
  *
- * @param {string} source The XML mime type only allows string input!
+ * @param {string} source
+ * The XML mime type only allows string input!
  * @param {string} [mimeType='application/xml']
- *        the mimeType or contentType of the document to be created
- *        determines the `type` of document created (XML or HTML)
- *
- * @throws ParseError for any `fatalError` or anything that is thrown by `onError`
- * @throws TypeError for any invalid `mimeType`
- * @returns the `Document` node
- *
+ * the mimeType or contentType of the document to be created determines the `type` of document created (XML or HTML)
+ * @returns The `Document` node.
+ * @throws
+ * ParseError for any `fatalError` or anything that is thrown by `onError`
+ * @throws
+ * TypeError for any invalid `mimeType`
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
  * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
  */
@@ -248,7 +235,7 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 /**
  * @typedef DOMHandlerOptions
  * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION]
- * @property {string|null} [defaultNamespace=null]
+ * @property {string | null} [defaultNamespace=null]
  */
 /**
  * The class that is used to handle events from the SAX parser to create the related DOM elements.
@@ -256,7 +243,7 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
  * Some methods are only implemented as an empty function,
  * since they are (at least currently) not relevant for xmldom.
  *
- * @constructor
+ * @class
  * @param {DOMHandlerOptions} [options]
  * @see http://www.saxproject.org/apidoc/org/xml/sax/ext/DefaultHandler2.html
  */
@@ -268,8 +255,8 @@ function DOMHandler(options) {
 	 * It defaults to MIME_TYPE.XML_APPLICATION.
 	 *
 	 * @type {string}
+	 * @see MIME_TYPE.
 	 * @readonly
-	 * @see MIME_TYPE
 	 */
 	this.mimeType = opt.mimeType || MIME_TYPE.XML_APPLICATION;
 
@@ -277,21 +264,21 @@ function DOMHandler(options) {
 	 * The namespace to use to create an XML document.
 	 * For the following reasons this is required:
 	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace,
-	 *   since at that point there is no way for the parser to know what the default namespace from the document will be.
+	 * since at that point there is no way for the parser to know what the default namespace from the document will be.
 	 * - When creating using `DOMImplementation.createDocument` it is required to pass a namespace,
-	 *   to determine the correct `Document.contentType`, which should match `this.mimeType`.
+	 * to determine the correct `Document.contentType`, which should match `this.mimeType`.
 	 * - When parsing an XML document with the `application/xhtml+xml` mimeType,
-	 *   the HTML namespace needs to be the default namespace.
+	 * the HTML namespace needs to be the default namespace.
 	 *
-	 * @type {string|null}
+	 * @type {string | null}
+	 * @access private
 	 * @readonly
-	 * @private
 	 */
 	this.defaultNamespace = opt.defaultNamespace || null;
 
 	/**
-	 * @private
 	 * @type {boolean}
+	 * @access private
 	 */
 	this.cdata = false;
 
@@ -302,7 +289,7 @@ function DOMHandler(options) {
 	 * Note: The sax parser currently sets it to white space text nodes between tags.
 	 *
 	 * @type {Element | Node | undefined}
-	 * @private
+	 * @access private
 	 */
 	this.currentElement = undefined;
 
@@ -317,14 +304,14 @@ function DOMHandler(options) {
 
 	/**
 	 * The locator is stored as part of setDocumentLocator.
-	 * It is controlled and mutated by the SAX parser
-	 * to store the current parsing position.
+	 * It is controlled and mutated by the SAX parser to store the current parsing position.
 	 * It is used by DOMHandler to set `columnNumber` and `lineNumber`
 	 * on the DOM nodes.
 	 *
 	 * @type {Readonly<Locator> | undefined}
-	 * @readonly (the sax parser currently sometimes set's it)
-	 * @private
+	 * @access private
+	 * @readonly (the
+	 * sax parser currently sometimes set's it)
 	 */
 	this.locator = undefined;
 	/**
@@ -346,7 +333,7 @@ DOMHandler.prototype = {
 	 * and it will not contain any `childNodes`.
 	 * If it is an HTML document, it will be created without any `childNodes`.
 	 *
-	 * @see  http://www.saxproject.org/apidoc/org/xml/sax/ContentHandler.html
+	 * @see http://www.saxproject.org/apidoc/org/xml/sax/ContentHandler.html
 	 */
 	startDocument: function () {
 		var impl = new DOMImplementation();
@@ -463,9 +450,11 @@ DOMHandler.prototype = {
 	/**
 	 * This function reports a fatal error and throws a ParseError.
 	 *
-	 * @param {string} message - The message to be used for reporting and throwing the error.
+	 * @param {string} message
+	 * - The message to be used for reporting and throwing the error.
 	 * @returns {never} This function always throws an error and never returns a value.
-	 * @throws {ParseError} Always throws a ParseError with the provided message.
+	 * @throws {ParseError}
+	 * Always throws a ParseError with the provided message.
 	 */
 	fatalError: function (message) {
 		this.reportError('fatalError', message);
@@ -544,8 +533,8 @@ function appendElement(handler, node) {
  * A method that prevents any further parsing when an `error`
  * with level `error` is reported during parsing.
  *
- * @see DOMParserOptions.onError
- * @see onWarningStopParsing
+ * @see DOMParserOptions.onError.
+ * @see OnWarningStopParsing.
  */
 function onErrorStopParsing(level) {
 	if (level === 'error') throw 'onErrorStopParsing';
@@ -554,8 +543,8 @@ function onErrorStopParsing(level) {
 /**
  * A method that prevents any further parsing when any `error` is reported during parsing.
  *
- * @see DOMParserOptions.onError
- * @see onErrorStopParsing
+ * @see DOMParserOptions.onError.
+ * @see OnErrorStopParsing.
  */
 function onWarningStopParsing() {
 	throw 'onWarningStopParsing';

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -98,9 +98,9 @@ function DOMParser(options) {
 	 * The method to use instead of `Object.assign` (defaults to or `conventions.assign`),
 	 * which is used to copy values from the options before they are used for parsing.
 	 *
-	 * @type {function (target: Object, source: Object | null | undefined): Object}
+	 * @type {conventions.assign}
 	 * @access private
-	 * @see Conventions.assign.
+	 * @see {@link conventions.assign}
 	 * @readonly
 	 */
 	this.assign = options.assign || conventions.assign;

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -95,8 +95,8 @@ function DOMParser(options) {
 	options = options || { locator: true };
 
 	/**
-	 * The method to use instead of `Object.assign` (defaults to or `conventions.assign`),
-	 * which is used to copy values from the options before they are used for parsing.
+	 * The method to use instead of `conventions.assign`, which is used to copy values from `options` before they are used for
+	 * parsing.
 	 *
 	 * @type {conventions.assign}
 	 * @access private

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -24,9 +24,7 @@ var XMLReader = sax.XMLReader;
  * document entity) on input, before parsing, by translating all of the following to a single #xA Character:
  *
  * 1. The two-character sequence #xD #xA 2. The two-character sequence #xD #x85 3. The single character #x85 4. The Single
- * character
- *
- * - #x2028 5. Any #xD character that is not immediately followed by #xA or #x85.
+ * character * #x2028 5. Any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}
@@ -43,33 +41,232 @@ function normalizeLineEndings(input) {
 
 /**
  * @typedef DOMParserOptions
- * @property {typeof assign} assign
- * The method to use instead of `Object.assign`
- * (or if not available `conventions.assign`), which is used to copy values from the options before they are used for parsing.
- * Default is `Object.assign || conventions.assign`
- * @property {typeof DOMHandler} [domHandler]
- * For internal testing: The class for creating an instance for handling events from the SAX parser. ****Warning: By configuring a
- * faulty implementation, the specified behavior can completely be broken.****
- * @property {Function} [errorHandler]
- * DEPRECATED! use `onError` instead.
- * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]
- * A function that is invoked for every error that occurs during parsing.
+ * @property {typeof conventions.assign}                                            [assign=Object.assign || conventions.assign]  The
+ *                                                                                                                                method
+ *                                                                                                                                to
+ *                                                                                                                                use
+ *                                                                                                                                instead
+ *                                                                                                                                of
+ *                                                                                                                                `Object.assign`
  *
- * If it is not provided, all errors are reported to `console.error` and only `fatalError`s are thrown as a `ParseError`, which
- * prevents any further processing. If the provided method throws, a `ParserError` is thrown, which prevents any further
- * processing.
+ *                                                                                                                                (or
+ *                                                                                                                                if
+ *                                                                                                                                not
+ *                                                                                                                                available
+ *                                                                                                                                `conventions.assign`),
+ *                                                                                                                                which
+ *                                                                                                                                is
+ *                                                                                                                                used
+ *                                                                                                                                to
+ *                                                                                                                                copy
+ *                                                                                                                                values
+ *                                                                                                                                from
+ *                                                                                                                                the
+ *                                                                                                                                options
+ *                                                                                                                                before
+ *                                                                                                                                they
+ *                                                                                                                                are
+ *                                                                                                                                used
+ *                                                                                                                                for
+ *                                                                                                                                parsing.
  *
- * Be aware that many `warning`s are considered an error that prevents further processing in most implementations. .
- * @property {boolean} [locator=true]
- * Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber`
+ *                                                                                                                                Default
+ *                                                                                                                                is
+ *                                                                                                                                `Object.assign
+ *                                                                                                                                ||
+ *                                                                                                                                conventions.assign`
+ * @property {typeof DOMHandler}                                                    [domHandler]                                  For
+ *                                                                                                                                internal
+ *                                                                                                                                testing:
+ *                                                                                                                                The
+ *                                                                                                                                class
+ *                                                                                                                                for
+ *                                                                                                                                creating
+ *                                                                                                                                an
+ *                                                                                                                                instance
+ *                                                                                                                                for
+ *                                                                                                                                handling
+ *                                                                                                                                events
+ *                                                                                                                                from
+ *                                                                                                                                the
+ *                                                                                                                                SAX
+ *                                                                                                                                parser.
+ *                                                                                                                                ****Warning:
+ *                                                                                                                                By
+ *                                                                                                                                configuring
+ *                                                                                                                                a
+ *                                                                                                                                faulty
+ *                                                                                                                                implementation,
+ *                                                                                                                                the
+ *                                                                                                                                specified
+ *                                                                                                                                behavior
+ *                                                                                                                                can
+ *                                                                                                                                completely
+ *                                                                                                                                be
+ *                                                                                                                                broken.****
+ * @property {Function}                                                             [errorHandler]                                DEPRECATED!
+ *                                                                                                                                use
+ *                                                                                                                                `onError`
+ *                                                                                                                                instead.
+ * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]                                     A
+ *                                                                                                                                function
+ *                                                                                                                                that
+ *                                                                                                                                is
+ *                                                                                                                                invoked
+ *                                                                                                                                for
+ *                                                                                                                                every
+ *                                                                                                                                error
+ *                                                                                                                                that
+ *                                                                                                                                occurs
+ *                                                                                                                                during
+ *                                                                                                                                parsing.
  *
- * Attribute describing their location in the XML string. Default is true. Default is `true`
- * @property {(string) => string} [normalizeLineEndings]
- * Used to replace line endings before parsing, defaults to `normalizeLineEndings`
- * @property {Object} [xmlns]
- * The XML namespaces that should be assumed when parsing. The default namespace can be provided by the key that is the empty
- * string. When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`, the default namespace that will be used,
- * will be overridden according to the specification.
+ *
+ *                                                                                                                                If
+ *                                                                                                                                it
+ *                                                                                                                                is
+ *                                                                                                                                not
+ *                                                                                                                                provided,
+ *                                                                                                                                all
+ *                                                                                                                                errors
+ *                                                                                                                                are
+ *                                                                                                                                reported
+ *                                                                                                                                to
+ *                                                                                                                                `console.error`
+ *                                                                                                                                and
+ *                                                                                                                                only
+ *                                                                                                                                `fatalError`s
+ *                                                                                                                                are
+ *                                                                                                                                thrown
+ *                                                                                                                                as
+ *                                                                                                                                a
+ *                                                                                                                                `ParseError`,
+ *                                                                                                                                which
+ *                                                                                                                                prevents
+ *                                                                                                                                any
+ *                                                                                                                                further
+ *                                                                                                                                processing.
+ *                                                                                                                                If
+ *                                                                                                                                the
+ *                                                                                                                                provided
+ *                                                                                                                                method
+ *                                                                                                                                throws,
+ *                                                                                                                                a
+ *                                                                                                                                `ParserError`
+ *                                                                                                                                is
+ *                                                                                                                                thrown,
+ *                                                                                                                                which
+ *                                                                                                                                prevents
+ *                                                                                                                                any
+ *                                                                                                                                further
+ *                                                                                                                                processing.
+ *
+ *
+ *                                                                                                                                Be
+ *                                                                                                                                aware
+ *                                                                                                                                that
+ *                                                                                                                                many
+ *                                                                                                                                `warning`s
+ *                                                                                                                                are
+ *                                                                                                                                considered
+ *                                                                                                                                an
+ *                                                                                                                                error
+ *                                                                                                                                that
+ *                                                                                                                                prevents
+ *                                                                                                                                further
+ *                                                                                                                                processing
+ *                                                                                                                                in
+ *                                                                                                                                most
+ *                                                                                                                                implementations.
+ *                                                                                                                                .
+ * @property {boolean}                                                              [locator=true]                                Configures
+ *                                                                                                                                if
+ *                                                                                                                                the
+ *                                                                                                                                nodes
+ *                                                                                                                                created
+ *                                                                                                                                during
+ *                                                                                                                                parsing
+ *                                                                                                                                will
+ *                                                                                                                                have
+ *                                                                                                                                a
+ *                                                                                                                                `lineNumber`
+ *                                                                                                                                and
+ *                                                                                                                                a
+ *                                                                                                                                `columnNumber`
+ *
+ *                                                                                                                                attribute
+ *                                                                                                                                describing
+ *                                                                                                                                their
+ *                                                                                                                                location
+ *                                                                                                                                in
+ *                                                                                                                                the
+ *                                                                                                                                XML
+ *                                                                                                                                string.
+ *                                                                                                                                Default
+ *                                                                                                                                is
+ *                                                                                                                                true.
+ *                                                                                                                                Default
+ *                                                                                                                                is
+ *                                                                                                                                `true`
+ * @property {(string) => string}                                                   [normalizeLineEndings]                        Used
+ *                                                                                                                                to
+ *                                                                                                                                replace
+ *                                                                                                                                line
+ *                                                                                                                                endings
+ *                                                                                                                                before
+ *                                                                                                                                parsing,
+ *                                                                                                                                defaults
+ *                                                                                                                                to
+ *                                                                                                                                `normalizeLineEndings`
+ * @property {Object}                                                               [xmlns]                                       The
+ *                                                                                                                                XML
+ *                                                                                                                                namespaces
+ *                                                                                                                                that
+ *                                                                                                                                should
+ *                                                                                                                                be
+ *                                                                                                                                assumed
+ *                                                                                                                                when
+ *                                                                                                                                parsing.
+ *                                                                                                                                The
+ *                                                                                                                                default
+ *                                                                                                                                namespace
+ *                                                                                                                                can
+ *                                                                                                                                be
+ *                                                                                                                                provided
+ *                                                                                                                                by
+ *                                                                                                                                the
+ *                                                                                                                                key
+ *                                                                                                                                that
+ *                                                                                                                                is
+ *                                                                                                                                the
+ *                                                                                                                                empty
+ *                                                                                                                                string.
+ *                                                                                                                                When
+ *                                                                                                                                the
+ *                                                                                                                                `mimeType`
+ *                                                                                                                                for
+ *                                                                                                                                HTML,
+ *                                                                                                                                XHTML
+ *                                                                                                                                or
+ *                                                                                                                                SVG
+ *                                                                                                                                are
+ *                                                                                                                                passed
+ *                                                                                                                                to
+ *                                                                                                                                `parseFromString`,
+ *                                                                                                                                the
+ *                                                                                                                                default
+ *                                                                                                                                namespace
+ *                                                                                                                                that
+ *                                                                                                                                will
+ *                                                                                                                                be
+ *                                                                                                                                used,
+ *                                                                                                                                will
+ *                                                                                                                                be
+ *                                                                                                                                overridden
+ *                                                                                                                                according
+ *                                                                                                                                to
+ *                                                                                                                                the
+ *                                                                                                                                specification.
  * @see NormalizeLineEndings.
  */
 
@@ -162,21 +359,18 @@ function DOMParser(options) {
  *
  * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior.
  * - Any unexpected input is reported to `onError` with either a `warning`, `error` or `fatalError` level.
+ *
  * - Any `fatalError` throws a `ParseError` which prevents further processing.
  * - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing - If no `Document` was created
  * during parsing it is reported as a `fatalError`. ****Warning: By configuring a faulty DOMHandler implementation, the specified
  * behavior can completely be broken.****
  *
- * @param {string} source
- * The XML mime type only allows string input!
- * @param {string} [mimeType='application/xml']
- * The mimeType or contentType of the document to be created determines the `type`
- * of document created (XML or HTML). Default is `'application/xml'`
+ * @param {string} source                        The XML mime type only allows string input!
+ * @param {string} [mimeType='application/xml']  The mimeType or contentType of the document to be created determines the `type`
+ *                                               of document created (XML or HTML). Default is `'application/xml'`
  * @returns The `Document` node.
- * @throws
- * ParseError for any `fatalError` or anything that is thrown by `onError`
- * @throws
- * TypeError for any invalid `mimeType`
+ * @throws ParseError for any `fatalError` or anything that is thrown by `onError`
+ * @throws TypeError for any invalid `mimeType`
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
  * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
  */
@@ -222,10 +416,8 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 
 /**
  * @typedef DOMHandlerOptions
- * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION]
- * Default is `MIME_TYPE.XML_APPLICATION`
- * @property {string | null} [defaultNamespace=null]
- * Default is `null`
+ * @property {string}        [mimeType=MIME_TYPE.XML_APPLICATION]  Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string | null} [defaultNamespace=null]               Default is `null`
  */
 /**
  * The class that is used to handle events from the SAX parser to create the related DOM elements.
@@ -294,8 +486,7 @@ function DOMHandler(options) {
 	 *
 	 * @type {Readonly<Locator> | undefined}
 	 * @access private
-	 * @readonly (the
-	 * sax parser currently sometimes set's it)
+	 * @readonly (the  sax parser currently sometimes set's it)
 	 */
 	this.locator = undefined;
 	/**
@@ -432,11 +623,9 @@ DOMHandler.prototype = {
 	/**
 	 * This function reports a fatal error and throws a ParseError.
 	 *
-	 * @param {string} message
-	 * - The message to be used for reporting and throwing the error.
+	 * @param {string} message  - The message to be used for reporting and throwing the error.
 	 * @returns {never} This function always throws an error and never returns a value.
-	 * @throws {ParseError}
-	 * Always throws a ParseError with the provided message.
+	 * @throws {ParseError} Always throws a ParseError with the provided message.
 	 */
 	fatalError: function (message) {
 		this.reportError('fatalError', message);

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -45,9 +45,9 @@ function normalizeLineEndings(input) {
 
 /**
  * @typedef DOMParserOptions
- * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign]
- * The method to use instead of `Object.assign` (or if not available `conventions.assign`),
- * which is used to copy values from the options before they are used for parsing.
+ * @property {typeof assign} [assign]
+ * The method to use instead of `conventions.assign`, which is used to copy values from `options` before they are used for
+ * parsing.
  * @property {typeof DOMHandler} [domHandler]
  * For internal testing: The class for creating an instance for handling events from the SAX parser.
  * __**Warning: By configuring a faulty implementation,

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -17,22 +17,17 @@ var ParseError = conventions.ParseError;
 var XMLReader = sax.XMLReader;
 
 /**
- * Normalizes line ending according to <https://www.w3.org/TR/xml11/#sec-line-ends>:
+ * Normalizes line ending according to [https://www.w3.org/TR/xml11/#sec-line-ends](https://www.w3.org/TR/xml11/#sec-line-ends):
+ * XML parsed entities are often stored in computer files which, for editing convenience, are organized into lines. These lines
+ * Are typically separated by some combination of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA). To simplify the tasks
+ * of applications, the XML processor must behave as if it normalized all line breaks in external parsed Entities (including the
+ * document entity) on input, before parsing, by translating all of the following to a single #xA Character:
  *
- * > XML parsed entities are often stored in computer files which,
- * > for editing convenience, are organized into lines.
- * > These lines are typically separated by some combination
- * > of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
- * >
- * > To simplify the tasks of applications, the XML processor must behave
- * > as if it normalized all line breaks in external parsed entities (including the document entity)
- * > on input, before parsing, by translating all of the following to a single #xA character:
- * >
- * > 1. the two-character sequence #xD #xA
- * > 2. the two-character sequence #xD #x85
- * > 3. the single character #x85
- * > 4. the single character #x2028
- * > 5. any #xD character that is not immediately followed by #xA or #x85.
+ * 1. The two-character sequence #xD #xA
+ * 2. The two-character sequence #xD #x85
+ * 3. The single character #x85
+ * 4. The Single character * #x2028
+ * 5. Any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}
@@ -49,55 +44,37 @@ function normalizeLineEndings(input) {
 
 /**
  * @typedef DOMParserOptions
- * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign]
- * The method to use instead of `Object.assign` (or if not available `conventions.assign`),
- * which is used to copy values from the options before they are used for parsing.
- * @property {typeof DOMHandler} [domHandler]
- * For internal testing: The class for creating an instance for handling events from the SAX parser.
- * __**Warning: By configuring a faulty implementation,
- * the specified behavior can completely be broken.**__
+ * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign] The method to use instead of `Object.assign`
+ *   (or if not available `conventions.assign`), which is used to copy values from the options before they are used for parsing.
+ *   Default is `Object.assign || conventions.assign`
+ * @property {typeof DOMHandler} [domHandler] For internal testing: The class for creating an instance for handling events from
+ *   the SAX parser. ****Warning: By configuring a faulty implementation, the specified behavior can completely be broken.****
+ * @property {Function} [errorHandler] DEPRECATED! use `onError` instead.
+ * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError] A function that is invoked for every
+ *   error that occurs during parsing.
  *
- * @property {Function} [errorHandler]
- * DEPRECATED! use `onError` instead.
- * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]
- * A function that is invoked for every error that occurs during parsing.
+ *   If it is not provided, all errors are reported to `console.error` and only `fatalError`s are thrown as a `ParseError`, which
+ *   prevents any further processing. If the provided method throws, a `ParserError` is thrown, which prevents any further
+ *   processing.
  *
- * If it is not provided, all errors are reported to `console.error`
- * and only `fatalError`s are thrown as a `ParseError`,
- * which prevents any further processing.
- * If the provided method throws, a `ParserError` is thrown,
- * which prevents any further processing.
- *
- * Be aware that many `warning`s are considered an error
- * that prevents further processing in most implementations.
- *.
- * @property {boolean} [locator=true]
- * Configures if the nodes created during parsing
- * will have a `lineNumber` and a `columnNumber` attribute
- * describing their location in the XML string.
- * Default is true.
- * @property {(string) => string} [normalizeLineEndings]
- * used to replace line endings before parsing, defaults to `normalizeLineEndings`
- * @property {object} [xmlns]
- * The XML namespaces that should be assumed when parsing.
- * The default namespace can be provided by the key that is the empty string.
- * When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`,
- * the default namespace that will be used,
- * will be overridden according to the specification.
- *
+ *   Be aware that many `warning`s are considered an error that prevents further processing in most implementations. .
+ * @property {boolean} [locator=true] Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber`
+ *   attribute describing their location in the XML string. Default is true. Default is `true`
+ * @property {(string) => string} [normalizeLineEndings] Used to replace line endings before parsing, defaults to
+ *   `normalizeLineEndings`
+ * @property {object} [xmlns] The XML namespaces that should be assumed when parsing. The default namespace can be provided by the
+ *   key that is the empty string. When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`, the default
+ *   namespace that will be used, will be overridden according to the specification.
  * @see normalizeLineEndings
  */
 
 /**
- * The DOMParser interface provides the ability to parse XML or HTML source code
- * from a string into a DOM `Document`.
+ * The DOMParser interface provides the ability to parse XML or HTML source code from a string into a DOM `Document`.
  *
- * _xmldom is different from the spec in that it allows an `options` parameter,
- * to control the behavior._
+ * _xmldom is different from the spec in that it allows an `options` parameter, to control the behavior._
  *
+ * @class
  * @param {DOMParserOptions} [options]
- * @constructor
- *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
  * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
  */
@@ -105,40 +82,36 @@ function DOMParser(options) {
 	options = options || { locator: true };
 
 	/**
-	 * The method to use instead of `Object.assign` (defaults to or `conventions.assign`),
-	 * which is used to copy values from the options before they are used for parsing.
+	 * The method to use instead of `Object.assign` (defaults to or `conventions.assign`), which is used to copy values from the
+	 * options before they are used for parsing.
 	 *
+	 * @private
 	 * @type {function (target: object, source: object | null | undefined): object}
 	 * @readonly
-	 * @private
 	 * @see conventions.assign
 	 */
 	this.assign = options.assign || conventions.assign;
 
 	/**
-	 * For internal testing: The class for creating an instance for handling events from the SAX parser.
-	 * __**Warning: By configuring a faulty implementation, the specified behavior can completely be broken.**__
+	 * For internal testing: The class for creating an instance for handling events from the SAX parser. ****Warning: By configuring
+	 * a faulty implementation, the specified behavior can completely be broken.****
 	 *
+	 * @private
 	 * @type {typeof DOMHandler}
 	 * @readonly
-	 * @private
 	 */
 	this.domHandler = options.domHandler || DOMHandler;
 
 	/**
 	 * A function that is invoked for every error that occurs during parsing.
 	 *
-	 * If it is not provided, all errors are reported to `console.error`
-	 * and only `fatalError`s are thrown as a `ParseError`,
-	 * which prevents any further processing.
-	 * If the provided method throws, a `ParserError` is thrown,
-	 * which prevents any further processing.
+	 * If it is not provided, all errors are reported to `console.error` and only `fatalError`s are thrown as a `ParseError`, which
+	 * prevents any further processing. If the provided method throws, a `ParserError` is thrown, which prevents any further
+	 * processing.
 	 *
-	 * Be aware that many `warning`s are considered an error
-	 * that prevents further processing in most implementations.
+	 * Be aware that many `warning`s are considered an error that prevents further processing in most implementations.
 	 *
 	 * @type {function(level:ErrorLevel, message:string, context: DOMHandler):void}
-	 *
 	 * @see onErrorStopParsing
 	 * @see onWarningStopParsing
 	 */
@@ -150,7 +123,7 @@ function DOMParser(options) {
 	}
 
 	/**
-	 * used to replace line endings before parsing, defaults to `normalizeLineEndings`
+	 * Used to replace line endings before parsing, defaults to `normalizeLineEndings`
 	 *
 	 * @type {(string) => string}
 	 * @readonly
@@ -158,20 +131,18 @@ function DOMParser(options) {
 	this.normalizeLineEndings = options.normalizeLineEndings || normalizeLineEndings;
 
 	/**
-	 * Configures if the nodes created during parsing
-	 * will have a `lineNumber` and a `columnNumber` attribute
-	 * describing their location in the XML string.
-	 * Default is true.
+	 * Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber` attribute describing their
+	 * location in the XML string. Default is true.
+	 *
 	 * @type {boolean}
 	 * @readonly
 	 */
 	this.locator = !!options.locator;
 
 	/**
-	 * The default namespace can be provided by the key that is the empty string.
-	 * When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`,
-	 * the default namespace that will be used,
-	 * will be overridden according to the specification.
+	 * The default namespace can be provided by the key that is the empty string. When the `mimeType` for HTML, XHTML or SVG are
+	 * passed to `parseFromString`, the default namespace that will be used, will be overridden according to the specification.
+	 *
 	 * @type {Readonly<object>}
 	 * @readonly
 	 */
@@ -179,29 +150,25 @@ function DOMParser(options) {
 }
 
 /**
- * Parses `source` using the options in the way configured by the `DOMParserOptions` of `this`
- * `DOMParser`. If `mimeType` is `text/html` an HTML `Document` is created, otherwise an XML
- * `Document` is created.
+ * Parses `source` using the options in the way configured by the `DOMParserOptions` of `this` `DOMParser`. If `mimeType` is
+ * `text/html` an HTML `Document` is created, otherwise an XML `Document` is created.
  *
- * __It behaves different from the description in the living standard__:
- * - Uses the `options` passed to the `DOMParser` constructor to modify the
- *   behavior.
+ * **It behaves different from the description in the living standard**:
+ *
+ * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior.
  * - Any unexpected input is reported to `onError` with either a `warning`, `error` or `fatalError` level.
+ *
  *   - Any `fatalError` throws a `ParseError` which prevents further processing.
  *   - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing
- * - If no `Document` was created during parsing it is reported as a `fatalError`.
- * __**Warning: By configuring a faulty DOMHandler implementation,
- * the specified behavior can completely be broken.**__
+ * - If no `Document` was created during parsing it is reported as a `fatalError`. ****Warning: By configuring a faulty DOMHandler
+ *   implementation, the specified behavior can completely be broken.****
  *
  * @param {string} source The XML mime type only allows string input!
- * @param {string} [mimeType='application/xml']
- *        the mimeType or contentType of the document to be created
- *        determines the `type` of document created (XML or HTML)
- *
+ * @param {string} [mimeType='application/xml'] The mimeType or contentType of the document to be created determines the `type` of
+ *   document created (XML or HTML). Default is `'application/xml'`
+ * @returns The `Document` node
  * @throws ParseError for any `fatalError` or anything that is thrown by `onError`
  * @throws TypeError for any invalid `mimeType`
- * @returns the `Document` node
- *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
  * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
  */
@@ -247,25 +214,23 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 
 /**
  * @typedef DOMHandlerOptions
- * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION]
- * @property {string|null} [defaultNamespace=null]
+ * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION] Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string | null} [defaultNamespace=null] Default is `null`
  */
 /**
  * The class that is used to handle events from the SAX parser to create the related DOM elements.
  *
- * Some methods are only implemented as an empty function,
- * since they are (at least currently) not relevant for xmldom.
+ * Some methods are only implemented as an empty function, since they are (at least currently) not relevant for xmldom.
  *
- * @constructor
+ * @class
  * @param {DOMHandlerOptions} [options]
  * @see http://www.saxproject.org/apidoc/org/xml/sax/ext/DefaultHandler2.html
  */
 function DOMHandler(options) {
 	var opt = options || {};
 	/**
-	 * The mime type is used to determine if the DOM handler will create an XML or HTML document.
-	 * Only if it is set to `text/html` it will create an HTML document.
-	 * It defaults to MIME_TYPE.XML_APPLICATION.
+	 * The mime type is used to determine if the DOM handler will create an XML or HTML document. Only if it is set to `text/html`
+	 * it will create an HTML document. It defaults to MIME_TYPE.XML_APPLICATION.
 	 *
 	 * @type {string}
 	 * @readonly
@@ -274,18 +239,17 @@ function DOMHandler(options) {
 	this.mimeType = opt.mimeType || MIME_TYPE.XML_APPLICATION;
 
 	/**
-	 * The namespace to use to create an XML document.
-	 * For the following reasons this is required:
-	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace,
-	 *   since at that point there is no way for the parser to know what the default namespace from the document will be.
-	 * - When creating using `DOMImplementation.createDocument` it is required to pass a namespace,
-	 *   to determine the correct `Document.contentType`, which should match `this.mimeType`.
-	 * - When parsing an XML document with the `application/xhtml+xml` mimeType,
-	 *   the HTML namespace needs to be the default namespace.
+	 * The namespace to use to create an XML document. For the following reasons this is required:
 	 *
-	 * @type {string|null}
-	 * @readonly
+	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace, since at that point there is no way for the parser
+	 *   to know what the default namespace from the document will be.
+	 * - When creating using `DOMImplementation.createDocument` it is required to pass a namespace, to determine the correct
+	 *   `Document.contentType`, which should match `this.mimeType`.
+	 * - When parsing an XML document with the `application/xhtml+xml` mimeType, the HTML namespace needs to be the default namespace.
+	 *
 	 * @private
+	 * @type {string | null}
+	 * @readonly
 	 */
 	this.defaultNamespace = opt.defaultNamespace || null;
 
@@ -296,19 +260,17 @@ function DOMHandler(options) {
 	this.cdata = false;
 
 	/**
-	 * The last `Element` that was created by `startElement`.
-	 * `endElement` sets it to the `currentElement.parentNode`.
+	 * The last `Element` that was created by `startElement`. `endElement` sets it to the `currentElement.parentNode`.
 	 *
 	 * Note: The sax parser currently sets it to white space text nodes between tags.
 	 *
-	 * @type {Element | Node | undefined}
 	 * @private
+	 * @type {Element | Node | undefined}
 	 */
 	this.currentElement = undefined;
 
 	/**
-	 * The Document that is created as part of `startDocument`,
-	 * and returned by `DOMParser.parseFromString`.
+	 * The Document that is created as part of `startDocument`, and returned by `DOMParser.parseFromString`.
 	 *
 	 * @type {Document | undefined}
 	 * @readonly
@@ -316,15 +278,12 @@ function DOMHandler(options) {
 	this.doc = undefined;
 
 	/**
-	 * The locator is stored as part of setDocumentLocator.
-	 * It is controlled and mutated by the SAX parser
-	 * to store the current parsing position.
-	 * It is used by DOMHandler to set `columnNumber` and `lineNumber`
-	 * on the DOM nodes.
+	 * The locator is stored as part of setDocumentLocator. It is controlled and mutated by the SAX parser to store the current
+	 * parsing position. It is used by DOMHandler to set `columnNumber` and `lineNumber` on the DOM nodes.
 	 *
+	 * @private
 	 * @type {Readonly<Locator> | undefined}
 	 * @readonly (the sax parser currently sometimes set's it)
-	 * @private
 	 */
 	this.locator = undefined;
 	/**
@@ -341,12 +300,11 @@ function position(locator, node) {
 
 DOMHandler.prototype = {
 	/**
-	 * Either creates an XML or an HTML document and stores it under `this.doc`.
-	 * If it is an XML document, `this.defaultNamespace` is used to create it,
-	 * and it will not contain any `childNodes`.
-	 * If it is an HTML document, it will be created without any `childNodes`.
+	 * Either creates an XML or an HTML document and stores it under `this.doc`. If it is an XML document, `this.defaultNamespace`
+	 * is used to create it, and it will not contain any `childNodes`. If it is an HTML document, it will be created without any
+	 * `childNodes`.
 	 *
-	 * @see  http://www.saxproject.org/apidoc/org/xml/sax/ContentHandler.html
+	 * @see http://www.saxproject.org/apidoc/org/xml/sax/ContentHandler.html
 	 */
 	startDocument: function () {
 		var impl = new DOMImplementation();
@@ -404,8 +362,7 @@ DOMHandler.prototype = {
 		this.doc.normalize();
 	},
 	/**
-	 * Stores the locator to be able to set the `columnNumber` and `lineNumber`
-	 * on the created DOM nodes.
+	 * Stores the locator to be able to set the `columnNumber` and `lineNumber` on the created DOM nodes.
 	 *
 	 * @param {Locator} locator
 	 */
@@ -451,9 +408,7 @@ DOMHandler.prototype = {
 			console.error('[xmldom ' + level + ']\t' + message, _locator(this.locator));
 		}
 	},
-	/**
-	 * @see http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
-	 */
+	/** @see http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html */
 	warning: function (message) {
 		this.reportError('warning', message);
 	},
@@ -541,8 +496,7 @@ function appendElement(handler, node) {
 }
 
 /**
- * A method that prevents any further parsing when an `error`
- * with level `error` is reported during parsing.
+ * A method that prevents any further parsing when an `error` with level `error` is reported during parsing.
  *
  * @see DOMParserOptions.onError
  * @see onWarningStopParsing

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -23,11 +23,8 @@ var XMLReader = sax.XMLReader;
  * of applications, the XML processor must behave as if it normalized all line breaks in external parsed Entities (including the
  * document entity) on input, before parsing, by translating all of the following to a single #xA Character:
  *
- * 1. The two-character sequence #xD #xA
- * 2. The two-character sequence #xD #x85
- * 3. The single character #x85
- * 4. The Single character * #x2028
- * 5. Any #xD character that is not immediately followed by #xA or #x85.
+ * 1. The two-character sequence #xD #xA 2. The two-character sequence #xD #x85 3. The single character #x85 4. The Single
+ * character * #x2028 5. Any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}
@@ -44,34 +41,239 @@ function normalizeLineEndings(input) {
 
 /**
  * @typedef DOMParserOptions
- * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign] The method to use instead of `Object.assign`
- *   (or if not available `conventions.assign`), which is used to copy values from the options before they are used for parsing.
- *   Default is `Object.assign || conventions.assign`
- * @property {typeof DOMHandler} [domHandler] For internal testing: The class for creating an instance for handling events from
- *   the SAX parser. ****Warning: By configuring a faulty implementation, the specified behavior can completely be broken.****
- * @property {Function} [errorHandler] DEPRECATED! use `onError` instead.
- * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError] A function that is invoked for every
- *   error that occurs during parsing.
+ * @property {typeof conventions.assign}                                            [assign=Object.assign || conventions.assign]  The
+ *                                                                                                                                method
+ *                                                                                                                                to
+ *                                                                                                                                use
+ *                                                                                                                                instead
+ *                                                                                                                                of
+ *                                                                                                                                `Object.assign`
  *
- *   If it is not provided, all errors are reported to `console.error` and only `fatalError`s are thrown as a `ParseError`, which
- *   prevents any further processing. If the provided method throws, a `ParserError` is thrown, which prevents any further
- *   processing.
+ *                                                                                                                                (or
+ *                                                                                                                                if
+ *                                                                                                                                not
+ *                                                                                                                                available
+ *                                                                                                                                `conventions.assign`),
+ *                                                                                                                                which
+ *                                                                                                                                is
+ *                                                                                                                                used
+ *                                                                                                                                to
+ *                                                                                                                                copy
+ *                                                                                                                                values
+ *                                                                                                                                from
+ *                                                                                                                                the
+ *                                                                                                                                options
+ *                                                                                                                                before
+ *                                                                                                                                they
+ *                                                                                                                                are
+ *                                                                                                                                used
+ *                                                                                                                                for
+ *                                                                                                                                parsing.
  *
- *   Be aware that many `warning`s are considered an error that prevents further processing in most implementations. .
- * @property {boolean} [locator=true] Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber`
- *   attribute describing their location in the XML string. Default is true. Default is `true`
- * @property {(string) => string} [normalizeLineEndings] Used to replace line endings before parsing, defaults to
- *   `normalizeLineEndings`
- * @property {object} [xmlns] The XML namespaces that should be assumed when parsing. The default namespace can be provided by the
- *   key that is the empty string. When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`, the default
- *   namespace that will be used, will be overridden according to the specification.
- * @see normalizeLineEndings
+ *                                                                                                                                Default
+ *                                                                                                                                is
+ *                                                                                                                                `Object.assign
+ *                                                                                                                                ||
+ *                                                                                                                                conventions.assign`
+ * @property {typeof DOMHandler}                                                    [domHandler]                                  For
+ *                                                                                                                                internal
+ *                                                                                                                                testing:
+ *                                                                                                                                The
+ *                                                                                                                                class
+ *                                                                                                                                for
+ *                                                                                                                                creating
+ *                                                                                                                                an
+ *                                                                                                                                instance
+ *                                                                                                                                for
+ *                                                                                                                                handling
+ *                                                                                                                                events
+ *                                                                                                                                from
+ *                                                                                                                                the
+ *                                                                                                                                SAX
+ *                                                                                                                                parser.
+ *                                                                                                                                ****Warning:
+ *                                                                                                                                By
+ *                                                                                                                                configuring
+ *                                                                                                                                a
+ *                                                                                                                                faulty
+ *                                                                                                                                implementation,
+ *                                                                                                                                the
+ *                                                                                                                                specified
+ *                                                                                                                                behavior
+ *                                                                                                                                can
+ *                                                                                                                                completely
+ *                                                                                                                                be
+ *                                                                                                                                broken.****
+ * @property {Function}                                                             [errorHandler]                                DEPRECATED!
+ *                                                                                                                                use
+ *                                                                                                                                `onError`
+ *                                                                                                                                instead.
+ * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]                                     A
+ *                                                                                                                                function
+ *                                                                                                                                that
+ *                                                                                                                                is
+ *                                                                                                                                invoked
+ *                                                                                                                                for
+ *                                                                                                                                every
+ *                                                                                                                                error
+ *                                                                                                                                that
+ *                                                                                                                                occurs
+ *                                                                                                                                during
+ *                                                                                                                                parsing.
+ *
+ *
+ *                                                                                                                                If
+ *                                                                                                                                it
+ *                                                                                                                                is
+ *                                                                                                                                not
+ *                                                                                                                                provided,
+ *                                                                                                                                all
+ *                                                                                                                                errors
+ *                                                                                                                                are
+ *                                                                                                                                reported
+ *                                                                                                                                to
+ *                                                                                                                                `console.error`
+ *                                                                                                                                and
+ *                                                                                                                                only
+ *                                                                                                                                `fatalError`s
+ *                                                                                                                                are
+ *                                                                                                                                thrown
+ *                                                                                                                                as
+ *                                                                                                                                a
+ *                                                                                                                                `ParseError`,
+ *                                                                                                                                which
+ *                                                                                                                                prevents
+ *                                                                                                                                any
+ *                                                                                                                                further
+ *                                                                                                                                processing.
+ *                                                                                                                                If
+ *                                                                                                                                the
+ *                                                                                                                                provided
+ *                                                                                                                                method
+ *                                                                                                                                throws,
+ *                                                                                                                                a
+ *                                                                                                                                `ParserError`
+ *                                                                                                                                is
+ *                                                                                                                                thrown,
+ *                                                                                                                                which
+ *                                                                                                                                prevents
+ *                                                                                                                                any
+ *                                                                                                                                further
+ *                                                                                                                                processing.
+ *
+ *
+ *                                                                                                                                Be
+ *                                                                                                                                aware
+ *                                                                                                                                that
+ *                                                                                                                                many
+ *                                                                                                                                `warning`s
+ *                                                                                                                                are
+ *                                                                                                                                considered
+ *                                                                                                                                an
+ *                                                                                                                                error
+ *                                                                                                                                that
+ *                                                                                                                                prevents
+ *                                                                                                                                further
+ *                                                                                                                                processing
+ *                                                                                                                                in
+ *                                                                                                                                most
+ *                                                                                                                                implementations.
+ *                                                                                                                                .
+ * @property {boolean}                                                              [locator=true]                                Configures
+ *                                                                                                                                if
+ *                                                                                                                                the
+ *                                                                                                                                nodes
+ *                                                                                                                                created
+ *                                                                                                                                during
+ *                                                                                                                                parsing
+ *                                                                                                                                will
+ *                                                                                                                                have
+ *                                                                                                                                a
+ *                                                                                                                                `lineNumber`
+ *                                                                                                                                and
+ *                                                                                                                                a
+ *                                                                                                                                `columnNumber`
+ *
+ *                                                                                                                                attribute
+ *                                                                                                                                describing
+ *                                                                                                                                their
+ *                                                                                                                                location
+ *                                                                                                                                in
+ *                                                                                                                                the
+ *                                                                                                                                XML
+ *                                                                                                                                string.
+ *                                                                                                                                Default
+ *                                                                                                                                is
+ *                                                                                                                                true.
+ *                                                                                                                                Default
+ *                                                                                                                                is
+ *                                                                                                                                `true`
+ * @property {(string) => string}                                                   [normalizeLineEndings]                        Used
+ *                                                                                                                                to
+ *                                                                                                                                replace
+ *                                                                                                                                line
+ *                                                                                                                                endings
+ *                                                                                                                                before
+ *                                                                                                                                parsing,
+ *                                                                                                                                defaults
+ *                                                                                                                                to
+ *                                                                                                                                `normalizeLineEndings`
+ * @property {Object}                                                               [xmlns]                                       The
+ *                                                                                                                                XML
+ *                                                                                                                                namespaces
+ *                                                                                                                                that
+ *                                                                                                                                should
+ *                                                                                                                                be
+ *                                                                                                                                assumed
+ *                                                                                                                                when
+ *                                                                                                                                parsing.
+ *                                                                                                                                The
+ *                                                                                                                                default
+ *                                                                                                                                namespace
+ *                                                                                                                                can
+ *                                                                                                                                be
+ *                                                                                                                                provided
+ *                                                                                                                                by
+ *                                                                                                                                the
+ *                                                                                                                                key
+ *                                                                                                                                that
+ *                                                                                                                                is
+ *                                                                                                                                the
+ *                                                                                                                                empty
+ *                                                                                                                                string.
+ *                                                                                                                                When
+ *                                                                                                                                the
+ *                                                                                                                                `mimeType`
+ *                                                                                                                                for
+ *                                                                                                                                HTML,
+ *                                                                                                                                XHTML
+ *                                                                                                                                or
+ *                                                                                                                                SVG
+ *                                                                                                                                are
+ *                                                                                                                                passed
+ *                                                                                                                                to
+ *                                                                                                                                `parseFromString`,
+ *                                                                                                                                the
+ *                                                                                                                                default
+ *                                                                                                                                namespace
+ *                                                                                                                                that
+ *                                                                                                                                will
+ *                                                                                                                                be
+ *                                                                                                                                used,
+ *                                                                                                                                will
+ *                                                                                                                                be
+ *                                                                                                                                overridden
+ *                                                                                                                                according
+ *                                                                                                                                to
+ *                                                                                                                                the
+ *                                                                                                                                specification.
+ * @see NormalizeLineEndings.
  */
 
 /**
  * The DOMParser interface provides the ability to parse XML or HTML source code from a string into a DOM `Document`.
  *
- * _xmldom is different from the spec in that it allows an `options` parameter, to control the behavior._
+ * _xmldom is different from the spec in that it allows an `options` parameter, to control the behavior._.
  *
  * @class
  * @param {DOMParserOptions} [options]
@@ -85,10 +287,10 @@ function DOMParser(options) {
 	 * The method to use instead of `Object.assign` (defaults to or `conventions.assign`), which is used to copy values from the
 	 * options before they are used for parsing.
 	 *
-	 * @private
-	 * @type {function (target: object, source: object | null | undefined): object}
+	 * @type {function (target: Object, source: Object | null | undefined): Object}
+	 * @access private
+	 * @see Conventions.assign.
 	 * @readonly
-	 * @see conventions.assign
 	 */
 	this.assign = options.assign || conventions.assign;
 
@@ -96,8 +298,8 @@ function DOMParser(options) {
 	 * For internal testing: The class for creating an instance for handling events from the SAX parser. ****Warning: By configuring
 	 * a faulty implementation, the specified behavior can completely be broken.****
 	 *
-	 * @private
 	 * @type {typeof DOMHandler}
+	 * @access private
 	 * @readonly
 	 */
 	this.domHandler = options.domHandler || DOMHandler;
@@ -112,8 +314,8 @@ function DOMParser(options) {
 	 * Be aware that many `warning`s are considered an error that prevents further processing in most implementations.
 	 *
 	 * @type {function(level:ErrorLevel, message:string, context: DOMHandler):void}
-	 * @see onErrorStopParsing
-	 * @see onWarningStopParsing
+	 * @see OnErrorStopParsing.
+	 * @see OnWarningStopParsing.
 	 */
 	this.onError = options.onError || options.errorHandler;
 	if (options.errorHandler && typeof options.errorHandler !== 'function') {
@@ -143,7 +345,7 @@ function DOMParser(options) {
 	 * The default namespace can be provided by the key that is the empty string. When the `mimeType` for HTML, XHTML or SVG are
 	 * passed to `parseFromString`, the default namespace that will be used, will be overridden according to the specification.
 	 *
-	 * @type {Readonly<object>}
+	 * @type {Readonly<Object>}
 	 * @readonly
 	 */
 	this.xmlns = options.xmlns || {};
@@ -158,15 +360,15 @@ function DOMParser(options) {
  * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior.
  * - Any unexpected input is reported to `onError` with either a `warning`, `error` or `fatalError` level.
  *
- *   - Any `fatalError` throws a `ParseError` which prevents further processing.
- *   - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing
- * - If no `Document` was created during parsing it is reported as a `fatalError`. ****Warning: By configuring a faulty DOMHandler
- *   implementation, the specified behavior can completely be broken.****
+ * - Any `fatalError` throws a `ParseError` which prevents further processing.
+ * - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing - If no `Document` was created
+ * during parsing it is reported as a `fatalError`. ****Warning: By configuring a faulty DOMHandler implementation, the specified
+ * behavior can completely be broken.****
  *
- * @param {string} source The XML mime type only allows string input!
- * @param {string} [mimeType='application/xml'] The mimeType or contentType of the document to be created determines the `type` of
- *   document created (XML or HTML). Default is `'application/xml'`
- * @returns The `Document` node
+ * @param {string} source                        The XML mime type only allows string input!
+ * @param {string} [mimeType='application/xml']  The mimeType or contentType of the document to be created determines the `type`
+ *                                               of document created (XML or HTML). Default is `'application/xml'`
+ * @returns The `Document` node.
  * @throws ParseError for any `fatalError` or anything that is thrown by `onError`
  * @throws TypeError for any invalid `mimeType`
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
@@ -214,8 +416,8 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 
 /**
  * @typedef DOMHandlerOptions
- * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION] Default is `MIME_TYPE.XML_APPLICATION`
- * @property {string | null} [defaultNamespace=null] Default is `null`
+ * @property {string}        [mimeType=MIME_TYPE.XML_APPLICATION]  Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string | null} [defaultNamespace=null]               Default is `null`
  */
 /**
  * The class that is used to handle events from the SAX parser to create the related DOM elements.
@@ -233,29 +435,30 @@ function DOMHandler(options) {
 	 * it will create an HTML document. It defaults to MIME_TYPE.XML_APPLICATION.
 	 *
 	 * @type {string}
+	 * @see MIME_TYPE.
 	 * @readonly
-	 * @see MIME_TYPE
 	 */
 	this.mimeType = opt.mimeType || MIME_TYPE.XML_APPLICATION;
 
 	/**
 	 * The namespace to use to create an XML document. For the following reasons this is required:
 	 *
-	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace, since at that point there is no way for the parser
-	 *   to know what the default namespace from the document will be.
+	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace, since at that point there is no way for the
+	 * parser to know what the default namespace from the document will be.
 	 * - When creating using `DOMImplementation.createDocument` it is required to pass a namespace, to determine the correct
-	 *   `Document.contentType`, which should match `this.mimeType`.
-	 * - When parsing an XML document with the `application/xhtml+xml` mimeType, the HTML namespace needs to be the default namespace.
+	 * `Document.contentType`, which should match `this.mimeType`.
+	 * - When parsing an XML document with the `application/xhtml+xml` mimeType, the HTML namespace needs to be the default
+	 * namespace.
 	 *
-	 * @private
 	 * @type {string | null}
+	 * @access private
 	 * @readonly
 	 */
 	this.defaultNamespace = opt.defaultNamespace || null;
 
 	/**
-	 * @private
 	 * @type {boolean}
+	 * @access private
 	 */
 	this.cdata = false;
 
@@ -264,8 +467,8 @@ function DOMHandler(options) {
 	 *
 	 * Note: The sax parser currently sets it to white space text nodes between tags.
 	 *
-	 * @private
 	 * @type {Element | Node | undefined}
+	 * @access private
 	 */
 	this.currentElement = undefined;
 
@@ -281,9 +484,9 @@ function DOMHandler(options) {
 	 * The locator is stored as part of setDocumentLocator. It is controlled and mutated by the SAX parser to store the current
 	 * parsing position. It is used by DOMHandler to set `columnNumber` and `lineNumber` on the DOM nodes.
 	 *
-	 * @private
 	 * @type {Readonly<Locator> | undefined}
-	 * @readonly (the sax parser currently sometimes set's it)
+	 * @access private
+	 * @readonly (the  sax parser currently sometimes set's it)
 	 */
 	this.locator = undefined;
 	/**
@@ -408,7 +611,9 @@ DOMHandler.prototype = {
 			console.error('[xmldom ' + level + ']\t' + message, _locator(this.locator));
 		}
 	},
-	/** @see http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html */
+	/**
+	 * @see http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
+	 */
 	warning: function (message) {
 		this.reportError('warning', message);
 	},
@@ -418,7 +623,7 @@ DOMHandler.prototype = {
 	/**
 	 * This function reports a fatal error and throws a ParseError.
 	 *
-	 * @param {string} message - The message to be used for reporting and throwing the error.
+	 * @param {string} message  - The message to be used for reporting and throwing the error.
 	 * @returns {never} This function always throws an error and never returns a value.
 	 * @throws {ParseError} Always throws a ParseError with the provided message.
 	 */
@@ -498,8 +703,8 @@ function appendElement(handler, node) {
 /**
  * A method that prevents any further parsing when an `error` with level `error` is reported during parsing.
  *
- * @see DOMParserOptions.onError
- * @see onWarningStopParsing
+ * @see DOMParserOptions.onError.
+ * @see OnWarningStopParsing.
  */
 function onErrorStopParsing(level) {
 	if (level === 'error') throw 'onErrorStopParsing';
@@ -508,8 +713,8 @@ function onErrorStopParsing(level) {
 /**
  * A method that prevents any further parsing when any `error` is reported during parsing.
  *
- * @see DOMParserOptions.onError
- * @see onErrorStopParsing
+ * @see DOMParserOptions.onError.
+ * @see OnErrorStopParsing.
  */
 function onWarningStopParsing() {
 	throw 'onWarningStopParsing';

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -201,10 +201,10 @@ function DOMParser(options) {
  * the mimeType or contentType of the document to be created determines the `type` of document
  * created (XML or HTML)
  * @returns The `Document` node.
- * @throws
- * ParseError for any `fatalError` or anything that is thrown by `onError`
- * @throws
- * TypeError for any invalid `mimeType`
+ * @throws {ParseError}
+ * for any `fatalError` or anything that is thrown by `onError`
+ * @throws {TypeError}
+ * for any invalid `mimeType`
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
  * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
  */

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -24,7 +24,9 @@ var XMLReader = sax.XMLReader;
  * document entity) on input, before parsing, by translating all of the following to a single #xA Character:
  *
  * 1. The two-character sequence #xD #xA 2. The two-character sequence #xD #x85 3. The single character #x85 4. The Single
- * character * #x2028 5. Any #xD character that is not immediately followed by #xA or #x85.
+ * character
+ *
+ * - #x2028 5. Any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}
@@ -41,232 +43,33 @@ function normalizeLineEndings(input) {
 
 /**
  * @typedef DOMParserOptions
- * @property {typeof conventions.assign}                                            [assign=Object.assign || conventions.assign]  The
- *                                                                                                                                method
- *                                                                                                                                to
- *                                                                                                                                use
- *                                                                                                                                instead
- *                                                                                                                                of
- *                                                                                                                                `Object.assign`
+ * @property {typeof assign} assign
+ * The method to use instead of `Object.assign`
+ * (or if not available `conventions.assign`), which is used to copy values from the options before they are used for parsing.
+ * Default is `Object.assign || conventions.assign`
+ * @property {typeof DOMHandler} [domHandler]
+ * For internal testing: The class for creating an instance for handling events from the SAX parser. ****Warning: By configuring a
+ * faulty implementation, the specified behavior can completely be broken.****
+ * @property {Function} [errorHandler]
+ * DEPRECATED! use `onError` instead.
+ * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]
+ * A function that is invoked for every error that occurs during parsing.
  *
- *                                                                                                                                (or
- *                                                                                                                                if
- *                                                                                                                                not
- *                                                                                                                                available
- *                                                                                                                                `conventions.assign`),
- *                                                                                                                                which
- *                                                                                                                                is
- *                                                                                                                                used
- *                                                                                                                                to
- *                                                                                                                                copy
- *                                                                                                                                values
- *                                                                                                                                from
- *                                                                                                                                the
- *                                                                                                                                options
- *                                                                                                                                before
- *                                                                                                                                they
- *                                                                                                                                are
- *                                                                                                                                used
- *                                                                                                                                for
- *                                                                                                                                parsing.
+ * If it is not provided, all errors are reported to `console.error` and only `fatalError`s are thrown as a `ParseError`, which
+ * prevents any further processing. If the provided method throws, a `ParserError` is thrown, which prevents any further
+ * processing.
  *
- *                                                                                                                                Default
- *                                                                                                                                is
- *                                                                                                                                `Object.assign
- *                                                                                                                                ||
- *                                                                                                                                conventions.assign`
- * @property {typeof DOMHandler}                                                    [domHandler]                                  For
- *                                                                                                                                internal
- *                                                                                                                                testing:
- *                                                                                                                                The
- *                                                                                                                                class
- *                                                                                                                                for
- *                                                                                                                                creating
- *                                                                                                                                an
- *                                                                                                                                instance
- *                                                                                                                                for
- *                                                                                                                                handling
- *                                                                                                                                events
- *                                                                                                                                from
- *                                                                                                                                the
- *                                                                                                                                SAX
- *                                                                                                                                parser.
- *                                                                                                                                ****Warning:
- *                                                                                                                                By
- *                                                                                                                                configuring
- *                                                                                                                                a
- *                                                                                                                                faulty
- *                                                                                                                                implementation,
- *                                                                                                                                the
- *                                                                                                                                specified
- *                                                                                                                                behavior
- *                                                                                                                                can
- *                                                                                                                                completely
- *                                                                                                                                be
- *                                                                                                                                broken.****
- * @property {Function}                                                             [errorHandler]                                DEPRECATED!
- *                                                                                                                                use
- *                                                                                                                                `onError`
- *                                                                                                                                instead.
- * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]                                     A
- *                                                                                                                                function
- *                                                                                                                                that
- *                                                                                                                                is
- *                                                                                                                                invoked
- *                                                                                                                                for
- *                                                                                                                                every
- *                                                                                                                                error
- *                                                                                                                                that
- *                                                                                                                                occurs
- *                                                                                                                                during
- *                                                                                                                                parsing.
+ * Be aware that many `warning`s are considered an error that prevents further processing in most implementations. .
+ * @property {boolean} [locator=true]
+ * Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber`
  *
- *
- *                                                                                                                                If
- *                                                                                                                                it
- *                                                                                                                                is
- *                                                                                                                                not
- *                                                                                                                                provided,
- *                                                                                                                                all
- *                                                                                                                                errors
- *                                                                                                                                are
- *                                                                                                                                reported
- *                                                                                                                                to
- *                                                                                                                                `console.error`
- *                                                                                                                                and
- *                                                                                                                                only
- *                                                                                                                                `fatalError`s
- *                                                                                                                                are
- *                                                                                                                                thrown
- *                                                                                                                                as
- *                                                                                                                                a
- *                                                                                                                                `ParseError`,
- *                                                                                                                                which
- *                                                                                                                                prevents
- *                                                                                                                                any
- *                                                                                                                                further
- *                                                                                                                                processing.
- *                                                                                                                                If
- *                                                                                                                                the
- *                                                                                                                                provided
- *                                                                                                                                method
- *                                                                                                                                throws,
- *                                                                                                                                a
- *                                                                                                                                `ParserError`
- *                                                                                                                                is
- *                                                                                                                                thrown,
- *                                                                                                                                which
- *                                                                                                                                prevents
- *                                                                                                                                any
- *                                                                                                                                further
- *                                                                                                                                processing.
- *
- *
- *                                                                                                                                Be
- *                                                                                                                                aware
- *                                                                                                                                that
- *                                                                                                                                many
- *                                                                                                                                `warning`s
- *                                                                                                                                are
- *                                                                                                                                considered
- *                                                                                                                                an
- *                                                                                                                                error
- *                                                                                                                                that
- *                                                                                                                                prevents
- *                                                                                                                                further
- *                                                                                                                                processing
- *                                                                                                                                in
- *                                                                                                                                most
- *                                                                                                                                implementations.
- *                                                                                                                                .
- * @property {boolean}                                                              [locator=true]                                Configures
- *                                                                                                                                if
- *                                                                                                                                the
- *                                                                                                                                nodes
- *                                                                                                                                created
- *                                                                                                                                during
- *                                                                                                                                parsing
- *                                                                                                                                will
- *                                                                                                                                have
- *                                                                                                                                a
- *                                                                                                                                `lineNumber`
- *                                                                                                                                and
- *                                                                                                                                a
- *                                                                                                                                `columnNumber`
- *
- *                                                                                                                                attribute
- *                                                                                                                                describing
- *                                                                                                                                their
- *                                                                                                                                location
- *                                                                                                                                in
- *                                                                                                                                the
- *                                                                                                                                XML
- *                                                                                                                                string.
- *                                                                                                                                Default
- *                                                                                                                                is
- *                                                                                                                                true.
- *                                                                                                                                Default
- *                                                                                                                                is
- *                                                                                                                                `true`
- * @property {(string) => string}                                                   [normalizeLineEndings]                        Used
- *                                                                                                                                to
- *                                                                                                                                replace
- *                                                                                                                                line
- *                                                                                                                                endings
- *                                                                                                                                before
- *                                                                                                                                parsing,
- *                                                                                                                                defaults
- *                                                                                                                                to
- *                                                                                                                                `normalizeLineEndings`
- * @property {Object}                                                               [xmlns]                                       The
- *                                                                                                                                XML
- *                                                                                                                                namespaces
- *                                                                                                                                that
- *                                                                                                                                should
- *                                                                                                                                be
- *                                                                                                                                assumed
- *                                                                                                                                when
- *                                                                                                                                parsing.
- *                                                                                                                                The
- *                                                                                                                                default
- *                                                                                                                                namespace
- *                                                                                                                                can
- *                                                                                                                                be
- *                                                                                                                                provided
- *                                                                                                                                by
- *                                                                                                                                the
- *                                                                                                                                key
- *                                                                                                                                that
- *                                                                                                                                is
- *                                                                                                                                the
- *                                                                                                                                empty
- *                                                                                                                                string.
- *                                                                                                                                When
- *                                                                                                                                the
- *                                                                                                                                `mimeType`
- *                                                                                                                                for
- *                                                                                                                                HTML,
- *                                                                                                                                XHTML
- *                                                                                                                                or
- *                                                                                                                                SVG
- *                                                                                                                                are
- *                                                                                                                                passed
- *                                                                                                                                to
- *                                                                                                                                `parseFromString`,
- *                                                                                                                                the
- *                                                                                                                                default
- *                                                                                                                                namespace
- *                                                                                                                                that
- *                                                                                                                                will
- *                                                                                                                                be
- *                                                                                                                                used,
- *                                                                                                                                will
- *                                                                                                                                be
- *                                                                                                                                overridden
- *                                                                                                                                according
- *                                                                                                                                to
- *                                                                                                                                the
- *                                                                                                                                specification.
+ * Attribute describing their location in the XML string. Default is true. Default is `true`
+ * @property {(string) => string} [normalizeLineEndings]
+ * Used to replace line endings before parsing, defaults to `normalizeLineEndings`
+ * @property {Object} [xmlns]
+ * The XML namespaces that should be assumed when parsing. The default namespace can be provided by the key that is the empty
+ * string. When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`, the default namespace that will be used,
+ * will be overridden according to the specification.
  * @see NormalizeLineEndings.
  */
 
@@ -359,18 +162,21 @@ function DOMParser(options) {
  *
  * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior.
  * - Any unexpected input is reported to `onError` with either a `warning`, `error` or `fatalError` level.
- *
  * - Any `fatalError` throws a `ParseError` which prevents further processing.
  * - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing - If no `Document` was created
  * during parsing it is reported as a `fatalError`. ****Warning: By configuring a faulty DOMHandler implementation, the specified
  * behavior can completely be broken.****
  *
- * @param {string} source                        The XML mime type only allows string input!
- * @param {string} [mimeType='application/xml']  The mimeType or contentType of the document to be created determines the `type`
- *                                               of document created (XML or HTML). Default is `'application/xml'`
+ * @param {string} source
+ * The XML mime type only allows string input!
+ * @param {string} [mimeType='application/xml']
+ * The mimeType or contentType of the document to be created determines the `type`
+ * of document created (XML or HTML). Default is `'application/xml'`
  * @returns The `Document` node.
- * @throws ParseError for any `fatalError` or anything that is thrown by `onError`
- * @throws TypeError for any invalid `mimeType`
+ * @throws
+ * ParseError for any `fatalError` or anything that is thrown by `onError`
+ * @throws
+ * TypeError for any invalid `mimeType`
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
  * @see https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev
  */
@@ -416,8 +222,10 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 
 /**
  * @typedef DOMHandlerOptions
- * @property {string}        [mimeType=MIME_TYPE.XML_APPLICATION]  Default is `MIME_TYPE.XML_APPLICATION`
- * @property {string | null} [defaultNamespace=null]               Default is `null`
+ * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION]
+ * Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string | null} [defaultNamespace=null]
+ * Default is `null`
  */
 /**
  * The class that is used to handle events from the SAX parser to create the related DOM elements.
@@ -486,7 +294,8 @@ function DOMHandler(options) {
 	 *
 	 * @type {Readonly<Locator> | undefined}
 	 * @access private
-	 * @readonly (the  sax parser currently sometimes set's it)
+	 * @readonly (the
+	 * sax parser currently sometimes set's it)
 	 */
 	this.locator = undefined;
 	/**
@@ -623,9 +432,11 @@ DOMHandler.prototype = {
 	/**
 	 * This function reports a fatal error and throws a ParseError.
 	 *
-	 * @param {string} message  - The message to be used for reporting and throwing the error.
+	 * @param {string} message
+	 * - The message to be used for reporting and throwing the error.
 	 * @returns {never} This function always throws an error and never returns a value.
-	 * @throws {ParseError} Always throws a ParseError with the provided message.
+	 * @throws {ParseError}
+	 * Always throws a ParseError with the provided message.
 	 */
 	fatalError: function (message) {
 		this.reportError('fatalError', message);

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -23,8 +23,11 @@ var XMLReader = sax.XMLReader;
  * of applications, the XML processor must behave as if it normalized all line breaks in external parsed Entities (including the
  * document entity) on input, before parsing, by translating all of the following to a single #xA Character:
  *
- * 1. The two-character sequence #xD #xA 2. The two-character sequence #xD #x85 3. The single character #x85 4. The Single
- * character * #x2028 5. Any #xD character that is not immediately followed by #xA or #x85.
+ * 1. The two-character sequence #xD #xA
+ * 2. The two-character sequence #xD #x85
+ * 3. The single character #x85
+ * 4. The Single character * #x2028
+ * 5. Any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}
@@ -41,239 +44,34 @@ function normalizeLineEndings(input) {
 
 /**
  * @typedef DOMParserOptions
- * @property {typeof conventions.assign}                                            [assign=Object.assign || conventions.assign]  The
- *                                                                                                                                method
- *                                                                                                                                to
- *                                                                                                                                use
- *                                                                                                                                instead
- *                                                                                                                                of
- *                                                                                                                                `Object.assign`
+ * @property {typeof conventions.assign} [assign=Object.assign || conventions.assign] The method to use instead of `Object.assign`
+ *   (or if not available `conventions.assign`), which is used to copy values from the options before they are used for parsing.
+ *   Default is `Object.assign || conventions.assign`
+ * @property {typeof DOMHandler} [domHandler] For internal testing: The class for creating an instance for handling events from
+ *   the SAX parser. ****Warning: By configuring a faulty implementation, the specified behavior can completely be broken.****
+ * @property {Function} [errorHandler] DEPRECATED! use `onError` instead.
+ * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError] A function that is invoked for every
+ *   error that occurs during parsing.
  *
- *                                                                                                                                (or
- *                                                                                                                                if
- *                                                                                                                                not
- *                                                                                                                                available
- *                                                                                                                                `conventions.assign`),
- *                                                                                                                                which
- *                                                                                                                                is
- *                                                                                                                                used
- *                                                                                                                                to
- *                                                                                                                                copy
- *                                                                                                                                values
- *                                                                                                                                from
- *                                                                                                                                the
- *                                                                                                                                options
- *                                                                                                                                before
- *                                                                                                                                they
- *                                                                                                                                are
- *                                                                                                                                used
- *                                                                                                                                for
- *                                                                                                                                parsing.
+ *   If it is not provided, all errors are reported to `console.error` and only `fatalError`s are thrown as a `ParseError`, which
+ *   prevents any further processing. If the provided method throws, a `ParserError` is thrown, which prevents any further
+ *   processing.
  *
- *                                                                                                                                Default
- *                                                                                                                                is
- *                                                                                                                                `Object.assign
- *                                                                                                                                ||
- *                                                                                                                                conventions.assign`
- * @property {typeof DOMHandler}                                                    [domHandler]                                  For
- *                                                                                                                                internal
- *                                                                                                                                testing:
- *                                                                                                                                The
- *                                                                                                                                class
- *                                                                                                                                for
- *                                                                                                                                creating
- *                                                                                                                                an
- *                                                                                                                                instance
- *                                                                                                                                for
- *                                                                                                                                handling
- *                                                                                                                                events
- *                                                                                                                                from
- *                                                                                                                                the
- *                                                                                                                                SAX
- *                                                                                                                                parser.
- *                                                                                                                                ****Warning:
- *                                                                                                                                By
- *                                                                                                                                configuring
- *                                                                                                                                a
- *                                                                                                                                faulty
- *                                                                                                                                implementation,
- *                                                                                                                                the
- *                                                                                                                                specified
- *                                                                                                                                behavior
- *                                                                                                                                can
- *                                                                                                                                completely
- *                                                                                                                                be
- *                                                                                                                                broken.****
- * @property {Function}                                                             [errorHandler]                                DEPRECATED!
- *                                                                                                                                use
- *                                                                                                                                `onError`
- *                                                                                                                                instead.
- * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void} [onError]                                     A
- *                                                                                                                                function
- *                                                                                                                                that
- *                                                                                                                                is
- *                                                                                                                                invoked
- *                                                                                                                                for
- *                                                                                                                                every
- *                                                                                                                                error
- *                                                                                                                                that
- *                                                                                                                                occurs
- *                                                                                                                                during
- *                                                                                                                                parsing.
- *
- *
- *                                                                                                                                If
- *                                                                                                                                it
- *                                                                                                                                is
- *                                                                                                                                not
- *                                                                                                                                provided,
- *                                                                                                                                all
- *                                                                                                                                errors
- *                                                                                                                                are
- *                                                                                                                                reported
- *                                                                                                                                to
- *                                                                                                                                `console.error`
- *                                                                                                                                and
- *                                                                                                                                only
- *                                                                                                                                `fatalError`s
- *                                                                                                                                are
- *                                                                                                                                thrown
- *                                                                                                                                as
- *                                                                                                                                a
- *                                                                                                                                `ParseError`,
- *                                                                                                                                which
- *                                                                                                                                prevents
- *                                                                                                                                any
- *                                                                                                                                further
- *                                                                                                                                processing.
- *                                                                                                                                If
- *                                                                                                                                the
- *                                                                                                                                provided
- *                                                                                                                                method
- *                                                                                                                                throws,
- *                                                                                                                                a
- *                                                                                                                                `ParserError`
- *                                                                                                                                is
- *                                                                                                                                thrown,
- *                                                                                                                                which
- *                                                                                                                                prevents
- *                                                                                                                                any
- *                                                                                                                                further
- *                                                                                                                                processing.
- *
- *
- *                                                                                                                                Be
- *                                                                                                                                aware
- *                                                                                                                                that
- *                                                                                                                                many
- *                                                                                                                                `warning`s
- *                                                                                                                                are
- *                                                                                                                                considered
- *                                                                                                                                an
- *                                                                                                                                error
- *                                                                                                                                that
- *                                                                                                                                prevents
- *                                                                                                                                further
- *                                                                                                                                processing
- *                                                                                                                                in
- *                                                                                                                                most
- *                                                                                                                                implementations.
- *                                                                                                                                .
- * @property {boolean}                                                              [locator=true]                                Configures
- *                                                                                                                                if
- *                                                                                                                                the
- *                                                                                                                                nodes
- *                                                                                                                                created
- *                                                                                                                                during
- *                                                                                                                                parsing
- *                                                                                                                                will
- *                                                                                                                                have
- *                                                                                                                                a
- *                                                                                                                                `lineNumber`
- *                                                                                                                                and
- *                                                                                                                                a
- *                                                                                                                                `columnNumber`
- *
- *                                                                                                                                attribute
- *                                                                                                                                describing
- *                                                                                                                                their
- *                                                                                                                                location
- *                                                                                                                                in
- *                                                                                                                                the
- *                                                                                                                                XML
- *                                                                                                                                string.
- *                                                                                                                                Default
- *                                                                                                                                is
- *                                                                                                                                true.
- *                                                                                                                                Default
- *                                                                                                                                is
- *                                                                                                                                `true`
- * @property {(string) => string}                                                   [normalizeLineEndings]                        Used
- *                                                                                                                                to
- *                                                                                                                                replace
- *                                                                                                                                line
- *                                                                                                                                endings
- *                                                                                                                                before
- *                                                                                                                                parsing,
- *                                                                                                                                defaults
- *                                                                                                                                to
- *                                                                                                                                `normalizeLineEndings`
- * @property {Object}                                                               [xmlns]                                       The
- *                                                                                                                                XML
- *                                                                                                                                namespaces
- *                                                                                                                                that
- *                                                                                                                                should
- *                                                                                                                                be
- *                                                                                                                                assumed
- *                                                                                                                                when
- *                                                                                                                                parsing.
- *                                                                                                                                The
- *                                                                                                                                default
- *                                                                                                                                namespace
- *                                                                                                                                can
- *                                                                                                                                be
- *                                                                                                                                provided
- *                                                                                                                                by
- *                                                                                                                                the
- *                                                                                                                                key
- *                                                                                                                                that
- *                                                                                                                                is
- *                                                                                                                                the
- *                                                                                                                                empty
- *                                                                                                                                string.
- *                                                                                                                                When
- *                                                                                                                                the
- *                                                                                                                                `mimeType`
- *                                                                                                                                for
- *                                                                                                                                HTML,
- *                                                                                                                                XHTML
- *                                                                                                                                or
- *                                                                                                                                SVG
- *                                                                                                                                are
- *                                                                                                                                passed
- *                                                                                                                                to
- *                                                                                                                                `parseFromString`,
- *                                                                                                                                the
- *                                                                                                                                default
- *                                                                                                                                namespace
- *                                                                                                                                that
- *                                                                                                                                will
- *                                                                                                                                be
- *                                                                                                                                used,
- *                                                                                                                                will
- *                                                                                                                                be
- *                                                                                                                                overridden
- *                                                                                                                                according
- *                                                                                                                                to
- *                                                                                                                                the
- *                                                                                                                                specification.
- * @see NormalizeLineEndings.
+ *   Be aware that many `warning`s are considered an error that prevents further processing in most implementations. .
+ * @property {boolean} [locator=true] Configures if the nodes created during parsing will have a `lineNumber` and a `columnNumber`
+ *   attribute describing their location in the XML string. Default is true. Default is `true`
+ * @property {(string) => string} [normalizeLineEndings] Used to replace line endings before parsing, defaults to
+ *   `normalizeLineEndings`
+ * @property {object} [xmlns] The XML namespaces that should be assumed when parsing. The default namespace can be provided by the
+ *   key that is the empty string. When the `mimeType` for HTML, XHTML or SVG are passed to `parseFromString`, the default
+ *   namespace that will be used, will be overridden according to the specification.
+ * @see normalizeLineEndings
  */
 
 /**
  * The DOMParser interface provides the ability to parse XML or HTML source code from a string into a DOM `Document`.
  *
- * _xmldom is different from the spec in that it allows an `options` parameter, to control the behavior._.
+ * _xmldom is different from the spec in that it allows an `options` parameter, to control the behavior._
  *
  * @class
  * @param {DOMParserOptions} [options]
@@ -287,10 +85,10 @@ function DOMParser(options) {
 	 * The method to use instead of `Object.assign` (defaults to or `conventions.assign`), which is used to copy values from the
 	 * options before they are used for parsing.
 	 *
-	 * @type {function (target: Object, source: Object | null | undefined): Object}
-	 * @access private
-	 * @see Conventions.assign.
+	 * @private
+	 * @type {function (target: object, source: object | null | undefined): object}
 	 * @readonly
+	 * @see conventions.assign
 	 */
 	this.assign = options.assign || conventions.assign;
 
@@ -298,8 +96,8 @@ function DOMParser(options) {
 	 * For internal testing: The class for creating an instance for handling events from the SAX parser. ****Warning: By configuring
 	 * a faulty implementation, the specified behavior can completely be broken.****
 	 *
+	 * @private
 	 * @type {typeof DOMHandler}
-	 * @access private
 	 * @readonly
 	 */
 	this.domHandler = options.domHandler || DOMHandler;
@@ -314,8 +112,8 @@ function DOMParser(options) {
 	 * Be aware that many `warning`s are considered an error that prevents further processing in most implementations.
 	 *
 	 * @type {function(level:ErrorLevel, message:string, context: DOMHandler):void}
-	 * @see OnErrorStopParsing.
-	 * @see OnWarningStopParsing.
+	 * @see onErrorStopParsing
+	 * @see onWarningStopParsing
 	 */
 	this.onError = options.onError || options.errorHandler;
 	if (options.errorHandler && typeof options.errorHandler !== 'function') {
@@ -345,7 +143,7 @@ function DOMParser(options) {
 	 * The default namespace can be provided by the key that is the empty string. When the `mimeType` for HTML, XHTML or SVG are
 	 * passed to `parseFromString`, the default namespace that will be used, will be overridden according to the specification.
 	 *
-	 * @type {Readonly<Object>}
+	 * @type {Readonly<object>}
 	 * @readonly
 	 */
 	this.xmlns = options.xmlns || {};
@@ -360,15 +158,15 @@ function DOMParser(options) {
  * - Uses the `options` passed to the `DOMParser` constructor to modify the behavior.
  * - Any unexpected input is reported to `onError` with either a `warning`, `error` or `fatalError` level.
  *
- * - Any `fatalError` throws a `ParseError` which prevents further processing.
- * - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing - If no `Document` was created
- * during parsing it is reported as a `fatalError`. ****Warning: By configuring a faulty DOMHandler implementation, the specified
- * behavior can completely be broken.****
+ *   - Any `fatalError` throws a `ParseError` which prevents further processing.
+ *   - Any error thrown by `onError` is converted to a `ParseError` which prevents further processing
+ * - If no `Document` was created during parsing it is reported as a `fatalError`. ****Warning: By configuring a faulty DOMHandler
+ *   implementation, the specified behavior can completely be broken.****
  *
- * @param {string} source                        The XML mime type only allows string input!
- * @param {string} [mimeType='application/xml']  The mimeType or contentType of the document to be created determines the `type`
- *                                               of document created (XML or HTML). Default is `'application/xml'`
- * @returns The `Document` node.
+ * @param {string} source The XML mime type only allows string input!
+ * @param {string} [mimeType='application/xml'] The mimeType or contentType of the document to be created determines the `type` of
+ *   document created (XML or HTML). Default is `'application/xml'`
+ * @returns The `Document` node
  * @throws ParseError for any `fatalError` or anything that is thrown by `onError`
  * @throws TypeError for any invalid `mimeType`
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
@@ -416,8 +214,8 @@ DOMParser.prototype.parseFromString = function (source, mimeType) {
 
 /**
  * @typedef DOMHandlerOptions
- * @property {string}        [mimeType=MIME_TYPE.XML_APPLICATION]  Default is `MIME_TYPE.XML_APPLICATION`
- * @property {string | null} [defaultNamespace=null]               Default is `null`
+ * @property {string} [mimeType=MIME_TYPE.XML_APPLICATION] Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string | null} [defaultNamespace=null] Default is `null`
  */
 /**
  * The class that is used to handle events from the SAX parser to create the related DOM elements.
@@ -435,30 +233,29 @@ function DOMHandler(options) {
 	 * it will create an HTML document. It defaults to MIME_TYPE.XML_APPLICATION.
 	 *
 	 * @type {string}
-	 * @see MIME_TYPE.
 	 * @readonly
+	 * @see MIME_TYPE
 	 */
 	this.mimeType = opt.mimeType || MIME_TYPE.XML_APPLICATION;
 
 	/**
 	 * The namespace to use to create an XML document. For the following reasons this is required:
 	 *
-	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace, since at that point there is no way for the
-	 * parser to know what the default namespace from the document will be.
+	 * - The SAX API for `startDocument` doesn't offer any way to pass a namespace, since at that point there is no way for the parser
+	 *   to know what the default namespace from the document will be.
 	 * - When creating using `DOMImplementation.createDocument` it is required to pass a namespace, to determine the correct
-	 * `Document.contentType`, which should match `this.mimeType`.
-	 * - When parsing an XML document with the `application/xhtml+xml` mimeType, the HTML namespace needs to be the default
-	 * namespace.
+	 *   `Document.contentType`, which should match `this.mimeType`.
+	 * - When parsing an XML document with the `application/xhtml+xml` mimeType, the HTML namespace needs to be the default namespace.
 	 *
+	 * @private
 	 * @type {string | null}
-	 * @access private
 	 * @readonly
 	 */
 	this.defaultNamespace = opt.defaultNamespace || null;
 
 	/**
+	 * @private
 	 * @type {boolean}
-	 * @access private
 	 */
 	this.cdata = false;
 
@@ -467,8 +264,8 @@ function DOMHandler(options) {
 	 *
 	 * Note: The sax parser currently sets it to white space text nodes between tags.
 	 *
+	 * @private
 	 * @type {Element | Node | undefined}
-	 * @access private
 	 */
 	this.currentElement = undefined;
 
@@ -484,9 +281,9 @@ function DOMHandler(options) {
 	 * The locator is stored as part of setDocumentLocator. It is controlled and mutated by the SAX parser to store the current
 	 * parsing position. It is used by DOMHandler to set `columnNumber` and `lineNumber` on the DOM nodes.
 	 *
+	 * @private
 	 * @type {Readonly<Locator> | undefined}
-	 * @access private
-	 * @readonly (the  sax parser currently sometimes set's it)
+	 * @readonly (the sax parser currently sometimes set's it)
 	 */
 	this.locator = undefined;
 	/**
@@ -611,9 +408,7 @@ DOMHandler.prototype = {
 			console.error('[xmldom ' + level + ']\t' + message, _locator(this.locator));
 		}
 	},
-	/**
-	 * @see http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
-	 */
+	/** @see http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html */
 	warning: function (message) {
 		this.reportError('warning', message);
 	},
@@ -623,7 +418,7 @@ DOMHandler.prototype = {
 	/**
 	 * This function reports a fatal error and throws a ParseError.
 	 *
-	 * @param {string} message  - The message to be used for reporting and throwing the error.
+	 * @param {string} message - The message to be used for reporting and throwing the error.
 	 * @returns {never} This function always throws an error and never returns a value.
 	 * @throws {ParseError} Always throws a ParseError with the provided message.
 	 */
@@ -703,8 +498,8 @@ function appendElement(handler, node) {
 /**
  * A method that prevents any further parsing when an `error` with level `error` is reported during parsing.
  *
- * @see DOMParserOptions.onError.
- * @see OnWarningStopParsing.
+ * @see DOMParserOptions.onError
+ * @see onWarningStopParsing
  */
 function onErrorStopParsing(level) {
 	if (level === 'error') throw 'onErrorStopParsing';
@@ -713,8 +508,8 @@ function onErrorStopParsing(level) {
 /**
  * A method that prevents any further parsing when any `error` is reported during parsing.
  *
- * @see DOMParserOptions.onError.
- * @see OnErrorStopParsing.
+ * @see DOMParserOptions.onError
+ * @see onErrorStopParsing
  */
 function onWarningStopParsing() {
 	throw 'onWarningStopParsing';

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -11,7 +11,7 @@ var NAMESPACE = conventions.NAMESPACE;
 var g = require('./grammar');
 
 /**
- * A prerequisite for `[].filter`, to drop elements that are empty
+ * A prerequisite for `[].filter`, to drop elements that are empty.
  *
  * @param {string} input
  * @returns {boolean}
@@ -34,7 +34,7 @@ function splitOnASCIIWhitespace(input) {
  * Adds element as a key to current if it is not already present.
  *
  * @param {Record<string, boolean | undefined>} current
- * @param {string} element
+ * @param {string}                              element
  * @returns {Record<string, boolean | undefined>}
  */
 function orderedSetReducer(current, element) {
@@ -69,7 +69,7 @@ function arrayIncludes(list) {
 
 /**
  * @param {string} qualifiedName
- * @throws DOMException
+ * @throws DOMException.
  * @see https://dom.spec.whatwg.org/#validate
  */
 function validateQualifiedName(qualifiedName) {
@@ -80,14 +80,16 @@ function validateQualifiedName(qualifiedName) {
 
 /**
  * @param {string | null} namespace
- * @param {string} qualifiedName
+ * @param {string}        qualifiedName
  * @returns {[namespace: string | null, prefix: string | null, localName: string]}
  * @see https://dom.spec.whatwg.org/#validate-and-extract
  */
 function validateAndExtract(namespace, qualifiedName) {
 	validateQualifiedName(qualifiedName);
 	namespace = namespace || null;
-	/** @type {string | null} */
+	/**
+	 * @type {string | null}
+	 */
 	var prefix = null;
 	var localName = qualifiedName;
 	if (qualifiedName.indexOf(':') >= 0) {
@@ -188,7 +190,7 @@ var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = (DocumentPosition.DOCUMENT_POSIT
 /**
  * Construct a parent chain for a node.
  *
- * @param {Node} node The start node.
+ * @param {Node} node  The start node.
  * @returns {Node[]} The parent chain.
  */
 function parentChain(node) {
@@ -203,8 +205,8 @@ function parentChain(node) {
 /**
  * Find the common ancestor in two parent chains.
  *
- * @param {Node[]} a A parent chain.
- * @param {Node[]} b A parent chain.
+ * @param {Node[]} a  A parent chain.
+ * @param {Node[]} b  A parent chain.
  * @returns {Node} The common ancestor if it exists.
  */
 function commonAncestor(a, b) {
@@ -220,7 +222,7 @@ function commonAncestor(a, b) {
 /**
  * Comparing unrelated nodes must be consistent, so we assign a guid to the compared docs for further reference.
  *
- * @param {Document} doc The document.
+ * @param {Document} doc  The document.
  * @returns {string} The document's guid.
  */
 function docGUID(doc) {
@@ -230,7 +232,7 @@ function docGUID(doc) {
 //-- end of helper functions
 
 /**
- * DOM Level 2 Object DOMException
+ * DOM Level 2 Object DOMException.
  *
  * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/ecma-script-binding.html
  * @see http://www.w3.org/TR/REC-DOM-Level-1/ecma-script-language-binding.html
@@ -252,8 +254,10 @@ DOMException.prototype = Error.prototype;
 copy(ExceptionCode, DOMException);
 
 /**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The NodeList interface provides the abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented. NodeList objects in the DOM are live.
- * The items in the NodeList are accessible via an integral index, starting from 0.
+ * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The NodeList interface provides the
+ *      abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented.
+ *      NodeList objects in the DOM are live.
+ *      The items in the NodeList are accessible via an integral index, starting from 0.
  */
 function NodeList() {}
 NodeList.prototype = {
@@ -264,10 +268,10 @@ NodeList.prototype = {
 	 */
 	length: 0,
 	/**
-	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this
-	 * returns null.
+	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns
+	 * null.
 	 *
-	 * @param index Unsigned long Index into the collection.
+	 * @param index  Unsigned long Index into the collection.
 	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 * @standard level1
 	 */
@@ -281,17 +285,17 @@ NodeList.prototype = {
 		return buf.join('');
 	},
 	/**
-	 * @private
 	 * @param {function (Node):boolean} predicate
 	 * @returns {Node[]}
+	 * @access private
 	 */
 	filter: function (predicate) {
 		return Array.prototype.filter.call(this, predicate);
 	},
 	/**
-	 * @private
 	 * @param {Node} item
 	 * @returns {number}
+	 * @access private
 	 */
 	indexOf: function (item) {
 		return Array.prototype.indexOf.call(this, item);
@@ -405,7 +409,7 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Set an attribute
+	 * Set an attribute.
 	 *
 	 * @param {Attr} attr
 	 * @returns {Attr | null}
@@ -425,7 +429,7 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Set an attribute
+	 * Set an attribute.
 	 *
 	 * @param {Attr} attr
 	 * @returns {Attr | null}
@@ -453,10 +457,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Remove an attribute by namespace and local name
+	 * Remove an attribute by namespace and local name.
 	 *
 	 * @param {string | null} namespaceURI
-	 * @param {string} localName
+	 * @param {string}        localName
 	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-namespace
@@ -471,10 +475,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Get an attribute by namespace and local name
+	 * Get an attribute by namespace and local name.
 	 *
 	 * @param {string | null} namespaceURI
-	 * @param {string} localName
+	 * @param {string}        localName
 	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
 	 */
@@ -515,13 +519,13 @@ DOMImplementation.prototype = {
 	 * implementations fairly diverged in what kind of features were reported. The latest version of the spec settled to force this
 	 * method to always return true, where the functionality was accurate and in use.
 	 *
-	 * @deprecated It is deprecated and modern browsers return true in all cases.
 	 * @param {string} feature
 	 * @param {string} [version]
-	 * @returns {boolean} Always true
+	 * @returns {boolean} Always true.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
 	 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
+	 * @deprecated It is deprecated and modern browsers return true in all cases.
 	 */
 	hasFeature: function (feature, version) {
 		return true;
@@ -534,11 +538,11 @@ DOMImplementation.prototype = {
 	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
-	 * @param {string | null} namespaceURI
-	 * @param {string} qualifiedName
-	 * @param {DocumentType | null} [doctype=null] Default is `null`
-	 * @returns {Document} The XML document
-	 * @see #createHTMLDocument
+	 * @param {string | null}       namespaceURI
+	 * @param {string}              qualifiedName
+	 * @param {DocumentType | null} [doctype=null]  Default is `null`
+	 * @returns {Document} The XML document.
+	 * @see #createHTMLDocument.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM Level 2 Core (initial)
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument DOM Level 2 Core
@@ -570,15 +574,15 @@ DOMImplementation.prototype = {
 	 *
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 * - `publicId` and `systemId` contain the raw data including any possible quotes, so they can always be serialized back to the
-	 *   original value
-	 * - `internalSubset` contains the raw string between `[` and `]` if present, but is not parsed or validated in any form
+	 * original value - `internalSubset` contains the raw string between `[` and `]` if present, but is not parsed or validated in
+	 * any form.
 	 *
 	 * @param {string} qualifiedName
 	 * @param {string} [publicId]
 	 * @param {string} [systemId]
-	 * @param {string} [internalSubset] (from DOM Level 2 Core)
+	 * @param {string} [internalSubset]  (from DOM Level 2 Core)
 	 * @returns {DocumentType} Which can either be used with `DOMImplementation.createDocument` on document creation or can be put
-	 *   into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
+	 *                         into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocType DOM Level 2 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype DOM Living Standard
@@ -605,7 +609,7 @@ DOMImplementation.prototype = {
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string | false} [title]
-	 * @returns {Document} The HTML document
+	 * @returns {Document} The HTML document.
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 	 * @see https://dom.spec.whatwg.org/#html-document
 	 */
@@ -632,7 +636,9 @@ DOMImplementation.prototype = {
 	},
 };
 
-/** @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247 */
+/**
+ * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247
+ */
 function Node() {}
 
 Node.prototype = {
@@ -698,7 +704,7 @@ Node.prototype = {
 	 * Look up the prefix associated to the given namespace URI, starting from this node. **The default namespace declarations are
 	 * ignored by this method.** See Namespace Prefix Lookup for details on the algorithm used by this method.
 	 *
-	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._
+	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._.
 	 *
 	 * @param {string | null} namespaceURI
 	 * @returns {string | null}
@@ -747,9 +753,9 @@ Node.prototype = {
 	/**
 	 * Compares the reference node with a node with regard to their position in the document and according to the document order.
 	 *
-	 * @param {Node} other The node to compare the reference node to.
-	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if
-	 *   reference node and given node are the same.
+	 * @param {Node} other  The node to compare the reference node to.
+	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if reference
+	 *                   node and given node are the same.
 	 * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
 	 */
 	compareDocumentPosition: function (other) {
@@ -811,7 +817,7 @@ copy(DocumentPosition, Node);
 copy(DocumentPosition, Node.prototype);
 
 /**
- * @param callback Return true for continue,false for break
+ * @param callback  Return true for continue,false for break.
  * @returns Boolean true: break visit;
  */
 function _visitNode(node, callback) {
@@ -829,7 +835,7 @@ function _visitNode(node, callback) {
 
 /**
  * @typedef DocumentOptions
- * @property {string} [contentType=MIME_TYPE.XML_APPLICATION] Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string} [contentType=MIME_TYPE.XML_APPLICATION]  Default is `MIME_TYPE.XML_APPLICATION`
  */
 /**
  * The Document interface describes the common properties and methods for any kind of document.
@@ -839,9 +845,9 @@ function _visitNode(node, callback) {
  *
  * The constructor is considered a private API and offers to initially set the `contentType` property via it's options parameter.
  *
- * @private
  * @class
  * @param {DocumentOptions} [options]
+ * @access private
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Document
  * @see https://dom.spec.whatwg.org/#interface-document
  */
@@ -852,17 +858,17 @@ function Document(options) {
 	 * The mime type of the document is determined at creation time and can not be modified.
 	 *
 	 * @type {string}
-	 * @readonly
 	 * @see https://dom.spec.whatwg.org/#concept-document-content-type
-	 * @see DOMImplementation
-	 * @see MIME_TYPE
+	 * @see DOMImplementation.
+	 * @see MIME_TYPE.
+	 * @readonly
 	 */
 	this.contentType = opt.contentType || MIME_TYPE.XML_APPLICATION;
 	/**
 	 * @type {'html' | 'xml'}
-	 * @readonly
 	 * @see https://dom.spec.whatwg.org/#concept-document-type
-	 * @see DOMImplementation
+	 * @see DOMImplementation.
+	 * @readonly
 	 */
 	this.type = isHTMLMimeType(this.contentType) ? 'html' : 'xml';
 }
@@ -890,10 +896,10 @@ function _onRemoveAttribute(doc, el, newAttr, remove) {
  * it's assumed that an item has been removed, and `el.firstNode` and it's `.nextSibling` are used to walk the current list of
  * child nodes.
  *
- * @private
  * @param {Document} doc
- * @param {Node} el
- * @param {Node} [newChild]
+ * @param {Node}     el
+ * @param {Node}     [newChild]
+ * @access private
  */
 function _onUpdateChild(doc, el, newChild) {
 	if (doc && doc._inc) {
@@ -918,10 +924,10 @@ function _onUpdateChild(doc, el, newChild) {
 /**
  * Removes the connections between `parentNode` and `child` and any existing `child.previousSibling` or `child.nextSibling`.
  *
- * @private
  * @param {Node} parentNode
  * @param {Node} child
  * @returns {Node} The child that was removed.
+ * @access private
  * @see https://github.com/xmldom/xmldom/issues/135
  * @see https://github.com/xmldom/xmldom/issues/145
  */
@@ -981,7 +987,7 @@ function hasInsertableNodeType(node) {
 }
 
 /**
- * Returns true if `node` is a DOCTYPE node
+ * Returns true if `node` is a DOCTYPE node.
  *
  * @param {Node} node
  * @returns {boolean}
@@ -991,7 +997,7 @@ function isDocTypeNode(node) {
 }
 
 /**
- * Returns true if the node is an element
+ * Returns true if the node is an element.
  *
  * @param {Node} node
  * @returns {boolean}
@@ -1000,7 +1006,7 @@ function isElementNode(node) {
 	return node && node.nodeType === Node.ELEMENT_NODE;
 }
 /**
- * Returns true if `node` is a text node
+ * Returns true if `node` is a text node.
  *
  * @param {Node} node
  * @returns {boolean}
@@ -1013,10 +1019,10 @@ function isTextNode(node) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
  * position of a doctype node on the same level.
  *
- * @private https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
- * @param {Document} doc The document node
- * @param {Node} child The node that would become the nextSibling if the element would be inserted
- * @returns {boolean} `true` if an element can be inserted before child
+ * @param {Document} doc    The document node.
+ * @param {Node}     child  The node that would become the nextSibling if the element would be inserted.
+ * @returns {boolean} `true` if an element can be inserted before child.
+ * @access private
  */
 function isElementInsertionPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1031,10 +1037,10 @@ function isElementInsertionPossible(doc, child) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
  * position of a doctype node on the same level.
  *
- * @private https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
- * @param {Node} doc The document node
- * @param {Node} child The node that would become the nextSibling if the element would be inserted
- * @returns {boolean} `true` if an element can be inserted before child
+ * @param {Node} doc    The document node.
+ * @param {Node} child  The node that would become the nextSibling if the element would be inserted.
+ * @returns {boolean} `true` if an element can be inserted before child.
+ * @access private
  */
 function isElementReplacementPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1051,13 +1057,13 @@ function isElementReplacementPossible(doc, child) {
 }
 
 /**
- * @private Steps 1-5 of the checks before inserting and before replacing a child are the same.
- * @param {Node} parent The parent node to insert `node` into
- * @param {Node} node The node to insert
- * @param {Node} [child] The node that should become the `nextSibling` of `node`
+ * @param {Node} parent   The parent node to insert `node` into.
+ * @param {Node} node     The node to insert.
+ * @param {Node} [child]  The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1089,13 +1095,13 @@ function assertPreInsertionValidity1to5(parent, node, child) {
 }
 
 /**
- * @private Step 6 of the checks before inserting and before replacing a child are different.
- * @param {Document} parent The parent node to insert `node` into
- * @param {Node} node The node to insert
- * @param {Node | undefined} child The node that should become the `nextSibling` of `node`
+ * @param {Document}         parent  The parent node to insert `node` into.
+ * @param {Node}             node    The node to insert.
+ * @param {Node | undefined} child   The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1143,13 +1149,13 @@ function assertPreInsertionValidityInDocument(parent, node, child) {
 }
 
 /**
- * @private Step 6 of the checks before inserting and before replacing a child are different.
- * @param {Document} parent The parent node to insert `node` into
- * @param {Node} node The node to insert
- * @param {Node | undefined} child The node that should become the `nextSibling` of `node`
+ * @param {Document}         parent  The parent node to insert `node` into.
+ * @param {Node}             node    The node to insert.
+ * @param {Node | undefined} child   The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1195,13 +1201,13 @@ function assertPreReplacementValidityInDocument(parent, node, child) {
 }
 
 /**
- * @private
- * @param {Node} parent The parent node to insert `node` into
- * @param {Node} node The node to insert
- * @param {Node} [child] The node that should become the `nextSibling` of `node`
+ * @param {Node} parent   The parent node to insert `node` into.
+ * @param {Node} node     The node to insert.
+ * @param {Node} [child]  The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
 function _insertBefore(parent, node, child, _inDocumentAssertion) {
@@ -1256,10 +1262,10 @@ function _insertBefore(parent, node, child, _inDocumentAssertion) {
 /**
  * Appends `newChild` to `parentNode`. If `newChild` is already connected to a `parentNode` it is first removed from it.
  *
- * @private
  * @param {Node} parentNode
  * @param {Node} newChild
  * @returns {Node}
+ * @access private
  * @see https://github.com/xmldom/xmldom/issues/135
  * @see https://github.com/xmldom/xmldom/issues/145
  */
@@ -1282,7 +1288,7 @@ function _appendSingleChild(parentNode, newChild) {
 
 Document.prototype = {
 	/**
-	 * The implementation that created this document
+	 * The implementation that created this document.
 	 *
 	 * @type DOMImplementation
 	 * @readonly
@@ -1365,8 +1371,8 @@ Document.prototype = {
 	 * selected by this array no longer qualifies for the selector, it will automatically be removed. Be aware of this for iteration
 	 * purposes.
 	 *
-	 * @param {string} classNames Is a string representing the class name(s) to match; multiple class names are separated by
-	 *   (ASCII-)whitespace
+	 * @param {string} classNames  Is a string representing the class name(s) to match; multiple class names are separated by
+	 *                             (ASCII-)whitespace.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */
@@ -1399,8 +1405,7 @@ Document.prototype = {
 
 	/**
 	 * Creates a new `Element` that is owned by this `Document`. In HTML Documents `localName` is the lower cased `tagName`,
-	 * otherwise no transformation is being applied. When `contentType` implies the HTML namespace, it will be set as
-	 * `namespaceURI`.
+	 * otherwise no transformation is being applied. When `contentType` implies the HTML namespace, it will be set as `namespaceURI`.
 	 *
 	 * **This implementation differs from the specification:**
 	 *
@@ -1660,8 +1665,8 @@ Element.prototype = {
 	 * This is undesirable when trying to match camel-cased SVG elements (such as `<linearGradient>`) in an HTML document. Instead,
 	 * use `Element.getElementsByTagNameNS()`, which preserves the capitalization of the tag name.
 	 *
-	 * `Element.getElementsByTagName` is similar to `Document.getElementsByTagName()`, except that it only searches for elements
-	 * that are descendants of the specified element.
+	 * `Element.getElementsByTagName` is similar to `Document.getElementsByTagName()`, except that it only searches for elements that
+	 * are descendants of the specified element.
 	 *
 	 * @param {string} qualifiedName
 	 * @returns {LiveNodeList}
@@ -1860,9 +1865,9 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
  * attribute value must not contain a <.
  *
  * @see https://www.w3.org/TR/xml11/#CleanAttrVals
- * @see https://www.w3.org/TR/xml11/#NT-AttValue Literal whitespace other than space that appear in attribute values
- * are serialized as their entity references, so they will be preserved.
- * (In contrast to whitespace literals in the input which are normalized to spaces)
+ * @see https://www.w3.org/TR/xml11/#NT-AttValue Literal whitespace other than space that appear in attribute values are
+ *      serialized as their entity references, so they will be preserved.
+ *      (In contrast to whitespace literals in the input which are normalized to spaces)
  * @see https://www.w3.org/TR/xml11/#AVNormalize
  * @see https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes
  */
@@ -2006,12 +2011,11 @@ function serializeToString(node, buf, nodeFilter, visibleNamespaces) {
 			return addSerializedAttribute(buf, node.name, node.value);
 		case TEXT_NODE:
 			/**
-			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form, except when used as
-			 * markup delimiters, or within a comment, a processing instruction, or a CDATA section. If they are needed elsewhere, they
-			 * must be escaped using either numeric character references or the strings `&amp;` and `&lt;` respectively. The right angle
-			 * bracket (>) may be represented using the string " > ", and must, for compatibility, be escaped using either `&gt;` or a
-			 * character reference when it appears in the string `]]>` in content, when that string is not marking the end of a CDATA
-			 * section.
+			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form, except when used as markup
+			 * delimiters, or within a comment, a processing instruction, or a CDATA section. If they are needed elsewhere, they must be
+			 * escaped using either numeric character references or the strings `&amp;` and `&lt;` respectively. The right angle bracket
+			 * (>) may be represented using the string " > ", and must, for compatibility, be escaped using either `&gt;` or a character
+			 * reference when it appears in the string `]]>` in content, when that string is not marking the end of a CDATA section.
 			 *
 			 * In the content of elements, character data is any string of characters which does not contain the start-delimiter of any
 			 * markup and does not include the CDATA-section-close delimiter, `]]>`.

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -34,7 +34,7 @@ function splitOnASCIIWhitespace(input) {
  * Adds element as a key to current if it is not already present.
  *
  * @param {Record<string, boolean | undefined>} current
- * @param {string} element
+ * @param {string}                              element
  * @returns {Record<string, boolean | undefined>}
  */
 function orderedSetReducer(current, element) {
@@ -69,8 +69,7 @@ function arrayIncludes(list) {
 
 /**
  * @param {string} qualifiedName
- * @throws
- * DOMException.
+ * @throws DOMException.
  * @see https://dom.spec.whatwg.org/#validate
  */
 function validateQualifiedName(qualifiedName) {
@@ -81,7 +80,7 @@ function validateQualifiedName(qualifiedName) {
 
 /**
  * @param {string | null} namespace
- * @param {string} qualifiedName
+ * @param {string}        qualifiedName
  * @returns {[namespace: string | null, prefix: string | null, localName: string]}
  * @see https://dom.spec.whatwg.org/#validate-and-extract
  */
@@ -191,8 +190,7 @@ var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = (DocumentPosition.DOCUMENT_POSIT
 /**
  * Construct a parent chain for a node.
  *
- * @param {Node} node
- * The start node.
+ * @param {Node} node  The start node.
  * @returns {Node[]} The parent chain.
  */
 function parentChain(node) {
@@ -207,10 +205,8 @@ function parentChain(node) {
 /**
  * Find the common ancestor in two parent chains.
  *
- * @param {Node[]} a
- * A parent chain.
- * @param {Node[]} b
- * A parent chain.
+ * @param {Node[]} a  A parent chain.
+ * @param {Node[]} b  A parent chain.
  * @returns {Node} The common ancestor if it exists.
  */
 function commonAncestor(a, b) {
@@ -226,8 +222,7 @@ function commonAncestor(a, b) {
 /**
  * Comparing unrelated nodes must be consistent, so we assign a guid to the compared docs for further reference.
  *
- * @param {Document} doc
- * The document.
+ * @param {Document} doc  The document.
  * @returns {string} The document's guid.
  */
 function docGUID(doc) {
@@ -276,8 +271,7 @@ NodeList.prototype = {
 	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns
 	 * null.
 	 *
-	 * @param index
-	 * Unsigned long Index into the collection.
+	 * @param index  Unsigned long Index into the collection.
 	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 * @standard level1
 	 */
@@ -466,7 +460,7 @@ NamedNodeMap.prototype = {
 	 * Remove an attribute by namespace and local name.
 	 *
 	 * @param {string | null} namespaceURI
-	 * @param {string} localName
+	 * @param {string}        localName
 	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-namespace
@@ -484,7 +478,7 @@ NamedNodeMap.prototype = {
 	 * Get an attribute by namespace and local name.
 	 *
 	 * @param {string | null} namespaceURI
-	 * @param {string} localName
+	 * @param {string}        localName
 	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
 	 */
@@ -531,8 +525,7 @@ DOMImplementation.prototype = {
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
 	 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
-	 * @deprecated
-	 * It is deprecated and modern browsers return true in all cases.
+	 * @deprecated It is deprecated and modern browsers return true in all cases.
 	 */
 	hasFeature: function (feature, version) {
 		return true;
@@ -545,10 +538,9 @@ DOMImplementation.prototype = {
 	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
-	 * @param {string | null} namespaceURI
-	 * @param {string} qualifiedName
-	 * @param {DocumentType | null} [doctype=null]
-	 * Default is `null`
+	 * @param {string | null}       namespaceURI
+	 * @param {string}              qualifiedName
+	 * @param {DocumentType | null} [doctype=null]  Default is `null`
 	 * @returns {Document} The XML document.
 	 * @see #createHTMLDocument.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
@@ -588,8 +580,7 @@ DOMImplementation.prototype = {
 	 * @param {string} qualifiedName
 	 * @param {string} [publicId]
 	 * @param {string} [systemId]
-	 * @param {string} [internalSubset]
-	 * (from DOM Level 2 Core)
+	 * @param {string} [internalSubset]  (from DOM Level 2 Core)
 	 * @returns {DocumentType} Which can either be used with `DOMImplementation.createDocument` on document creation or can be put
 	 *                         into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType MDN
@@ -762,8 +753,7 @@ Node.prototype = {
 	/**
 	 * Compares the reference node with a node with regard to their position in the document and according to the document order.
 	 *
-	 * @param {Node} other
-	 * The node to compare the reference node to.
+	 * @param {Node} other  The node to compare the reference node to.
 	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if reference
 	 *                   node and given node are the same.
 	 * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
@@ -827,8 +817,7 @@ copy(DocumentPosition, Node);
 copy(DocumentPosition, Node.prototype);
 
 /**
- * @param callback
- * Return true for continue,false for break.
+ * @param callback  Return true for continue,false for break.
  * @returns Boolean true: break visit;
  */
 function _visitNode(node, callback) {
@@ -846,8 +835,7 @@ function _visitNode(node, callback) {
 
 /**
  * @typedef DocumentOptions
- * @property {string} [contentType=MIME_TYPE.XML_APPLICATION]
- * Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string} [contentType=MIME_TYPE.XML_APPLICATION]  Default is `MIME_TYPE.XML_APPLICATION`
  */
 /**
  * The Document interface describes the common properties and methods for any kind of document.
@@ -909,8 +897,8 @@ function _onRemoveAttribute(doc, el, newAttr, remove) {
  * child nodes.
  *
  * @param {Document} doc
- * @param {Node} el
- * @param {Node} [newChild]
+ * @param {Node}     el
+ * @param {Node}     [newChild]
  * @access private
  */
 function _onUpdateChild(doc, el, newChild) {
@@ -1031,10 +1019,8 @@ function isTextNode(node) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
  * position of a doctype node on the same level.
  *
- * @param {Document} doc
- * The document node.
- * @param {Node} child
- * The node that would become the nextSibling if the element would be inserted.
+ * @param {Document} doc    The document node.
+ * @param {Node}     child  The node that would become the nextSibling if the element would be inserted.
  * @returns {boolean} `true` if an element can be inserted before child.
  * @access private
  */
@@ -1051,10 +1037,8 @@ function isElementInsertionPossible(doc, child) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
  * position of a doctype node on the same level.
  *
- * @param {Node} doc
- * The document node.
- * @param {Node} child
- * The node that would become the nextSibling if the element would be inserted.
+ * @param {Node} doc    The document node.
+ * @param {Node} child  The node that would become the nextSibling if the element would be inserted.
  * @returns {boolean} `true` if an element can be inserted before child.
  * @access private
  */
@@ -1073,17 +1057,12 @@ function isElementReplacementPossible(doc, child) {
 }
 
 /**
- * @param {Node} parent
- * The parent node to insert `node` into.
- * @param {Node} node
- * The node to insert.
- * @param {Node} [child]
- * The node that should become the `nextSibling` of `node`
+ * @param {Node} parent   The parent node to insert `node` into.
+ * @param {Node} node     The node to insert.
+ * @param {Node} [child]  The node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws
- * DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws
- * DOMException if `child` is provided but is not a child of `parent`.
+ * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws DOMException if `child` is provided but is not a child of `parent`.
  * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
@@ -1116,17 +1095,12 @@ function assertPreInsertionValidity1to5(parent, node, child) {
 }
 
 /**
- * @param {Document} parent
- * The parent node to insert `node` into.
- * @param {Node} node
- * The node to insert.
- * @param {Node | undefined} child
- * The node that should become the `nextSibling` of `node`
+ * @param {Document}         parent  The parent node to insert `node` into.
+ * @param {Node}             node    The node to insert.
+ * @param {Node | undefined} child   The node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws
- * DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws
- * DOMException if `child` is provided but is not a child of `parent`.
+ * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws DOMException if `child` is provided but is not a child of `parent`.
  * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
@@ -1175,17 +1149,12 @@ function assertPreInsertionValidityInDocument(parent, node, child) {
 }
 
 /**
- * @param {Document} parent
- * The parent node to insert `node` into.
- * @param {Node} node
- * The node to insert.
- * @param {Node | undefined} child
- * The node that should become the `nextSibling` of `node`
+ * @param {Document}         parent  The parent node to insert `node` into.
+ * @param {Node}             node    The node to insert.
+ * @param {Node | undefined} child   The node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws
- * DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws
- * DOMException if `child` is provided but is not a child of `parent`.
+ * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws DOMException if `child` is provided but is not a child of `parent`.
  * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
@@ -1232,17 +1201,12 @@ function assertPreReplacementValidityInDocument(parent, node, child) {
 }
 
 /**
- * @param {Node} parent
- * The parent node to insert `node` into.
- * @param {Node} node
- * The node to insert.
- * @param {Node} [child]
- * The node that should become the `nextSibling` of `node`
+ * @param {Node} parent   The parent node to insert `node` into.
+ * @param {Node} node     The node to insert.
+ * @param {Node} [child]  The node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws
- * DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws
- * DOMException if `child` is provided but is not a child of `parent`.
+ * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws DOMException if `child` is provided but is not a child of `parent`.
  * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
@@ -1407,8 +1371,8 @@ Document.prototype = {
 	 * selected by this array no longer qualifies for the selector, it will automatically be removed. Be aware of this for iteration
 	 * purposes.
 	 *
-	 * @param {string} classNames
-	 * Is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace.
+	 * @param {string} classNames  Is a string representing the class name(s) to match; multiple class names are separated by
+	 *                             (ASCII-)whitespace.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -34,7 +34,7 @@ function splitOnASCIIWhitespace(input) {
  * Adds element as a key to current if it is not already present.
  *
  * @param {Record<string, boolean | undefined>} current
- * @param {string}                              element
+ * @param {string} element
  * @returns {Record<string, boolean | undefined>}
  */
 function orderedSetReducer(current, element) {
@@ -69,7 +69,8 @@ function arrayIncludes(list) {
 
 /**
  * @param {string} qualifiedName
- * @throws DOMException.
+ * @throws
+ * DOMException.
  * @see https://dom.spec.whatwg.org/#validate
  */
 function validateQualifiedName(qualifiedName) {
@@ -80,7 +81,7 @@ function validateQualifiedName(qualifiedName) {
 
 /**
  * @param {string | null} namespace
- * @param {string}        qualifiedName
+ * @param {string} qualifiedName
  * @returns {[namespace: string | null, prefix: string | null, localName: string]}
  * @see https://dom.spec.whatwg.org/#validate-and-extract
  */
@@ -190,7 +191,8 @@ var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = (DocumentPosition.DOCUMENT_POSIT
 /**
  * Construct a parent chain for a node.
  *
- * @param {Node} node  The start node.
+ * @param {Node} node
+ * The start node.
  * @returns {Node[]} The parent chain.
  */
 function parentChain(node) {
@@ -205,8 +207,10 @@ function parentChain(node) {
 /**
  * Find the common ancestor in two parent chains.
  *
- * @param {Node[]} a  A parent chain.
- * @param {Node[]} b  A parent chain.
+ * @param {Node[]} a
+ * A parent chain.
+ * @param {Node[]} b
+ * A parent chain.
  * @returns {Node} The common ancestor if it exists.
  */
 function commonAncestor(a, b) {
@@ -222,7 +226,8 @@ function commonAncestor(a, b) {
 /**
  * Comparing unrelated nodes must be consistent, so we assign a guid to the compared docs for further reference.
  *
- * @param {Document} doc  The document.
+ * @param {Document} doc
+ * The document.
  * @returns {string} The document's guid.
  */
 function docGUID(doc) {
@@ -271,7 +276,8 @@ NodeList.prototype = {
 	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns
 	 * null.
 	 *
-	 * @param index  Unsigned long Index into the collection.
+	 * @param index
+	 * Unsigned long Index into the collection.
 	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 * @standard level1
 	 */
@@ -460,7 +466,7 @@ NamedNodeMap.prototype = {
 	 * Remove an attribute by namespace and local name.
 	 *
 	 * @param {string | null} namespaceURI
-	 * @param {string}        localName
+	 * @param {string} localName
 	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-namespace
@@ -478,7 +484,7 @@ NamedNodeMap.prototype = {
 	 * Get an attribute by namespace and local name.
 	 *
 	 * @param {string | null} namespaceURI
-	 * @param {string}        localName
+	 * @param {string} localName
 	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
 	 */
@@ -525,7 +531,8 @@ DOMImplementation.prototype = {
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
 	 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
-	 * @deprecated It is deprecated and modern browsers return true in all cases.
+	 * @deprecated
+	 * It is deprecated and modern browsers return true in all cases.
 	 */
 	hasFeature: function (feature, version) {
 		return true;
@@ -538,9 +545,10 @@ DOMImplementation.prototype = {
 	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
-	 * @param {string | null}       namespaceURI
-	 * @param {string}              qualifiedName
-	 * @param {DocumentType | null} [doctype=null]  Default is `null`
+	 * @param {string | null} namespaceURI
+	 * @param {string} qualifiedName
+	 * @param {DocumentType | null} [doctype=null]
+	 * Default is `null`
 	 * @returns {Document} The XML document.
 	 * @see #createHTMLDocument.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
@@ -580,7 +588,8 @@ DOMImplementation.prototype = {
 	 * @param {string} qualifiedName
 	 * @param {string} [publicId]
 	 * @param {string} [systemId]
-	 * @param {string} [internalSubset]  (from DOM Level 2 Core)
+	 * @param {string} [internalSubset]
+	 * (from DOM Level 2 Core)
 	 * @returns {DocumentType} Which can either be used with `DOMImplementation.createDocument` on document creation or can be put
 	 *                         into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType MDN
@@ -753,7 +762,8 @@ Node.prototype = {
 	/**
 	 * Compares the reference node with a node with regard to their position in the document and according to the document order.
 	 *
-	 * @param {Node} other  The node to compare the reference node to.
+	 * @param {Node} other
+	 * The node to compare the reference node to.
 	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if reference
 	 *                   node and given node are the same.
 	 * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
@@ -817,7 +827,8 @@ copy(DocumentPosition, Node);
 copy(DocumentPosition, Node.prototype);
 
 /**
- * @param callback  Return true for continue,false for break.
+ * @param callback
+ * Return true for continue,false for break.
  * @returns Boolean true: break visit;
  */
 function _visitNode(node, callback) {
@@ -835,7 +846,8 @@ function _visitNode(node, callback) {
 
 /**
  * @typedef DocumentOptions
- * @property {string} [contentType=MIME_TYPE.XML_APPLICATION]  Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string} [contentType=MIME_TYPE.XML_APPLICATION]
+ * Default is `MIME_TYPE.XML_APPLICATION`
  */
 /**
  * The Document interface describes the common properties and methods for any kind of document.
@@ -897,8 +909,8 @@ function _onRemoveAttribute(doc, el, newAttr, remove) {
  * child nodes.
  *
  * @param {Document} doc
- * @param {Node}     el
- * @param {Node}     [newChild]
+ * @param {Node} el
+ * @param {Node} [newChild]
  * @access private
  */
 function _onUpdateChild(doc, el, newChild) {
@@ -1019,8 +1031,10 @@ function isTextNode(node) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
  * position of a doctype node on the same level.
  *
- * @param {Document} doc    The document node.
- * @param {Node}     child  The node that would become the nextSibling if the element would be inserted.
+ * @param {Document} doc
+ * The document node.
+ * @param {Node} child
+ * The node that would become the nextSibling if the element would be inserted.
  * @returns {boolean} `true` if an element can be inserted before child.
  * @access private
  */
@@ -1037,8 +1051,10 @@ function isElementInsertionPossible(doc, child) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
  * position of a doctype node on the same level.
  *
- * @param {Node} doc    The document node.
- * @param {Node} child  The node that would become the nextSibling if the element would be inserted.
+ * @param {Node} doc
+ * The document node.
+ * @param {Node} child
+ * The node that would become the nextSibling if the element would be inserted.
  * @returns {boolean} `true` if an element can be inserted before child.
  * @access private
  */
@@ -1057,12 +1073,17 @@ function isElementReplacementPossible(doc, child) {
 }
 
 /**
- * @param {Node} parent   The parent node to insert `node` into.
- * @param {Node} node     The node to insert.
- * @param {Node} [child]  The node that should become the `nextSibling` of `node`
+ * @param {Node} parent
+ * The parent node to insert `node` into.
+ * @param {Node} node
+ * The node to insert.
+ * @param {Node} [child]
+ * The node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @throws
+ * DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws
+ * DOMException if `child` is provided but is not a child of `parent`.
  * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
@@ -1095,12 +1116,17 @@ function assertPreInsertionValidity1to5(parent, node, child) {
 }
 
 /**
- * @param {Document}         parent  The parent node to insert `node` into.
- * @param {Node}             node    The node to insert.
- * @param {Node | undefined} child   The node that should become the `nextSibling` of `node`
+ * @param {Document} parent
+ * The parent node to insert `node` into.
+ * @param {Node} node
+ * The node to insert.
+ * @param {Node | undefined} child
+ * The node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @throws
+ * DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws
+ * DOMException if `child` is provided but is not a child of `parent`.
  * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
@@ -1149,12 +1175,17 @@ function assertPreInsertionValidityInDocument(parent, node, child) {
 }
 
 /**
- * @param {Document}         parent  The parent node to insert `node` into.
- * @param {Node}             node    The node to insert.
- * @param {Node | undefined} child   The node that should become the `nextSibling` of `node`
+ * @param {Document} parent
+ * The parent node to insert `node` into.
+ * @param {Node} node
+ * The node to insert.
+ * @param {Node | undefined} child
+ * The node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @throws
+ * DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws
+ * DOMException if `child` is provided but is not a child of `parent`.
  * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
@@ -1201,12 +1232,17 @@ function assertPreReplacementValidityInDocument(parent, node, child) {
 }
 
 /**
- * @param {Node} parent   The parent node to insert `node` into.
- * @param {Node} node     The node to insert.
- * @param {Node} [child]  The node that should become the `nextSibling` of `node`
+ * @param {Node} parent
+ * The parent node to insert `node` into.
+ * @param {Node} node
+ * The node to insert.
+ * @param {Node} [child]
+ * The node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @throws
+ * DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws
+ * DOMException if `child` is provided but is not a child of `parent`.
  * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
@@ -1371,8 +1407,8 @@ Document.prototype = {
 	 * selected by this array no longer qualifies for the selector, it will automatically be removed. Be aware of this for iteration
 	 * purposes.
 	 *
-	 * @param {string} classNames  Is a string representing the class name(s) to match; multiple class names are separated by
-	 *                             (ASCII-)whitespace.
+	 * @param {string} classNames
+	 * Is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -11,7 +11,8 @@ var NAMESPACE = conventions.NAMESPACE;
 var g = require('./grammar');
 
 /**
- * A prerequisite for `[].filter`, to drop elements that are empty
+ * A prerequisite for `[].filter`, to drop elements that are empty.
+ *
  * @param {string} input
  * @returns {boolean}
  */
@@ -19,11 +20,10 @@ function notEmptyString(input) {
 	return input !== '';
 }
 /**
- * @see https://infra.spec.whatwg.org/#split-on-ascii-whitespace
- * @see https://infra.spec.whatwg.org/#ascii-whitespace
- *
  * @param {string} input
  * @returns {string[]} (can be empty)
+ * @see https://infra.spec.whatwg.org/#split-on-ascii-whitespace
+ * @see https://infra.spec.whatwg.org/#ascii-whitespace
  */
 function splitOnASCIIWhitespace(input) {
 	// U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, U+0020 SPACE
@@ -45,9 +45,9 @@ function orderedSetReducer(current, element) {
 }
 
 /**
- * @see https://infra.spec.whatwg.org/#ordered-set
  * @param {string} input
  * @returns {string[]}
+ * @see https://infra.spec.whatwg.org/#ordered-set
  */
 function toOrderedSet(input) {
 	if (!input) return [];
@@ -70,7 +70,8 @@ function arrayIncludes(list) {
 
 /**
  * @param {string} qualifiedName
- * @throws DOMException
+ * @throws
+ * DOMException.
  * @see https://dom.spec.whatwg.org/#validate
  */
 function validateQualifiedName(qualifiedName) {
@@ -80,17 +81,17 @@ function validateQualifiedName(qualifiedName) {
 }
 
 /**
- *
  * @param {string | null} namespace
  * @param {string} qualifiedName
- *
- * @returns {[namespace:string|null, prefix:string|null, localName:string]}
+ * @returns {[namespace: string | null, prefix: string | null, localName: string]}
  * @see https://dom.spec.whatwg.org/#validate-and-extract
  */
 function validateAndExtract(namespace, qualifiedName) {
 	validateQualifiedName(qualifiedName);
 	namespace = namespace || null;
-	/** @type {string | null} */
+	/**
+	 * @type {string | null}
+	 */
 	var prefix = null;
 	var localName = qualifiedName;
 	if (qualifiedName.indexOf(':') >= 0) {
@@ -190,8 +191,10 @@ var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = (DocumentPosition.DOCUMENT_POSIT
 //helper functions for compareDocumentPosition
 /**
  * Construct a parent chain for a node.
- * @param {Node} node The start node.
- * @return {Node[]} The parent chain.
+ *
+ * @param {Node} node
+ * The start node.
+ * @returns {Node[]} The parent chain.
  */
 function parentChain(node) {
 	var chain = [];
@@ -204,9 +207,12 @@ function parentChain(node) {
 
 /**
  * Find the common ancestor in two parent chains.
- * @param {Node[]} a A parent chain.
- * @param {Node[]} b A parent chain.
- * @return {Node} The common ancestor if it exists.
+ *
+ * @param {Node[]} a
+ * A parent chain.
+ * @param {Node[]} b
+ * A parent chain.
+ * @returns {Node} The common ancestor if it exists.
  */
 function commonAncestor(a, b) {
 	if (b.length < a.length) return commonAncestor(b, a);
@@ -219,10 +225,11 @@ function commonAncestor(a, b) {
 }
 
 /**
- * Comparing unrelated nodes must be consistent, so we assign a guid to the
- * compared docs for further reference.
- * @param {Document} doc The document.
- * @return {string} The document's guid.
+ * Comparing unrelated nodes must be consistent, so we assign a guid to the compared docs for further reference.
+ *
+ * @param {Document} doc
+ * The document.
+ * @returns {string} The document's guid.
  */
 function docGUID(doc) {
 	if (!doc.guid) doc.guid = Math.random();
@@ -231,8 +238,8 @@ function docGUID(doc) {
 //-- end of helper functions
 
 /**
- * DOM Level 2
- * Object DOMException
+ * DOM Level 2 Object DOMException.
+ *
  * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/ecma-script-binding.html
  * @see http://www.w3.org/TR/REC-DOM-Level-1/ecma-script-language-binding.html
  */
@@ -253,24 +260,27 @@ DOMException.prototype = Error.prototype;
 copy(ExceptionCode, DOMException);
 
 /**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177
- * The NodeList interface provides the abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented. NodeList objects in the DOM are live.
- * The items in the NodeList are accessible via an integral index, starting from 0.
+ * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The NodeList interface provides the
+ *      abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented.
+ *      NodeList objects in the DOM are live.
+ *      The items in the NodeList are accessible via an integral index, starting from 0.
  */
 function NodeList() {}
 NodeList.prototype = {
 	/**
 	 * The number of nodes in the list. The range of valid child node indices is 0 to length-1 inclusive.
+	 *
 	 * @standard level1
 	 */
 	length: 0,
 	/**
-	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns null.
+	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns
+	 * null.
+	 *
+	 * @param index
+	 * Unsigned long Index into the collection.
+	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 * @standard level1
-	 * @param index  unsigned long
-	 *   Index into the collection.
-	 * @return Node
-	 * 	The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 */
 	item: function (index) {
 		return this[index] || null;
@@ -282,17 +292,17 @@ NodeList.prototype = {
 		return buf.join('');
 	},
 	/**
-	 * @private
 	 * @param {function (Node):boolean} predicate
 	 * @returns {Node[]}
+	 * @access private
 	 */
 	filter: function (predicate) {
 		return Array.prototype.filter.call(this, predicate);
 	},
 	/**
-	 * @private
 	 * @param {Node} item
 	 * @returns {number}
+	 * @access private
 	 */
 	indexOf: function (item) {
 		return Array.prototype.indexOf.call(this, item);
@@ -322,8 +332,7 @@ LiveNodeList.prototype.item = function (i) {
 _extends(LiveNodeList, NodeList);
 
 /**
- * Objects implementing the NamedNodeMap interface are used
- * to represent collections of nodes that can be accessed by name.
+ * Objects implementing the NamedNodeMap interface are used to represent collections of nodes that can be accessed by name.
  * Note that NamedNodeMap does not inherit from NodeList;
  * NamedNodeMaps are not maintained in any particular order.
  * Objects contained in an object implementing NamedNodeMap may also be accessed by an ordinal index,
@@ -391,9 +400,8 @@ NamedNodeMap.prototype = {
 	/**
 	 * get an attribute by name (lower case in case of HTML namespace and document)
 	 *
-	 * @param  {string} localName
-	 * @return {Attr | null}
-	 *
+	 * @param {string} localName
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
 	 */
 	getNamedItem: function (localName) {
@@ -412,10 +420,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * set an attribute
+	 * Set an attribute.
 	 *
 	 * @param {Attr} attr
-	 * @return {Attr | null}
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-set
 	 */
 	setNamedItem: function (attr) {
@@ -432,11 +440,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * set an attribute
+	 * Set an attribute.
 	 *
 	 * @param {Attr} attr
-	 * @return {Attr | null}
-	 *
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-set
 	 */
 	setNamedItemNS: function (attr) {
@@ -447,8 +454,7 @@ NamedNodeMap.prototype = {
 	 * remove an attribute by name (lower case in case of HTML namespace and document)
 	 *
 	 * @param {string} localName
-	 * @return {Attr | null}
-	 *
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditem
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-name
 	 */
@@ -462,12 +468,11 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * remove an attribute by namespace and local name
+	 * Remove an attribute by namespace and local name.
 	 *
 	 * @param {string | null} namespaceURI
 	 * @param {string} localName
-	 * @return {Attr | null}
-	 *
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-namespace
 	 */
@@ -481,12 +486,11 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * get an attribute by namespace and local name
+	 * Get an attribute by namespace and local name.
 	 *
 	 * @param {string | null} namespaceURI
 	 * @param {string} localName
-	 * @return {Attr | null}
-	 *
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
 	 */
 	getNamedItemNS: function (namespaceURI, localName) {
@@ -506,14 +510,12 @@ NamedNodeMap.prototype = {
 };
 
 /**
- * The DOMImplementation interface represents an object providing methods
- * which are not dependent on any particular document.
+ * The DOMImplementation interface represents an object providing methods which are not dependent on any particular document.
  * Such an object is returned by the `Document.implementation` property.
  *
- * __The individual methods describe the differences compared to the specs.__
+ * __The individual methods describe the differences compared to the specs.__.
  *
- * @constructor
- *
+ * @class
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation MDN
  * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-102161490 DOM Level 1 Core (Initial)
  * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-102161490 DOM Level 2 Core
@@ -526,17 +528,17 @@ DOMImplementation.prototype = {
 	/**
 	 * The DOMImplementation.hasFeature() method returns a Boolean flag indicating if a given feature is supported.
 	 * The different implementations fairly diverged in what kind of features were reported.
-	 * The latest version of the spec settled to force this method to always return true, where the functionality was accurate and in use.
-	 *
-	 * @deprecated It is deprecated and modern browsers return true in all cases.
+	 * The latest version of the spec settled to force this method to always return true, where the functionality was accurate and in
+	 * use.
 	 *
 	 * @param {string} feature
 	 * @param {string} [version]
-	 * @returns {boolean} always true
-	 *
+	 * @returns {boolean} Always true.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
 	 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
+	 * @deprecated
+	 * It is deprecated and modern browsers return true in all cases.
 	 */
 	hasFeature: function (feature, version) {
 		return true;
@@ -551,13 +553,11 @@ DOMImplementation.prototype = {
 	 * @param {string | null} namespaceURI
 	 * @param {string} qualifiedName
 	 * @param {DocumentType | null} [doctype=null]
-	 * @returns {Document} the XML document
-	 *
-	 * @see #createHTMLDocument
-	 *
+	 * @returns {Document} The XML document.
+	 * @see #createHTMLDocument.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM Level 2 Core (initial)
-	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument  DOM Level 2 Core
+	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument DOM Level 2 Core
 	 */
 	createDocument: function (namespaceURI, qualifiedName, doctype) {
 		var contentType = MIME_TYPE.XML_APPLICATION;
@@ -585,18 +585,18 @@ DOMImplementation.prototype = {
 	 * __This behavior is slightly different from the in the specs__:
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 * - `publicId` and `systemId` contain the raw data including any possible quotes,
-	 *   so they can always be serialized back to the original value
-	 * - `internalSubset` contains the raw string between `[` and `]` if present,
-	 *   but is not parsed or validated in any form
+	 * so they can always be serialized back to the original value - `internalSubset` contains the raw string between `[` and `]` if
+	 * present,
+	 * but is not parsed or validated in any form.
 	 *
 	 * @param {string} qualifiedName
 	 * @param {string} [publicId]
 	 * @param {string} [systemId]
-	 * @param {string} [internalSubset] (from DOM Level 2 Core)
+	 * @param {string} [internalSubset]
+	 * (from DOM Level 2 Core)
 	 * @returns {DocumentType} which can either be used with `DOMImplementation.createDocument`
-	 *                         on document creation or can be put into the document
-	 *                         via methods like `Node.insertBefore()` or `Node.replaceChild()`
-	 *
+	 *                         on document creation or can be put into the document via methods like `Node.insertBefore()` or
+	 *                         `Node.replaceChild()`
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocType DOM Level 2 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype DOM Living Standard
@@ -622,8 +622,7 @@ DOMImplementation.prototype = {
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string | false} [title]
-	 * @returns {Document} The HTML document
-	 *
+	 * @returns {Document} The HTML document.
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 	 * @see https://dom.spec.whatwg.org/#html-document
 	 */
@@ -719,7 +718,7 @@ Node.prototype = {
 	 * **The default namespace declarations are ignored by this method.**
 	 * See Namespace Prefix Lookup for details on the algorithm used by this method.
 	 *
-	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._
+	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._.
 	 *
 	 * @param {string | null} namespaceURI
 	 * @returns {string | null}
@@ -766,13 +765,12 @@ Node.prototype = {
 	},
 	// Introduced in DOM Level 3:
 	/**
-	 * Compares the reference node with a node with regard to their position
-	 * in the document and according to the document order.
+	 * Compares the reference node with a node with regard to their position in the document and according to the document order.
 	 *
-	 * @param {Node} other The node to compare the reference node to.
-	 * @return {number} Returns how the node is positioned relatively to the
-	 *    reference node according to the bitmask. 0 if reference node and
-	 *    given node are the same.
+	 * @param {Node} other
+	 * The node to compare the reference node to.
+	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if reference
+	 *                   node and given node are the same.
 	 * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
 	 */
 	compareDocumentPosition: function (other) {
@@ -834,8 +832,9 @@ copy(DocumentPosition, Node);
 copy(DocumentPosition, Node.prototype);
 
 /**
- * @param callback return true for continue,false for break
- * @return boolean true: break visit;
+ * @param callback
+ * Return true for continue,false for break.
+ * @returns boolean true: break visit;
  */
 function _visitNode(node, callback) {
 	if (callback(node)) {
@@ -860,13 +859,11 @@ function _visitNode(node, callback) {
  * It should usually be created using `new DOMImplementation().createDocument(...)`
  * or `new DOMImplementation().createHTMLDocument(...)`.
  *
- * The constructor is considered a private API and offers to initially set the `contentType` property
- * via it's options parameter.
+ * The constructor is considered a private API and offers to initially set the `contentType` property via it's options parameter.
  *
+ * @class
  * @param {DocumentOptions} [options]
- * @private
- * @constructor
- *
+ * @access private
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Document
  * @see https://dom.spec.whatwg.org/#interface-document
  */
@@ -877,20 +874,17 @@ function Document(options) {
 	 * The mime type of the document is determined at creation time and can not be modified.
 	 *
 	 * @type {string}
-	 * @readonly
-	 *
 	 * @see https://dom.spec.whatwg.org/#concept-document-content-type
-	 * @see DOMImplementation
-	 * @see MIME_TYPE
+	 * @see DOMImplementation.
+	 * @see MIME_TYPE.
+	 * @readonly
 	 */
 	this.contentType = opt.contentType || MIME_TYPE.XML_APPLICATION;
 	/**
-	 *
 	 * @type {'html' | 'xml'}
-	 * @readonly
-	 *
 	 * @see https://dom.spec.whatwg.org/#concept-document-type
-	 * @see DOMImplementation
+	 * @see DOMImplementation.
+	 * @readonly
 	 */
 	this.type = isHTMLMimeType(this.contentType) ? 'html' : 'xml';
 }
@@ -917,13 +911,12 @@ function _onRemoveAttribute(doc, el, newAttr, remove) {
  * Updates `el.childNodes`, updating the indexed items and it's `length`.
  * Passing `newChild` means it will be appended.
  * Otherwise it's assumed that an item has been removed,
- * and `el.firstNode` and it's `.nextSibling` are used
- * to walk the current list of child nodes.
+ * and `el.firstNode` and it's `.nextSibling` are used to walk the current list of child nodes.
  *
  * @param {Document} doc
  * @param {Node} el
  * @param {Node} [newChild]
- * @private
+ * @access private
  */
 function _onUpdateChild(doc, el, newChild) {
 	if (doc && doc._inc) {
@@ -949,13 +942,12 @@ function _onUpdateChild(doc, el, newChild) {
  * Removes the connections between `parentNode` and `child`
  * and any existing `child.previousSibling` or `child.nextSibling`.
  *
- * @see https://github.com/xmldom/xmldom/issues/135
- * @see https://github.com/xmldom/xmldom/issues/145
- *
  * @param {Node} parentNode
  * @param {Node} child
- * @returns {Node} the child that was removed.
- * @private
+ * @returns {Node} The child that was removed.
+ * @access private
+ * @see https://github.com/xmldom/xmldom/issues/135
+ * @see https://github.com/xmldom/xmldom/issues/145
  */
 function _removeChild(parentNode, child) {
 	if (parentNode !== child.parentNode) {
@@ -983,6 +975,7 @@ function _removeChild(parentNode, child) {
 
 /**
  * Returns `true` if `node` can be a parent for insertion.
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -995,6 +988,7 @@ function hasValidParentNodeType(node) {
 
 /**
  * Returns `true` if `node` can be inserted according to it's `nodeType`.
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1011,7 +1005,8 @@ function hasInsertableNodeType(node) {
 }
 
 /**
- * Returns true if `node` is a DOCTYPE node
+ * Returns true if `node` is a DOCTYPE node.
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1020,7 +1015,8 @@ function isDocTypeNode(node) {
 }
 
 /**
- * Returns true if the node is an element
+ * Returns true if the node is an element.
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1028,7 +1024,8 @@ function isElementNode(node) {
 	return node && node.nodeType === Node.ELEMENT_NODE;
 }
 /**
- * Returns true if `node` is a text node
+ * Returns true if `node` is a text node.
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1040,11 +1037,12 @@ function isTextNode(node) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy,
  * according to the presence and position of a doctype node on the same level.
  *
- * @param {Document} doc The document node
- * @param {Node} child the node that would become the nextSibling if the element would be inserted
- * @returns {boolean} `true` if an element can be inserted before child
- * @private
- * https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
+ * @param {Document} doc
+ * The document node.
+ * @param {Node} child
+ * The node that would become the nextSibling if the element would be inserted.
+ * @returns {boolean} `true` if an element can be inserted before child.
+ * @access private
  */
 function isElementInsertionPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1059,11 +1057,12 @@ function isElementInsertionPossible(doc, child) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy,
  * according to the presence and position of a doctype node on the same level.
  *
- * @param {Node} doc The document node
- * @param {Node} child the node that would become the nextSibling if the element would be inserted
- * @returns {boolean} `true` if an element can be inserted before child
- * @private
- * https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
+ * @param {Node} doc
+ * The document node.
+ * @param {Node} child
+ * The node that would become the nextSibling if the element would be inserted.
+ * @returns {boolean} `true` if an element can be inserted before child.
+ * @access private
  */
 function isElementReplacementPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1080,15 +1079,18 @@ function isElementReplacementPossible(doc, child) {
 }
 
 /**
- * @private
- * Steps 1-5 of the checks before inserting and before replacing a child are the same.
- *
- * @param {Node} parent the parent node to insert `node` into
- * @param {Node} node the node to insert
- * @param {Node=} child the node that should become the `nextSibling` of `node`
+ * @param {Node} parent
+ * The parent node to insert `node` into.
+ * @param {Node} node
+ * The node to insert.
+ * @param {Node=} child
+ * the node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @throws
+ * DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws
+ * DOMException if `child` is provided but is not a child of `parent`.
+ * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1120,15 +1122,18 @@ function assertPreInsertionValidity1to5(parent, node, child) {
 }
 
 /**
- * @private
- * Step 6 of the checks before inserting and before replacing a child are different.
- *
- * @param {Document} parent the parent node to insert `node` into
- * @param {Node} node the node to insert
- * @param {Node | undefined} child the node that should become the `nextSibling` of `node`
+ * @param {Document} parent
+ * The parent node to insert `node` into.
+ * @param {Node} node
+ * The node to insert.
+ * @param {Node | undefined} child
+ * the node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @throws
+ * DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws
+ * DOMException if `child` is provided but is not a child of `parent`.
+ * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1176,15 +1181,18 @@ function assertPreInsertionValidityInDocument(parent, node, child) {
 }
 
 /**
- * @private
- * Step 6 of the checks before inserting and before replacing a child are different.
- *
- * @param {Document} parent the parent node to insert `node` into
- * @param {Node} node the node to insert
- * @param {Node | undefined} child the node that should become the `nextSibling` of `node`
+ * @param {Document} parent
+ * The parent node to insert `node` into.
+ * @param {Node} node
+ * The node to insert.
+ * @param {Node | undefined} child
+ * the node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @throws
+ * DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws
+ * DOMException if `child` is provided but is not a child of `parent`.
+ * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1230,13 +1238,18 @@ function assertPreReplacementValidityInDocument(parent, node, child) {
 }
 
 /**
- * @private
- * @param {Node} parent the parent node to insert `node` into
- * @param {Node} node the node to insert
- * @param {Node=} child the node that should become the `nextSibling` of `node`
+ * @param {Node} parent
+ * The parent node to insert `node` into.
+ * @param {Node} node
+ * The node to insert.
+ * @param {Node=} child
+ * the node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws DOMException if `child` is provided but is not a child of `parent`.
+ * @throws
+ * DOMException for several node combinations that would create a DOM that is not well-formed.
+ * @throws
+ * DOMException if `child` is provided but is not a child of `parent`.
+ * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
 function _insertBefore(parent, node, child, _inDocumentAssertion) {
@@ -1292,12 +1305,12 @@ function _insertBefore(parent, node, child, _inDocumentAssertion) {
  * Appends `newChild` to `parentNode`.
  * If `newChild` is already connected to a `parentNode` it is first removed from it.
  *
- * @see https://github.com/xmldom/xmldom/issues/135
- * @see https://github.com/xmldom/xmldom/issues/145
  * @param {Node} parentNode
  * @param {Node} newChild
  * @returns {Node}
- * @private
+ * @access private
+ * @see https://github.com/xmldom/xmldom/issues/135
+ * @see https://github.com/xmldom/xmldom/issues/145
  */
 function _appendSingleChild(parentNode, newChild) {
 	if (newChild.parentNode) {
@@ -1318,9 +1331,10 @@ function _appendSingleChild(parentNode, newChild) {
 
 Document.prototype = {
 	/**
-	 * The implementation that created this document
-	 * @readonly
+	 * The implementation that created this document.
+	 *
 	 * @type DOMImplementation
+	 * @readonly
 	 */
 	implementation: null,
 	nodeName: '#document',
@@ -1328,8 +1342,8 @@ Document.prototype = {
 	/**
 	 * The DocumentType node of the document.
 	 *
-	 * @readonly
 	 * @type DocumentType
+	 * @readonly
 	 */
 	doctype: null,
 	documentElement: null,
@@ -1391,19 +1405,18 @@ Document.prototype = {
 	},
 
 	/**
-	 * The `getElementsByClassName` method of `Document` interface returns an array-like object
-	 * of all child elements which have **all** of the given class name(s).
+	 * The `getElementsByClassName` method of `Document` interface returns an array-like object of all child elements which have
+	 * **all** of the given class name(s).
 	 *
 	 * Returns an empty list if `classeNames` is an empty string or only contains HTML white space characters.
-	 *
 	 *
 	 * Warning: This is a live LiveNodeList.
 	 * Changes in the DOM will reflect in the array as the changes occur.
 	 * If an element selected by this array no longer qualifies for the selector,
 	 * it will automatically be removed. Be aware of this for iteration purposes.
 	 *
-	 * @param {string} classNames is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace
-	 *
+	 * @param {string} classNames
+	 * Is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */
@@ -1440,15 +1453,13 @@ Document.prototype = {
 	 * otherwise no transformation is being applied.
 	 * When `contentType` implies the HTML namespace, it will be set as `namespaceURI`.
 	 *
-	 * __This implementation differs from the specification:__
-	 * - The provided name is not checked against the `Name` production,
-	 *   so no related error will be thrown.
+	 * __This implementation differs from the specification:__ - The provided name is not checked against the `Name` production,
+	 * so no related error will be thrown.
 	 * - There is no interface `HTMLElement`, it is always an `Element`.
 	 * - There is no support for a second argument to indicate using custom elements.
 	 *
 	 * @param {string} tagName
-	 * @return {Element}
-	 *
+	 * @returns {Element}
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement
 	 * @see https://dom.spec.whatwg.org/#dom-document-createelement
 	 * @see https://dom.spec.whatwg.org/#concept-create-element
@@ -1506,13 +1517,11 @@ Document.prototype = {
 	 * In HTML Documents `localName` is the lower cased `name`,
 	 * otherwise no transformation is being applied.
 	 *
-	 * __This implementation differs from the specification:__
-	 * - The provided name is not checked against the `Name` production,
-	 *   so no related error will be thrown.
+	 * __This implementation differs from the specification:__ - The provided name is not checked against the `Name` production,
+	 * so no related error will be thrown.
 	 *
 	 * @param {string} name
-	 * @return {Attr}
-	 *
+	 * @returns {Attr}
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createAttribute
 	 * @see https://dom.spec.whatwg.org/#dom-document-createattribute
 	 */
@@ -1590,7 +1599,7 @@ Element.prototype = {
 	 * Returns element’s first attribute whose qualified name is `name`, and `null` if there is no such attribute.
 	 *
 	 * @param {string} name
-	 * @return {string | null}
+	 * @returns {string | null}
 	 */
 	getAttribute: function (name) {
 		var attr = this.getAttributeNode(name);
@@ -1659,7 +1668,7 @@ Element.prototype = {
 	 *
 	 * @param {string} namespaceURI
 	 * @param {string} localName
-	 * @return {string | null}
+	 * @returns {string | null}
 	 */
 	getAttributeNS: function (namespaceURI, localName) {
 		var attr = this.getAttributeNodeNS(namespaceURI, localName);
@@ -1671,7 +1680,6 @@ Element.prototype = {
 	 * @param {string} namespaceURI
 	 * @param {string} qualifiedName
 	 * @param {string} value
-	 *
 	 * @see https://dom.spec.whatwg.org/#dom-element-setattributens
 	 */
 	setAttributeNS: function (namespaceURI, qualifiedName, value) {
@@ -1701,8 +1709,7 @@ Element.prototype = {
 	 *
 	 * When called on an HTML element in an HTML document,
 	 * `getElementsByTagName` lower-cases the argument before searching for it.
-	 * This is undesirable when trying to match camel-cased SVG elements
-	 * (such as `<linearGradient>`) in an HTML document.
+	 * This is undesirable when trying to match camel-cased SVG elements (such as `<linearGradient>`) in an HTML document.
 	 * Instead, use `Element.getElementsByTagNameNS()`,
 	 * which preserves the capitalization of the tag name.
 	 *
@@ -1710,8 +1717,7 @@ Element.prototype = {
 	 * except that it only searches for elements that are descendants of the specified element.
 	 *
 	 * @param {string} qualifiedName
-	 * @return {LiveNodeList}
-	 *
+	 * @returns {LiveNodeList}
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByTagName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbytagname
 	 */
@@ -1903,15 +1909,15 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
 	return true;
 }
 /**
- * Well-formed constraint: No < in Attribute Values
- * > The replacement text of any entity referred to directly or indirectly
- * > in an attribute value must not contain a <.
+ * Well-formed constraint: No < in Attribute Values > The replacement text of any entity referred to directly or indirectly > in
+ * an attribute value must not contain a <.
+ *
  * @see https://www.w3.org/TR/xml11/#CleanAttrVals
  * @see https://www.w3.org/TR/xml11/#NT-AttValue
  *
- * Literal whitespace other than space that appear in attribute values
- * are serialized as their entity references, so they will be preserved.
- * (In contrast to whitespace literals in the input which are normalized to spaces)
+ *      Literal whitespace other than space that appear in attribute values are serialized as their entity references, so they
+ *      will be preserved.
+ *      (In contrast to whitespace literals in the input which are normalized to spaces)
  * @see https://www.w3.org/TR/xml11/#AVNormalize
  * @see https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes
  */
@@ -2057,15 +2063,14 @@ function serializeToString(node, buf, nodeFilter, visibleNamespaces) {
 			/**
 			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,
 			 * except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section.
-			 * If they are needed elsewhere, they must be escaped using either numeric character references or the strings
-			 * `&amp;` and `&lt;` respectively.
+			 * If they are needed elsewhere, they must be escaped using either numeric character references or the strings `&amp;` and
+			 * `&lt;` respectively.
 			 * The right angle bracket (>) may be represented using the string " &gt; ", and must, for compatibility,
 			 * be escaped using either `&gt;` or a character reference when it appears in the string `]]>` in content,
 			 * when that string is not marking the end of a CDATA section.
 			 *
-			 * In the content of elements, character data is any string of characters
-			 * which does not contain the start-delimiter of any markup
-			 * and does not include the CDATA-section-close delimiter, `]]>`.
+			 * In the content of elements, character data is any string of characters which does not contain the start-delimiter of any
+			 * markup and does not include the CDATA-section-close delimiter, `]]>`.
 			 *
 			 * @see https://www.w3.org/TR/xml/#NT-CharData
 			 * @see https://w3c.github.io/DOM-Parsing/#xml-serializing-a-text-node

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -11,7 +11,7 @@ var NAMESPACE = conventions.NAMESPACE;
 var g = require('./grammar');
 
 /**
- * A prerequisite for `[].filter`, to drop elements that are empty.
+ * A prerequisite for `[].filter`, to drop elements that are empty
  *
  * @param {string} input
  * @returns {boolean}
@@ -34,7 +34,7 @@ function splitOnASCIIWhitespace(input) {
  * Adds element as a key to current if it is not already present.
  *
  * @param {Record<string, boolean | undefined>} current
- * @param {string}                              element
+ * @param {string} element
  * @returns {Record<string, boolean | undefined>}
  */
 function orderedSetReducer(current, element) {
@@ -69,7 +69,7 @@ function arrayIncludes(list) {
 
 /**
  * @param {string} qualifiedName
- * @throws DOMException.
+ * @throws DOMException
  * @see https://dom.spec.whatwg.org/#validate
  */
 function validateQualifiedName(qualifiedName) {
@@ -80,16 +80,14 @@ function validateQualifiedName(qualifiedName) {
 
 /**
  * @param {string | null} namespace
- * @param {string}        qualifiedName
+ * @param {string} qualifiedName
  * @returns {[namespace: string | null, prefix: string | null, localName: string]}
  * @see https://dom.spec.whatwg.org/#validate-and-extract
  */
 function validateAndExtract(namespace, qualifiedName) {
 	validateQualifiedName(qualifiedName);
 	namespace = namespace || null;
-	/**
-	 * @type {string | null}
-	 */
+	/** @type {string | null} */
 	var prefix = null;
 	var localName = qualifiedName;
 	if (qualifiedName.indexOf(':') >= 0) {
@@ -190,7 +188,7 @@ var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = (DocumentPosition.DOCUMENT_POSIT
 /**
  * Construct a parent chain for a node.
  *
- * @param {Node} node  The start node.
+ * @param {Node} node The start node.
  * @returns {Node[]} The parent chain.
  */
 function parentChain(node) {
@@ -205,8 +203,8 @@ function parentChain(node) {
 /**
  * Find the common ancestor in two parent chains.
  *
- * @param {Node[]} a  A parent chain.
- * @param {Node[]} b  A parent chain.
+ * @param {Node[]} a A parent chain.
+ * @param {Node[]} b A parent chain.
  * @returns {Node} The common ancestor if it exists.
  */
 function commonAncestor(a, b) {
@@ -222,7 +220,7 @@ function commonAncestor(a, b) {
 /**
  * Comparing unrelated nodes must be consistent, so we assign a guid to the compared docs for further reference.
  *
- * @param {Document} doc  The document.
+ * @param {Document} doc The document.
  * @returns {string} The document's guid.
  */
 function docGUID(doc) {
@@ -232,7 +230,7 @@ function docGUID(doc) {
 //-- end of helper functions
 
 /**
- * DOM Level 2 Object DOMException.
+ * DOM Level 2 Object DOMException
  *
  * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/ecma-script-binding.html
  * @see http://www.w3.org/TR/REC-DOM-Level-1/ecma-script-language-binding.html
@@ -254,10 +252,8 @@ DOMException.prototype = Error.prototype;
 copy(ExceptionCode, DOMException);
 
 /**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The NodeList interface provides the
- *      abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented.
- *      NodeList objects in the DOM are live.
- *      The items in the NodeList are accessible via an integral index, starting from 0.
+ * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The NodeList interface provides the abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented. NodeList objects in the DOM are live.
+ * The items in the NodeList are accessible via an integral index, starting from 0.
  */
 function NodeList() {}
 NodeList.prototype = {
@@ -268,10 +264,10 @@ NodeList.prototype = {
 	 */
 	length: 0,
 	/**
-	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns
-	 * null.
+	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this
+	 * returns null.
 	 *
-	 * @param index  Unsigned long Index into the collection.
+	 * @param index Unsigned long Index into the collection.
 	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 * @standard level1
 	 */
@@ -285,17 +281,17 @@ NodeList.prototype = {
 		return buf.join('');
 	},
 	/**
+	 * @private
 	 * @param {function (Node):boolean} predicate
 	 * @returns {Node[]}
-	 * @access private
 	 */
 	filter: function (predicate) {
 		return Array.prototype.filter.call(this, predicate);
 	},
 	/**
+	 * @private
 	 * @param {Node} item
 	 * @returns {number}
-	 * @access private
 	 */
 	indexOf: function (item) {
 		return Array.prototype.indexOf.call(this, item);
@@ -409,7 +405,7 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Set an attribute.
+	 * Set an attribute
 	 *
 	 * @param {Attr} attr
 	 * @returns {Attr | null}
@@ -429,7 +425,7 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Set an attribute.
+	 * Set an attribute
 	 *
 	 * @param {Attr} attr
 	 * @returns {Attr | null}
@@ -457,10 +453,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Remove an attribute by namespace and local name.
+	 * Remove an attribute by namespace and local name
 	 *
 	 * @param {string | null} namespaceURI
-	 * @param {string}        localName
+	 * @param {string} localName
 	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-namespace
@@ -475,10 +471,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Get an attribute by namespace and local name.
+	 * Get an attribute by namespace and local name
 	 *
 	 * @param {string | null} namespaceURI
-	 * @param {string}        localName
+	 * @param {string} localName
 	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
 	 */
@@ -519,13 +515,13 @@ DOMImplementation.prototype = {
 	 * implementations fairly diverged in what kind of features were reported. The latest version of the spec settled to force this
 	 * method to always return true, where the functionality was accurate and in use.
 	 *
+	 * @deprecated It is deprecated and modern browsers return true in all cases.
 	 * @param {string} feature
 	 * @param {string} [version]
-	 * @returns {boolean} Always true.
+	 * @returns {boolean} Always true
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
 	 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
-	 * @deprecated It is deprecated and modern browsers return true in all cases.
 	 */
 	hasFeature: function (feature, version) {
 		return true;
@@ -538,11 +534,11 @@ DOMImplementation.prototype = {
 	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
-	 * @param {string | null}       namespaceURI
-	 * @param {string}              qualifiedName
-	 * @param {DocumentType | null} [doctype=null]  Default is `null`
-	 * @returns {Document} The XML document.
-	 * @see #createHTMLDocument.
+	 * @param {string | null} namespaceURI
+	 * @param {string} qualifiedName
+	 * @param {DocumentType | null} [doctype=null] Default is `null`
+	 * @returns {Document} The XML document
+	 * @see #createHTMLDocument
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM Level 2 Core (initial)
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument DOM Level 2 Core
@@ -574,15 +570,15 @@ DOMImplementation.prototype = {
 	 *
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 * - `publicId` and `systemId` contain the raw data including any possible quotes, so they can always be serialized back to the
-	 * original value - `internalSubset` contains the raw string between `[` and `]` if present, but is not parsed or validated in
-	 * any form.
+	 *   original value
+	 * - `internalSubset` contains the raw string between `[` and `]` if present, but is not parsed or validated in any form
 	 *
 	 * @param {string} qualifiedName
 	 * @param {string} [publicId]
 	 * @param {string} [systemId]
-	 * @param {string} [internalSubset]  (from DOM Level 2 Core)
+	 * @param {string} [internalSubset] (from DOM Level 2 Core)
 	 * @returns {DocumentType} Which can either be used with `DOMImplementation.createDocument` on document creation or can be put
-	 *                         into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
+	 *   into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocType DOM Level 2 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype DOM Living Standard
@@ -609,7 +605,7 @@ DOMImplementation.prototype = {
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string | false} [title]
-	 * @returns {Document} The HTML document.
+	 * @returns {Document} The HTML document
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 	 * @see https://dom.spec.whatwg.org/#html-document
 	 */
@@ -636,9 +632,7 @@ DOMImplementation.prototype = {
 	},
 };
 
-/**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247
- */
+/** @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247 */
 function Node() {}
 
 Node.prototype = {
@@ -704,7 +698,7 @@ Node.prototype = {
 	 * Look up the prefix associated to the given namespace URI, starting from this node. **The default namespace declarations are
 	 * ignored by this method.** See Namespace Prefix Lookup for details on the algorithm used by this method.
 	 *
-	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._.
+	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._
 	 *
 	 * @param {string | null} namespaceURI
 	 * @returns {string | null}
@@ -753,9 +747,9 @@ Node.prototype = {
 	/**
 	 * Compares the reference node with a node with regard to their position in the document and according to the document order.
 	 *
-	 * @param {Node} other  The node to compare the reference node to.
-	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if reference
-	 *                   node and given node are the same.
+	 * @param {Node} other The node to compare the reference node to.
+	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if
+	 *   reference node and given node are the same.
 	 * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
 	 */
 	compareDocumentPosition: function (other) {
@@ -817,7 +811,7 @@ copy(DocumentPosition, Node);
 copy(DocumentPosition, Node.prototype);
 
 /**
- * @param callback  Return true for continue,false for break.
+ * @param callback Return true for continue,false for break
  * @returns Boolean true: break visit;
  */
 function _visitNode(node, callback) {
@@ -835,7 +829,7 @@ function _visitNode(node, callback) {
 
 /**
  * @typedef DocumentOptions
- * @property {string} [contentType=MIME_TYPE.XML_APPLICATION]  Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string} [contentType=MIME_TYPE.XML_APPLICATION] Default is `MIME_TYPE.XML_APPLICATION`
  */
 /**
  * The Document interface describes the common properties and methods for any kind of document.
@@ -845,9 +839,9 @@ function _visitNode(node, callback) {
  *
  * The constructor is considered a private API and offers to initially set the `contentType` property via it's options parameter.
  *
+ * @private
  * @class
  * @param {DocumentOptions} [options]
- * @access private
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Document
  * @see https://dom.spec.whatwg.org/#interface-document
  */
@@ -858,17 +852,17 @@ function Document(options) {
 	 * The mime type of the document is determined at creation time and can not be modified.
 	 *
 	 * @type {string}
-	 * @see https://dom.spec.whatwg.org/#concept-document-content-type
-	 * @see DOMImplementation.
-	 * @see MIME_TYPE.
 	 * @readonly
+	 * @see https://dom.spec.whatwg.org/#concept-document-content-type
+	 * @see DOMImplementation
+	 * @see MIME_TYPE
 	 */
 	this.contentType = opt.contentType || MIME_TYPE.XML_APPLICATION;
 	/**
 	 * @type {'html' | 'xml'}
-	 * @see https://dom.spec.whatwg.org/#concept-document-type
-	 * @see DOMImplementation.
 	 * @readonly
+	 * @see https://dom.spec.whatwg.org/#concept-document-type
+	 * @see DOMImplementation
 	 */
 	this.type = isHTMLMimeType(this.contentType) ? 'html' : 'xml';
 }
@@ -896,10 +890,10 @@ function _onRemoveAttribute(doc, el, newAttr, remove) {
  * it's assumed that an item has been removed, and `el.firstNode` and it's `.nextSibling` are used to walk the current list of
  * child nodes.
  *
+ * @private
  * @param {Document} doc
- * @param {Node}     el
- * @param {Node}     [newChild]
- * @access private
+ * @param {Node} el
+ * @param {Node} [newChild]
  */
 function _onUpdateChild(doc, el, newChild) {
 	if (doc && doc._inc) {
@@ -924,10 +918,10 @@ function _onUpdateChild(doc, el, newChild) {
 /**
  * Removes the connections between `parentNode` and `child` and any existing `child.previousSibling` or `child.nextSibling`.
  *
+ * @private
  * @param {Node} parentNode
  * @param {Node} child
  * @returns {Node} The child that was removed.
- * @access private
  * @see https://github.com/xmldom/xmldom/issues/135
  * @see https://github.com/xmldom/xmldom/issues/145
  */
@@ -987,7 +981,7 @@ function hasInsertableNodeType(node) {
 }
 
 /**
- * Returns true if `node` is a DOCTYPE node.
+ * Returns true if `node` is a DOCTYPE node
  *
  * @param {Node} node
  * @returns {boolean}
@@ -997,7 +991,7 @@ function isDocTypeNode(node) {
 }
 
 /**
- * Returns true if the node is an element.
+ * Returns true if the node is an element
  *
  * @param {Node} node
  * @returns {boolean}
@@ -1006,7 +1000,7 @@ function isElementNode(node) {
 	return node && node.nodeType === Node.ELEMENT_NODE;
 }
 /**
- * Returns true if `node` is a text node.
+ * Returns true if `node` is a text node
  *
  * @param {Node} node
  * @returns {boolean}
@@ -1019,10 +1013,10 @@ function isTextNode(node) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
  * position of a doctype node on the same level.
  *
- * @param {Document} doc    The document node.
- * @param {Node}     child  The node that would become the nextSibling if the element would be inserted.
- * @returns {boolean} `true` if an element can be inserted before child.
- * @access private
+ * @private https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
+ * @param {Document} doc The document node
+ * @param {Node} child The node that would become the nextSibling if the element would be inserted
+ * @returns {boolean} `true` if an element can be inserted before child
  */
 function isElementInsertionPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1037,10 +1031,10 @@ function isElementInsertionPossible(doc, child) {
  * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
  * position of a doctype node on the same level.
  *
- * @param {Node} doc    The document node.
- * @param {Node} child  The node that would become the nextSibling if the element would be inserted.
- * @returns {boolean} `true` if an element can be inserted before child.
- * @access private
+ * @private https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
+ * @param {Node} doc The document node
+ * @param {Node} child The node that would become the nextSibling if the element would be inserted
+ * @returns {boolean} `true` if an element can be inserted before child
  */
 function isElementReplacementPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1057,13 +1051,13 @@ function isElementReplacementPossible(doc, child) {
 }
 
 /**
- * @param {Node} parent   The parent node to insert `node` into.
- * @param {Node} node     The node to insert.
- * @param {Node} [child]  The node that should become the `nextSibling` of `node`
+ * @private Steps 1-5 of the checks before inserting and before replacing a child are the same.
+ * @param {Node} parent The parent node to insert `node` into
+ * @param {Node} node The node to insert
+ * @param {Node} [child] The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
- * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1095,13 +1089,13 @@ function assertPreInsertionValidity1to5(parent, node, child) {
 }
 
 /**
- * @param {Document}         parent  The parent node to insert `node` into.
- * @param {Node}             node    The node to insert.
- * @param {Node | undefined} child   The node that should become the `nextSibling` of `node`
+ * @private Step 6 of the checks before inserting and before replacing a child are different.
+ * @param {Document} parent The parent node to insert `node` into
+ * @param {Node} node The node to insert
+ * @param {Node | undefined} child The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
- * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1149,13 +1143,13 @@ function assertPreInsertionValidityInDocument(parent, node, child) {
 }
 
 /**
- * @param {Document}         parent  The parent node to insert `node` into.
- * @param {Node}             node    The node to insert.
- * @param {Node | undefined} child   The node that should become the `nextSibling` of `node`
+ * @private Step 6 of the checks before inserting and before replacing a child are different.
+ * @param {Document} parent The parent node to insert `node` into
+ * @param {Node} node The node to insert
+ * @param {Node | undefined} child The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
- * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1201,13 +1195,13 @@ function assertPreReplacementValidityInDocument(parent, node, child) {
 }
 
 /**
- * @param {Node} parent   The parent node to insert `node` into.
- * @param {Node} node     The node to insert.
- * @param {Node} [child]  The node that should become the `nextSibling` of `node`
+ * @private
+ * @param {Node} parent The parent node to insert `node` into
+ * @param {Node} node The node to insert
+ * @param {Node} [child] The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
- * @access private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
 function _insertBefore(parent, node, child, _inDocumentAssertion) {
@@ -1262,10 +1256,10 @@ function _insertBefore(parent, node, child, _inDocumentAssertion) {
 /**
  * Appends `newChild` to `parentNode`. If `newChild` is already connected to a `parentNode` it is first removed from it.
  *
+ * @private
  * @param {Node} parentNode
  * @param {Node} newChild
  * @returns {Node}
- * @access private
  * @see https://github.com/xmldom/xmldom/issues/135
  * @see https://github.com/xmldom/xmldom/issues/145
  */
@@ -1288,7 +1282,7 @@ function _appendSingleChild(parentNode, newChild) {
 
 Document.prototype = {
 	/**
-	 * The implementation that created this document.
+	 * The implementation that created this document
 	 *
 	 * @type DOMImplementation
 	 * @readonly
@@ -1371,8 +1365,8 @@ Document.prototype = {
 	 * selected by this array no longer qualifies for the selector, it will automatically be removed. Be aware of this for iteration
 	 * purposes.
 	 *
-	 * @param {string} classNames  Is a string representing the class name(s) to match; multiple class names are separated by
-	 *                             (ASCII-)whitespace.
+	 * @param {string} classNames Is a string representing the class name(s) to match; multiple class names are separated by
+	 *   (ASCII-)whitespace
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */
@@ -1405,7 +1399,8 @@ Document.prototype = {
 
 	/**
 	 * Creates a new `Element` that is owned by this `Document`. In HTML Documents `localName` is the lower cased `tagName`,
-	 * otherwise no transformation is being applied. When `contentType` implies the HTML namespace, it will be set as `namespaceURI`.
+	 * otherwise no transformation is being applied. When `contentType` implies the HTML namespace, it will be set as
+	 * `namespaceURI`.
 	 *
 	 * **This implementation differs from the specification:**
 	 *
@@ -1665,8 +1660,8 @@ Element.prototype = {
 	 * This is undesirable when trying to match camel-cased SVG elements (such as `<linearGradient>`) in an HTML document. Instead,
 	 * use `Element.getElementsByTagNameNS()`, which preserves the capitalization of the tag name.
 	 *
-	 * `Element.getElementsByTagName` is similar to `Document.getElementsByTagName()`, except that it only searches for elements that
-	 * are descendants of the specified element.
+	 * `Element.getElementsByTagName` is similar to `Document.getElementsByTagName()`, except that it only searches for elements
+	 * that are descendants of the specified element.
 	 *
 	 * @param {string} qualifiedName
 	 * @returns {LiveNodeList}
@@ -1865,9 +1860,9 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
  * attribute value must not contain a <.
  *
  * @see https://www.w3.org/TR/xml11/#CleanAttrVals
- * @see https://www.w3.org/TR/xml11/#NT-AttValue Literal whitespace other than space that appear in attribute values are
- *      serialized as their entity references, so they will be preserved.
- *      (In contrast to whitespace literals in the input which are normalized to spaces)
+ * @see https://www.w3.org/TR/xml11/#NT-AttValue Literal whitespace other than space that appear in attribute values
+ * are serialized as their entity references, so they will be preserved.
+ * (In contrast to whitespace literals in the input which are normalized to spaces)
  * @see https://www.w3.org/TR/xml11/#AVNormalize
  * @see https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes
  */
@@ -2011,11 +2006,12 @@ function serializeToString(node, buf, nodeFilter, visibleNamespaces) {
 			return addSerializedAttribute(buf, node.name, node.value);
 		case TEXT_NODE:
 			/**
-			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form, except when used as markup
-			 * delimiters, or within a comment, a processing instruction, or a CDATA section. If they are needed elsewhere, they must be
-			 * escaped using either numeric character references or the strings `&amp;` and `&lt;` respectively. The right angle bracket
-			 * (>) may be represented using the string " > ", and must, for compatibility, be escaped using either `&gt;` or a character
-			 * reference when it appears in the string `]]>` in content, when that string is not marking the end of a CDATA section.
+			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form, except when used as
+			 * markup delimiters, or within a comment, a processing instruction, or a CDATA section. If they are needed elsewhere, they
+			 * must be escaped using either numeric character references or the strings `&amp;` and `&lt;` respectively. The right angle
+			 * bracket (>) may be represented using the string " > ", and must, for compatibility, be escaped using either `&gt;` or a
+			 * character reference when it appears in the string `]]>` in content, when that string is not marking the end of a CDATA
+			 * section.
 			 *
 			 * In the content of elements, character data is any string of characters which does not contain the start-delimiter of any
 			 * markup and does not include the CDATA-section-close delimiter, `]]>`.

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -12,6 +12,7 @@ var g = require('./grammar');
 
 /**
  * A prerequisite for `[].filter`, to drop elements that are empty
+ *
  * @param {string} input
  * @returns {boolean}
  */
@@ -19,11 +20,10 @@ function notEmptyString(input) {
 	return input !== '';
 }
 /**
- * @see https://infra.spec.whatwg.org/#split-on-ascii-whitespace
- * @see https://infra.spec.whatwg.org/#ascii-whitespace
- *
  * @param {string} input
  * @returns {string[]} (can be empty)
+ * @see https://infra.spec.whatwg.org/#split-on-ascii-whitespace
+ * @see https://infra.spec.whatwg.org/#ascii-whitespace
  */
 function splitOnASCIIWhitespace(input) {
 	// U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, U+0020 SPACE
@@ -45,9 +45,9 @@ function orderedSetReducer(current, element) {
 }
 
 /**
- * @see https://infra.spec.whatwg.org/#ordered-set
  * @param {string} input
  * @returns {string[]}
+ * @see https://infra.spec.whatwg.org/#ordered-set
  */
 function toOrderedSet(input) {
 	if (!input) return [];
@@ -56,8 +56,7 @@ function toOrderedSet(input) {
 }
 
 /**
- * Uses `list.indexOf` to implement something like `Array.prototype.includes`,
- * which we can not rely on being available.
+ * Uses `list.indexOf` to implement something like `Array.prototype.includes`, which we can not rely on being available.
  *
  * @param {any[]} list
  * @returns {function(any): boolean}
@@ -80,11 +79,9 @@ function validateQualifiedName(qualifiedName) {
 }
 
 /**
- *
  * @param {string | null} namespace
  * @param {string} qualifiedName
- *
- * @returns {[namespace:string|null, prefix:string|null, localName:string]}
+ * @returns {[namespace: string | null, prefix: string | null, localName: string]}
  * @see https://dom.spec.whatwg.org/#validate-and-extract
  */
 function validateAndExtract(namespace, qualifiedName) {
@@ -122,8 +119,8 @@ function copy(src, dest) {
 }
 
 /**
-^\w+\.prototype\.([_\w]+)\s*=\s*((?:.*\{\s*?[\r\n][\s\S]*?^})|\S.*?(?=[;\r\n]));?
-^\w+\.prototype\.([_\w]+)\s*=\s*(\S.*?(?=[;\r\n]));?
+ * ^\w+.prototype.([_\w]+)\s*=\s*((?:._{\s_?[\r\n][\s\S]_?^})|\S._?(?=[;\r\n]));?
+ * ^\w+.prototype.([_\w]+)\s*=\s*(\S.*?(?=[;\r\n]));?
  */
 function _extends(Class, Super) {
 	var pt = Class.prototype;
@@ -190,8 +187,9 @@ var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = (DocumentPosition.DOCUMENT_POSIT
 //helper functions for compareDocumentPosition
 /**
  * Construct a parent chain for a node.
+ *
  * @param {Node} node The start node.
- * @return {Node[]} The parent chain.
+ * @returns {Node[]} The parent chain.
  */
 function parentChain(node) {
 	var chain = [];
@@ -204,9 +202,10 @@ function parentChain(node) {
 
 /**
  * Find the common ancestor in two parent chains.
+ *
  * @param {Node[]} a A parent chain.
  * @param {Node[]} b A parent chain.
- * @return {Node} The common ancestor if it exists.
+ * @returns {Node} The common ancestor if it exists.
  */
 function commonAncestor(a, b) {
 	if (b.length < a.length) return commonAncestor(b, a);
@@ -219,10 +218,10 @@ function commonAncestor(a, b) {
 }
 
 /**
- * Comparing unrelated nodes must be consistent, so we assign a guid to the
- * compared docs for further reference.
+ * Comparing unrelated nodes must be consistent, so we assign a guid to the compared docs for further reference.
+ *
  * @param {Document} doc The document.
- * @return {string} The document's guid.
+ * @returns {string} The document's guid.
  */
 function docGUID(doc) {
 	if (!doc.guid) doc.guid = Math.random();
@@ -231,8 +230,8 @@ function docGUID(doc) {
 //-- end of helper functions
 
 /**
- * DOM Level 2
- * Object DOMException
+ * DOM Level 2 Object DOMException
+ *
  * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/ecma-script-binding.html
  * @see http://www.w3.org/TR/REC-DOM-Level-1/ecma-script-language-binding.html
  */
@@ -253,24 +252,24 @@ DOMException.prototype = Error.prototype;
 copy(ExceptionCode, DOMException);
 
 /**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177
- * The NodeList interface provides the abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented. NodeList objects in the DOM are live.
+ * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The NodeList interface provides the abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented. NodeList objects in the DOM are live.
  * The items in the NodeList are accessible via an integral index, starting from 0.
  */
 function NodeList() {}
 NodeList.prototype = {
 	/**
 	 * The number of nodes in the list. The range of valid child node indices is 0 to length-1 inclusive.
+	 *
 	 * @standard level1
 	 */
 	length: 0,
 	/**
-	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns null.
+	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this
+	 * returns null.
+	 *
+	 * @param index Unsigned long Index into the collection.
+	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 * @standard level1
-	 * @param index  unsigned long
-	 *   Index into the collection.
-	 * @return Node
-	 * 	The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 */
 	item: function (index) {
 		return this[index] || null;
@@ -322,18 +321,13 @@ LiveNodeList.prototype.item = function (i) {
 _extends(LiveNodeList, NodeList);
 
 /**
- * Objects implementing the NamedNodeMap interface are used
- * to represent collections of nodes that can be accessed by name.
- * Note that NamedNodeMap does not inherit from NodeList;
- * NamedNodeMaps are not maintained in any particular order.
- * Objects contained in an object implementing NamedNodeMap may also be accessed by an ordinal index,
- * but this is simply to allow convenient enumeration of the contents of a NamedNodeMap,
- * and does not imply that the DOM specifies an order to these Nodes.
- * NamedNodeMap objects in the DOM are live.
- * used for attributes or DocumentType entities
+ * Objects implementing the NamedNodeMap interface are used to represent collections of nodes that can be accessed by name. Note
+ * that NamedNodeMap does not inherit from NodeList; NamedNodeMaps are not maintained in any particular order. Objects contained
+ * in an object implementing NamedNodeMap may also be accessed by an ordinal index, but this is simply to allow convenient
+ * enumeration of the contents of a NamedNodeMap, and does not imply that the DOM specifies an order to these Nodes. NamedNodeMap
+ * objects in the DOM are live. used for attributes or DocumentType entities
  *
- * This implementation only supports property indices, but does not support named properties,
- * as specified in the living standard.
+ * This implementation only supports property indices, but does not support named properties, as specified in the living standard.
  *
  * @see https://dom.spec.whatwg.org/#interface-namednodemap
  * @see https://webidl.spec.whatwg.org/#dfn-supported-property-names
@@ -389,11 +383,10 @@ NamedNodeMap.prototype = {
 	item: NodeList.prototype.item,
 
 	/**
-	 * get an attribute by name (lower case in case of HTML namespace and document)
+	 * Get an attribute by name (lower case in case of HTML namespace and document)
 	 *
-	 * @param  {string} localName
-	 * @return {Attr | null}
-	 *
+	 * @param {string} localName
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
 	 */
 	getNamedItem: function (localName) {
@@ -412,10 +405,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * set an attribute
+	 * Set an attribute
 	 *
 	 * @param {Attr} attr
-	 * @return {Attr | null}
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-set
 	 */
 	setNamedItem: function (attr) {
@@ -432,11 +425,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * set an attribute
+	 * Set an attribute
 	 *
 	 * @param {Attr} attr
-	 * @return {Attr | null}
-	 *
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-set
 	 */
 	setNamedItemNS: function (attr) {
@@ -444,11 +436,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * remove an attribute by name (lower case in case of HTML namespace and document)
+	 * Remove an attribute by name (lower case in case of HTML namespace and document)
 	 *
 	 * @param {string} localName
-	 * @return {Attr | null}
-	 *
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditem
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-name
 	 */
@@ -462,12 +453,11 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * remove an attribute by namespace and local name
+	 * Remove an attribute by namespace and local name
 	 *
 	 * @param {string | null} namespaceURI
 	 * @param {string} localName
-	 * @return {Attr | null}
-	 *
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-namespace
 	 */
@@ -481,12 +471,11 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * get an attribute by namespace and local name
+	 * Get an attribute by namespace and local name
 	 *
 	 * @param {string | null} namespaceURI
 	 * @param {string} localName
-	 * @return {Attr | null}
-	 *
+	 * @returns {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
 	 */
 	getNamedItemNS: function (namespaceURI, localName) {
@@ -506,14 +495,12 @@ NamedNodeMap.prototype = {
 };
 
 /**
- * The DOMImplementation interface represents an object providing methods
- * which are not dependent on any particular document.
- * Such an object is returned by the `Document.implementation` property.
+ * The DOMImplementation interface represents an object providing methods which are not dependent on any particular document. Such
+ * an object is returned by the `Document.implementation` property.
  *
- * __The individual methods describe the differences compared to the specs.__
+ * **The individual methods describe the differences compared to the specs.**
  *
- * @constructor
- *
+ * @class
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation MDN
  * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-102161490 DOM Level 1 Core (Initial)
  * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-102161490 DOM Level 2 Core
@@ -524,16 +511,14 @@ function DOMImplementation() {}
 
 DOMImplementation.prototype = {
 	/**
-	 * The DOMImplementation.hasFeature() method returns a Boolean flag indicating if a given feature is supported.
-	 * The different implementations fairly diverged in what kind of features were reported.
-	 * The latest version of the spec settled to force this method to always return true, where the functionality was accurate and in use.
+	 * The DOMImplementation.hasFeature() method returns a Boolean flag indicating if a given feature is supported. The different
+	 * implementations fairly diverged in what kind of features were reported. The latest version of the spec settled to force this
+	 * method to always return true, where the functionality was accurate and in use.
 	 *
 	 * @deprecated It is deprecated and modern browsers return true in all cases.
-	 *
 	 * @param {string} feature
 	 * @param {string} [version]
-	 * @returns {boolean} always true
-	 *
+	 * @returns {boolean} Always true
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
 	 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
@@ -544,20 +529,19 @@ DOMImplementation.prototype = {
 	/**
 	 * Creates an XML Document object of the specified type with its document element.
 	 *
-	 * __It behaves slightly different from the description in the living standard__:
+	 * **It behaves slightly different from the description in the living standard**:
+	 *
 	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string | null} namespaceURI
 	 * @param {string} qualifiedName
-	 * @param {DocumentType | null} [doctype=null]
-	 * @returns {Document} the XML document
-	 *
+	 * @param {DocumentType | null} [doctype=null] Default is `null`
+	 * @returns {Document} The XML document
 	 * @see #createHTMLDocument
-	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM Level 2 Core (initial)
-	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument  DOM Level 2 Core
+	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument DOM Level 2 Core
 	 */
 	createDocument: function (namespaceURI, qualifiedName, doctype) {
 		var contentType = MIME_TYPE.XML_APPLICATION;
@@ -582,21 +566,19 @@ DOMImplementation.prototype = {
 	/**
 	 * Returns a doctype, with the given `qualifiedName`, `publicId`, and `systemId`.
 	 *
-	 * __This behavior is slightly different from the in the specs__:
+	 * **This behavior is slightly different from the in the specs**:
+	 *
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
-	 * - `publicId` and `systemId` contain the raw data including any possible quotes,
-	 *   so they can always be serialized back to the original value
-	 * - `internalSubset` contains the raw string between `[` and `]` if present,
-	 *   but is not parsed or validated in any form
+	 * - `publicId` and `systemId` contain the raw data including any possible quotes, so they can always be serialized back to the
+	 *   original value
+	 * - `internalSubset` contains the raw string between `[` and `]` if present, but is not parsed or validated in any form
 	 *
 	 * @param {string} qualifiedName
 	 * @param {string} [publicId]
 	 * @param {string} [systemId]
 	 * @param {string} [internalSubset] (from DOM Level 2 Core)
-	 * @returns {DocumentType} which can either be used with `DOMImplementation.createDocument`
-	 *                         on document creation or can be put into the document
-	 *                         via methods like `Node.insertBefore()` or `Node.replaceChild()`
-	 *
+	 * @returns {DocumentType} Which can either be used with `DOMImplementation.createDocument` on document creation or can be put
+	 *   into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocType DOM Level 2 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype DOM Living Standard
@@ -617,13 +599,13 @@ DOMImplementation.prototype = {
 	/**
 	 * Returns an HTML document, that might already have a basic DOM structure.
 	 *
-	 * __It behaves slightly different from the description in the living standard__:
+	 * **It behaves slightly different from the description in the living standard**:
+	 *
 	 * - If the first argument is `false` no initial nodes are added (steps 3-7 in the specs are omitted)
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string | false} [title]
 	 * @returns {Document} The HTML document
-	 *
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 	 * @see https://dom.spec.whatwg.org/#html-document
 	 */
@@ -650,9 +632,7 @@ DOMImplementation.prototype = {
 	},
 };
 
-/**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247
- */
+/** @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247 */
 function Node() {}
 
 Node.prototype = {
@@ -715,9 +695,8 @@ Node.prototype = {
 		return this.attributes.length > 0;
 	},
 	/**
-	 * Look up the prefix associated to the given namespace URI, starting from this node.
-	 * **The default namespace declarations are ignored by this method.**
-	 * See Namespace Prefix Lookup for details on the algorithm used by this method.
+	 * Look up the prefix associated to the given namespace URI, starting from this node. **The default namespace declarations are
+	 * ignored by this method.** See Namespace Prefix Lookup for details on the algorithm used by this method.
 	 *
 	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._
 	 *
@@ -766,13 +745,11 @@ Node.prototype = {
 	},
 	// Introduced in DOM Level 3:
 	/**
-	 * Compares the reference node with a node with regard to their position
-	 * in the document and according to the document order.
+	 * Compares the reference node with a node with regard to their position in the document and according to the document order.
 	 *
 	 * @param {Node} other The node to compare the reference node to.
-	 * @return {number} Returns how the node is positioned relatively to the
-	 *    reference node according to the bitmask. 0 if reference node and
-	 *    given node are the same.
+	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if
+	 *   reference node and given node are the same.
 	 * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
 	 */
 	compareDocumentPosition: function (other) {
@@ -834,8 +811,8 @@ copy(DocumentPosition, Node);
 copy(DocumentPosition, Node.prototype);
 
 /**
- * @param callback return true for continue,false for break
- * @return boolean true: break visit;
+ * @param callback Return true for continue,false for break
+ * @returns Boolean true: break visit;
  */
 function _visitNode(node, callback) {
 	if (callback(node)) {
@@ -852,21 +829,19 @@ function _visitNode(node, callback) {
 
 /**
  * @typedef DocumentOptions
- * @property {string} [contentType=MIME_TYPE.XML_APPLICATION]
+ * @property {string} [contentType=MIME_TYPE.XML_APPLICATION] Default is `MIME_TYPE.XML_APPLICATION`
  */
 /**
  * The Document interface describes the common properties and methods for any kind of document.
  *
- * It should usually be created using `new DOMImplementation().createDocument(...)`
- * or `new DOMImplementation().createHTMLDocument(...)`.
+ * It should usually be created using `new DOMImplementation().createDocument(...)` or `new
+ * DOMImplementation().createHTMLDocument(...)`.
  *
- * The constructor is considered a private API and offers to initially set the `contentType` property
- * via it's options parameter.
+ * The constructor is considered a private API and offers to initially set the `contentType` property via it's options parameter.
  *
- * @param {DocumentOptions} [options]
  * @private
- * @constructor
- *
+ * @class
+ * @param {DocumentOptions} [options]
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Document
  * @see https://dom.spec.whatwg.org/#interface-document
  */
@@ -878,17 +853,14 @@ function Document(options) {
 	 *
 	 * @type {string}
 	 * @readonly
-	 *
 	 * @see https://dom.spec.whatwg.org/#concept-document-content-type
 	 * @see DOMImplementation
 	 * @see MIME_TYPE
 	 */
 	this.contentType = opt.contentType || MIME_TYPE.XML_APPLICATION;
 	/**
-	 *
 	 * @type {'html' | 'xml'}
 	 * @readonly
-	 *
 	 * @see https://dom.spec.whatwg.org/#concept-document-type
 	 * @see DOMImplementation
 	 */
@@ -914,16 +886,14 @@ function _onRemoveAttribute(doc, el, newAttr, remove) {
 }
 
 /**
- * Updates `el.childNodes`, updating the indexed items and it's `length`.
- * Passing `newChild` means it will be appended.
- * Otherwise it's assumed that an item has been removed,
- * and `el.firstNode` and it's `.nextSibling` are used
- * to walk the current list of child nodes.
+ * Updates `el.childNodes`, updating the indexed items and it's `length`. Passing `newChild` means it will be appended. Otherwise
+ * it's assumed that an item has been removed, and `el.firstNode` and it's `.nextSibling` are used to walk the current list of
+ * child nodes.
  *
+ * @private
  * @param {Document} doc
  * @param {Node} el
  * @param {Node} [newChild]
- * @private
  */
 function _onUpdateChild(doc, el, newChild) {
 	if (doc && doc._inc) {
@@ -946,16 +916,14 @@ function _onUpdateChild(doc, el, newChild) {
 }
 
 /**
- * Removes the connections between `parentNode` and `child`
- * and any existing `child.previousSibling` or `child.nextSibling`.
+ * Removes the connections between `parentNode` and `child` and any existing `child.previousSibling` or `child.nextSibling`.
  *
- * @see https://github.com/xmldom/xmldom/issues/135
- * @see https://github.com/xmldom/xmldom/issues/145
- *
+ * @private
  * @param {Node} parentNode
  * @param {Node} child
- * @returns {Node} the child that was removed.
- * @private
+ * @returns {Node} The child that was removed.
+ * @see https://github.com/xmldom/xmldom/issues/135
+ * @see https://github.com/xmldom/xmldom/issues/145
  */
 function _removeChild(parentNode, child) {
 	if (parentNode !== child.parentNode) {
@@ -983,6 +951,7 @@ function _removeChild(parentNode, child) {
 
 /**
  * Returns `true` if `node` can be a parent for insertion.
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -995,6 +964,7 @@ function hasValidParentNodeType(node) {
 
 /**
  * Returns `true` if `node` can be inserted according to it's `nodeType`.
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1012,6 +982,7 @@ function hasInsertableNodeType(node) {
 
 /**
  * Returns true if `node` is a DOCTYPE node
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1021,6 +992,7 @@ function isDocTypeNode(node) {
 
 /**
  * Returns true if the node is an element
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1029,6 +1001,7 @@ function isElementNode(node) {
 }
 /**
  * Returns true if `node` is a text node
+ *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1037,14 +1010,13 @@ function isTextNode(node) {
 }
 
 /**
- * Check if en element node can be inserted before `child`, or at the end if child is falsy,
- * according to the presence and position of a doctype node on the same level.
+ * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
+ * position of a doctype node on the same level.
  *
+ * @private https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @param {Document} doc The document node
- * @param {Node} child the node that would become the nextSibling if the element would be inserted
+ * @param {Node} child The node that would become the nextSibling if the element would be inserted
  * @returns {boolean} `true` if an element can be inserted before child
- * @private
- * https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
 function isElementInsertionPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1056,14 +1028,13 @@ function isElementInsertionPossible(doc, child) {
 }
 
 /**
- * Check if en element node can be inserted before `child`, or at the end if child is falsy,
- * according to the presence and position of a doctype node on the same level.
+ * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
+ * position of a doctype node on the same level.
  *
+ * @private https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @param {Node} doc The document node
- * @param {Node} child the node that would become the nextSibling if the element would be inserted
+ * @param {Node} child The node that would become the nextSibling if the element would be inserted
  * @returns {boolean} `true` if an element can be inserted before child
- * @private
- * https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
 function isElementReplacementPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1080,12 +1051,10 @@ function isElementReplacementPossible(doc, child) {
 }
 
 /**
- * @private
- * Steps 1-5 of the checks before inserting and before replacing a child are the same.
- *
- * @param {Node} parent the parent node to insert `node` into
- * @param {Node} node the node to insert
- * @param {Node=} child the node that should become the `nextSibling` of `node`
+ * @private Steps 1-5 of the checks before inserting and before replacing a child are the same.
+ * @param {Node} parent The parent node to insert `node` into
+ * @param {Node} node The node to insert
+ * @param {Node} [child] The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
@@ -1120,12 +1089,10 @@ function assertPreInsertionValidity1to5(parent, node, child) {
 }
 
 /**
- * @private
- * Step 6 of the checks before inserting and before replacing a child are different.
- *
- * @param {Document} parent the parent node to insert `node` into
- * @param {Node} node the node to insert
- * @param {Node | undefined} child the node that should become the `nextSibling` of `node`
+ * @private Step 6 of the checks before inserting and before replacing a child are different.
+ * @param {Document} parent The parent node to insert `node` into
+ * @param {Node} node The node to insert
+ * @param {Node | undefined} child The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
@@ -1176,12 +1143,10 @@ function assertPreInsertionValidityInDocument(parent, node, child) {
 }
 
 /**
- * @private
- * Step 6 of the checks before inserting and before replacing a child are different.
- *
- * @param {Document} parent the parent node to insert `node` into
- * @param {Node} node the node to insert
- * @param {Node | undefined} child the node that should become the `nextSibling` of `node`
+ * @private Step 6 of the checks before inserting and before replacing a child are different.
+ * @param {Document} parent The parent node to insert `node` into
+ * @param {Node} node The node to insert
+ * @param {Node | undefined} child The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
@@ -1231,9 +1196,9 @@ function assertPreReplacementValidityInDocument(parent, node, child) {
 
 /**
  * @private
- * @param {Node} parent the parent node to insert `node` into
- * @param {Node} node the node to insert
- * @param {Node=} child the node that should become the `nextSibling` of `node`
+ * @param {Node} parent The parent node to insert `node` into
+ * @param {Node} node The node to insert
+ * @param {Node} [child] The node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
@@ -1289,15 +1254,14 @@ function _insertBefore(parent, node, child, _inDocumentAssertion) {
 }
 
 /**
- * Appends `newChild` to `parentNode`.
- * If `newChild` is already connected to a `parentNode` it is first removed from it.
+ * Appends `newChild` to `parentNode`. If `newChild` is already connected to a `parentNode` it is first removed from it.
  *
- * @see https://github.com/xmldom/xmldom/issues/135
- * @see https://github.com/xmldom/xmldom/issues/145
+ * @private
  * @param {Node} parentNode
  * @param {Node} newChild
  * @returns {Node}
- * @private
+ * @see https://github.com/xmldom/xmldom/issues/135
+ * @see https://github.com/xmldom/xmldom/issues/145
  */
 function _appendSingleChild(parentNode, newChild) {
 	if (newChild.parentNode) {
@@ -1319,8 +1283,9 @@ function _appendSingleChild(parentNode, newChild) {
 Document.prototype = {
 	/**
 	 * The implementation that created this document
-	 * @readonly
+	 *
 	 * @type DOMImplementation
+	 * @readonly
 	 */
 	implementation: null,
 	nodeName: '#document',
@@ -1328,8 +1293,8 @@ Document.prototype = {
 	/**
 	 * The DocumentType node of the document.
 	 *
-	 * @readonly
 	 * @type DocumentType
+	 * @readonly
 	 */
 	doctype: null,
 	documentElement: null,
@@ -1391,19 +1356,17 @@ Document.prototype = {
 	},
 
 	/**
-	 * The `getElementsByClassName` method of `Document` interface returns an array-like object
-	 * of all child elements which have **all** of the given class name(s).
+	 * The `getElementsByClassName` method of `Document` interface returns an array-like object of all child elements which have
+	 * **all** of the given class name(s).
 	 *
 	 * Returns an empty list if `classeNames` is an empty string or only contains HTML white space characters.
 	 *
+	 * Warning: This is a live LiveNodeList. Changes in the DOM will reflect in the array as the changes occur. If an element
+	 * selected by this array no longer qualifies for the selector, it will automatically be removed. Be aware of this for iteration
+	 * purposes.
 	 *
-	 * Warning: This is a live LiveNodeList.
-	 * Changes in the DOM will reflect in the array as the changes occur.
-	 * If an element selected by this array no longer qualifies for the selector,
-	 * it will automatically be removed. Be aware of this for iteration purposes.
-	 *
-	 * @param {string} classNames is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace
-	 *
+	 * @param {string} classNames Is a string representing the class name(s) to match; multiple class names are separated by
+	 *   (ASCII-)whitespace
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */
@@ -1435,20 +1398,18 @@ Document.prototype = {
 	},
 
 	/**
-	 * Creates a new `Element` that is owned by this `Document`.
-	 * In HTML Documents `localName` is the lower cased `tagName`,
-	 * otherwise no transformation is being applied.
-	 * When `contentType` implies the HTML namespace, it will be set as `namespaceURI`.
+	 * Creates a new `Element` that is owned by this `Document`. In HTML Documents `localName` is the lower cased `tagName`,
+	 * otherwise no transformation is being applied. When `contentType` implies the HTML namespace, it will be set as
+	 * `namespaceURI`.
 	 *
-	 * __This implementation differs from the specification:__
-	 * - The provided name is not checked against the `Name` production,
-	 *   so no related error will be thrown.
+	 * **This implementation differs from the specification:**
+	 *
+	 * - The provided name is not checked against the `Name` production, so no related error will be thrown.
 	 * - There is no interface `HTMLElement`, it is always an `Element`.
 	 * - There is no support for a second argument to indicate using custom elements.
 	 *
 	 * @param {string} tagName
-	 * @return {Element}
-	 *
+	 * @returns {Element}
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement
 	 * @see https://dom.spec.whatwg.org/#dom-document-createelement
 	 * @see https://dom.spec.whatwg.org/#concept-create-element
@@ -1502,17 +1463,15 @@ Document.prototype = {
 		return node;
 	},
 	/**
-	 * Creates an `Attr` node that is owned by this document.
-	 * In HTML Documents `localName` is the lower cased `name`,
-	 * otherwise no transformation is being applied.
+	 * Creates an `Attr` node that is owned by this document. In HTML Documents `localName` is the lower cased `name`, otherwise no
+	 * transformation is being applied.
 	 *
-	 * __This implementation differs from the specification:__
-	 * - The provided name is not checked against the `Name` production,
-	 *   so no related error will be thrown.
+	 * **This implementation differs from the specification:**
+	 *
+	 * - The provided name is not checked against the `Name` production, so no related error will be thrown.
 	 *
 	 * @param {string} name
-	 * @return {Attr}
-	 *
+	 * @returns {Attr}
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createAttribute
 	 * @see https://dom.spec.whatwg.org/#dom-document-createattribute
 	 */
@@ -1590,7 +1549,7 @@ Element.prototype = {
 	 * Returns element’s first attribute whose qualified name is `name`, and `null` if there is no such attribute.
 	 *
 	 * @param {string} name
-	 * @return {string | null}
+	 * @returns {string | null}
 	 */
 	getAttribute: function (name) {
 		var attr = this.getAttributeNode(name);
@@ -1654,12 +1613,12 @@ Element.prototype = {
 		return this.getAttributeNodeNS(namespaceURI, localName) != null;
 	},
 	/**
-	 * Returns element’s attribute whose namespace is `namespaceURI` and local name is `localName`,
-	 * or `null` if there is no such attribute.
+	 * Returns element’s attribute whose namespace is `namespaceURI` and local name is `localName`, or `null` if there is no such
+	 * attribute.
 	 *
 	 * @param {string} namespaceURI
 	 * @param {string} localName
-	 * @return {string | null}
+	 * @returns {string | null}
 	 */
 	getAttributeNS: function (namespaceURI, localName) {
 		var attr = this.getAttributeNodeNS(namespaceURI, localName);
@@ -1671,7 +1630,6 @@ Element.prototype = {
 	 * @param {string} namespaceURI
 	 * @param {string} qualifiedName
 	 * @param {string} value
-	 *
 	 * @see https://dom.spec.whatwg.org/#dom-element-setattributens
 	 */
 	setAttributeNS: function (namespaceURI, qualifiedName, value) {
@@ -1691,27 +1649,22 @@ Element.prototype = {
 	},
 
 	/**
-	 * Returns a LiveNodeList of elements with the given qualifiedName.
-	 * Searching for all descendants can be done by passing `*` as `qualifiedName`.
+	 * Returns a LiveNodeList of elements with the given qualifiedName. Searching for all descendants can be done by passing `*` as
+	 * `qualifiedName`.
 	 *
-	 * All descendants of the specified element are searched, but not the element itself.
-	 * The returned list is live, which means it updates itself with the DOM tree automatically.
-	 * Therefore, there is no need to call `Element.getElementsByTagName()`
-	 * with the same element and arguments repeatedly if the DOM changes in between calls.
+	 * All descendants of the specified element are searched, but not the element itself. The returned list is live, which means it
+	 * updates itself with the DOM tree automatically. Therefore, there is no need to call `Element.getElementsByTagName()` with the
+	 * same element and arguments repeatedly if the DOM changes in between calls.
 	 *
-	 * When called on an HTML element in an HTML document,
-	 * `getElementsByTagName` lower-cases the argument before searching for it.
-	 * This is undesirable when trying to match camel-cased SVG elements
-	 * (such as `<linearGradient>`) in an HTML document.
-	 * Instead, use `Element.getElementsByTagNameNS()`,
-	 * which preserves the capitalization of the tag name.
+	 * When called on an HTML element in an HTML document, `getElementsByTagName` lower-cases the argument before searching for it.
+	 * This is undesirable when trying to match camel-cased SVG elements (such as `<linearGradient>`) in an HTML document. Instead,
+	 * use `Element.getElementsByTagNameNS()`, which preserves the capitalization of the tag name.
 	 *
-	 * `Element.getElementsByTagName` is similar to `Document.getElementsByTagName()`,
-	 * except that it only searches for elements that are descendants of the specified element.
+	 * `Element.getElementsByTagName` is similar to `Document.getElementsByTagName()`, except that it only searches for elements
+	 * that are descendants of the specified element.
 	 *
 	 * @param {string} qualifiedName
-	 * @return {LiveNodeList}
-	 *
+	 * @returns {LiveNodeList}
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByTagName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbytagname
 	 */
@@ -1903,13 +1856,11 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
 	return true;
 }
 /**
- * Well-formed constraint: No < in Attribute Values
- * > The replacement text of any entity referred to directly or indirectly
- * > in an attribute value must not contain a <.
- * @see https://www.w3.org/TR/xml11/#CleanAttrVals
- * @see https://www.w3.org/TR/xml11/#NT-AttValue
+ * Well-formed constraint: No < in Attribute Values> The replacement text of any entity referred to directly or indirectly in an
+ * attribute value must not contain a <.
  *
- * Literal whitespace other than space that appear in attribute values
+ * @see https://www.w3.org/TR/xml11/#CleanAttrVals
+ * @see https://www.w3.org/TR/xml11/#NT-AttValue Literal whitespace other than space that appear in attribute values
  * are serialized as their entity references, so they will be preserved.
  * (In contrast to whitespace literals in the input which are normalized to spaces)
  * @see https://www.w3.org/TR/xml11/#AVNormalize
@@ -2055,17 +2006,15 @@ function serializeToString(node, buf, nodeFilter, visibleNamespaces) {
 			return addSerializedAttribute(buf, node.name, node.value);
 		case TEXT_NODE:
 			/**
-			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,
-			 * except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section.
-			 * If they are needed elsewhere, they must be escaped using either numeric character references or the strings
-			 * `&amp;` and `&lt;` respectively.
-			 * The right angle bracket (>) may be represented using the string " &gt; ", and must, for compatibility,
-			 * be escaped using either `&gt;` or a character reference when it appears in the string `]]>` in content,
-			 * when that string is not marking the end of a CDATA section.
+			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form, except when used as
+			 * markup delimiters, or within a comment, a processing instruction, or a CDATA section. If they are needed elsewhere, they
+			 * must be escaped using either numeric character references or the strings `&amp;` and `&lt;` respectively. The right angle
+			 * bracket (>) may be represented using the string " > ", and must, for compatibility, be escaped using either `&gt;` or a
+			 * character reference when it appears in the string `]]>` in content, when that string is not marking the end of a CDATA
+			 * section.
 			 *
-			 * In the content of elements, character data is any string of characters
-			 * which does not contain the start-delimiter of any markup
-			 * and does not include the CDATA-section-close delimiter, `]]>`.
+			 * In the content of elements, character data is any string of characters which does not contain the start-delimiter of any
+			 * markup and does not include the CDATA-section-close delimiter, `]]>`.
 			 *
 			 * @see https://www.w3.org/TR/xml/#NT-CharData
 			 * @see https://w3c.github.io/DOM-Parsing/#xml-serializing-a-text-node

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -531,14 +531,14 @@ DOMImplementation.prototype = {
 	 * The latest version of the spec settled to force this method to always return true, where the functionality was accurate and in
 	 * use.
 	 *
+	 * @deprecated
+	 * It is deprecated and modern browsers return true in all cases.
 	 * @param {string} feature
 	 * @param {string} [version]
 	 * @returns {boolean} Always true.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
 	 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
-	 * @deprecated
-	 * It is deprecated and modern browsers return true in all cases.
 	 */
 	hasFeature: function (feature, version) {
 		return true;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -294,7 +294,7 @@ NodeList.prototype = {
 	/**
 	 * @param {function (Node):boolean} predicate
 	 * @returns {Node[]}
-	 * @access private
+	 * @private
 	 */
 	filter: function (predicate) {
 		return Array.prototype.filter.call(this, predicate);
@@ -302,7 +302,7 @@ NodeList.prototype = {
 	/**
 	 * @param {Node} item
 	 * @returns {number}
-	 * @access private
+	 * @private
 	 */
 	indexOf: function (item) {
 		return Array.prototype.indexOf.call(this, item);
@@ -863,7 +863,7 @@ function _visitNode(node, callback) {
  *
  * @class
  * @param {DocumentOptions} [options]
- * @access private
+ * @private
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Document
  * @see https://dom.spec.whatwg.org/#interface-document
  */
@@ -916,7 +916,7 @@ function _onRemoveAttribute(doc, el, newAttr, remove) {
  * @param {Document} doc
  * @param {Node} el
  * @param {Node} [newChild]
- * @access private
+ * @private
  */
 function _onUpdateChild(doc, el, newChild) {
 	if (doc && doc._inc) {
@@ -945,7 +945,7 @@ function _onUpdateChild(doc, el, newChild) {
  * @param {Node} parentNode
  * @param {Node} child
  * @returns {Node} The child that was removed.
- * @access private
+ * @private
  * @see https://github.com/xmldom/xmldom/issues/135
  * @see https://github.com/xmldom/xmldom/issues/145
  */
@@ -1042,7 +1042,7 @@ function isTextNode(node) {
  * @param {Node} child
  * The node that would become the nextSibling if the element would be inserted.
  * @returns {boolean} `true` if an element can be inserted before child.
- * @access private
+ * @private
  */
 function isElementInsertionPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1062,7 +1062,7 @@ function isElementInsertionPossible(doc, child) {
  * @param {Node} child
  * The node that would become the nextSibling if the element would be inserted.
  * @returns {boolean} `true` if an element can be inserted before child.
- * @access private
+ * @private
  */
 function isElementReplacementPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1090,7 +1090,7 @@ function isElementReplacementPossible(doc, child) {
  * DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws
  * DOMException if `child` is provided but is not a child of `parent`.
- * @access private
+ * @private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1133,7 +1133,7 @@ function assertPreInsertionValidity1to5(parent, node, child) {
  * DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws
  * DOMException if `child` is provided but is not a child of `parent`.
- * @access private
+ * @private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1192,7 +1192,7 @@ function assertPreInsertionValidityInDocument(parent, node, child) {
  * DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws
  * DOMException if `child` is provided but is not a child of `parent`.
- * @access private
+ * @private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
  */
@@ -1249,7 +1249,7 @@ function assertPreReplacementValidityInDocument(parent, node, child) {
  * DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws
  * DOMException if `child` is provided but is not a child of `parent`.
- * @access private
+ * @private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
 function _insertBefore(parent, node, child, _inDocumentAssertion) {
@@ -1308,7 +1308,7 @@ function _insertBefore(parent, node, child, _inDocumentAssertion) {
  * @param {Node} parentNode
  * @param {Node} newChild
  * @returns {Node}
- * @access private
+ * @private
  * @see https://github.com/xmldom/xmldom/issues/135
  * @see https://github.com/xmldom/xmldom/issues/145
  */

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -225,7 +225,8 @@ function commonAncestor(a, b) {
 }
 
 /**
- * Comparing unrelated nodes must be consistent, so we assign a guid to the compared docs for further reference.
+ * Comparing unrelated nodes must be consistent, so we assign a guid to the compared docs for
+ * further reference.
  *
  * @param {Document} doc
  * The document.
@@ -260,26 +261,29 @@ DOMException.prototype = Error.prototype;
 copy(ExceptionCode, DOMException);
 
 /**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The NodeList interface provides the
- *      abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented.
+ * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The
+ *      NodeList interface provides the abstraction of an ordered collection of nodes,
+ *      without defining or constraining how this collection is implemented.
  *      NodeList objects in the DOM are live.
  *      The items in the NodeList are accessible via an integral index, starting from 0.
  */
 function NodeList() {}
 NodeList.prototype = {
 	/**
-	 * The number of nodes in the list. The range of valid child node indices is 0 to length-1 inclusive.
+	 * The number of nodes in the list. The range of valid child node indices is 0 to length-1
+	 * inclusive.
 	 *
 	 * @standard level1
 	 */
 	length: 0,
 	/**
-	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns
-	 * null.
+	 * Returns the indexth item in the collection. If index is greater than or equal to the number
+	 * of nodes in the list, this returns null.
 	 *
 	 * @param index
 	 * Unsigned long Index into the collection.
-	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a valid index.
+	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a
+	 *          valid index.
 	 * @standard level1
 	 */
 	item: function (index) {
@@ -332,10 +336,12 @@ LiveNodeList.prototype.item = function (i) {
 _extends(LiveNodeList, NodeList);
 
 /**
- * Objects implementing the NamedNodeMap interface are used to represent collections of nodes that can be accessed by name.
+ * Objects implementing the NamedNodeMap interface are used to represent collections of nodes
+ * that can be accessed by name.
  * Note that NamedNodeMap does not inherit from NodeList;
  * NamedNodeMaps are not maintained in any particular order.
- * Objects contained in an object implementing NamedNodeMap may also be accessed by an ordinal index,
+ * Objects contained in an object implementing NamedNodeMap may also be accessed by an ordinal
+ * index,
  * but this is simply to allow convenient enumeration of the contents of a NamedNodeMap,
  * and does not imply that the DOM specifies an order to these Nodes.
  * NamedNodeMap objects in the DOM are live.
@@ -510,14 +516,16 @@ NamedNodeMap.prototype = {
 };
 
 /**
- * The DOMImplementation interface represents an object providing methods which are not dependent on any particular document.
+ * The DOMImplementation interface represents an object providing methods which are not
+ * dependent on any particular document.
  * Such an object is returned by the `Document.implementation` property.
  *
- * __The individual methods describe the differences compared to the specs.__.
+ * **The individual methods describe the differences compared to the specs**.
  *
  * @class
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation MDN
- * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-102161490 DOM Level 1 Core (Initial)
+ * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-102161490 DOM Level 1 Core
+ *      (Initial)
  * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-102161490 DOM Level 2 Core
  * @see https://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-102161490 DOM Level 3 Core
  * @see https://dom.spec.whatwg.org/#domimplementation DOM Living Standard
@@ -526,10 +534,11 @@ function DOMImplementation() {}
 
 DOMImplementation.prototype = {
 	/**
-	 * The DOMImplementation.hasFeature() method returns a Boolean flag indicating if a given feature is supported.
+	 * The DOMImplementation.hasFeature() method returns a Boolean flag indicating if a given
+	 * feature is supported.
 	 * The different implementations fairly diverged in what kind of features were reported.
-	 * The latest version of the spec settled to force this method to always return true, where the functionality was accurate and in
-	 * use.
+	 * The latest version of the spec settled to force this method to always return true,
+	 * where the functionality was accurate and in use.
 	 *
 	 * @deprecated
 	 * It is deprecated and modern browsers return true in all cases.
@@ -547,16 +556,18 @@ DOMImplementation.prototype = {
 	 * Creates an XML Document object of the specified type with its document element.
 	 *
 	 * __It behaves slightly different from the description in the living standard__:
-	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
+	 * - There is no interface/class `XMLDocument`, it returns a `Document`
+	 * instance (with it's `type` set to `'xml'`).
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string | null} namespaceURI
 	 * @param {string} qualifiedName
 	 * @param {DocumentType | null} [doctype=null]
 	 * @returns {Document} The XML document.
-	 * @see #createHTMLDocument.
+	 * @see {@link #createHTMLDocument}
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
-	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM Level 2 Core (initial)
+	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM
+	 *      Level 2 Core (initial)
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument DOM Level 2 Core
 	 */
 	createDocument: function (namespaceURI, qualifiedName, doctype) {
@@ -585,8 +596,8 @@ DOMImplementation.prototype = {
 	 * __This behavior is slightly different from the in the specs__:
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 * - `publicId` and `systemId` contain the raw data including any possible quotes,
-	 * so they can always be serialized back to the original value - `internalSubset` contains the raw string between `[` and `]` if
-	 * present,
+	 * so they can always be serialized back to the original value -
+	 * `internalSubset` contains the raw string between `[` and `]` if present,
 	 * but is not parsed or validated in any form.
 	 *
 	 * @param {string} qualifiedName
@@ -595,11 +606,14 @@ DOMImplementation.prototype = {
 	 * @param {string} [internalSubset]
 	 * (from DOM Level 2 Core)
 	 * @returns {DocumentType} which can either be used with `DOMImplementation.createDocument`
-	 *                         on document creation or can be put into the document via methods like `Node.insertBefore()` or
-	 *                         `Node.replaceChild()`
-	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType MDN
-	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocType DOM Level 2 Core
-	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype DOM Living Standard
+	 *                         on document creation or can be put into the document via methods
+	 *                         like `Node.insertBefore()` or `Node.replaceChild()`
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType
+	 *      MDN
+	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocType DOM
+	 *      Level 2 Core
+	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype DOM Living
+	 *      Standard
 	 * @see https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md#050
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/#core-ID-Core-DocType-internalSubset
 	 */
@@ -618,11 +632,13 @@ DOMImplementation.prototype = {
 	 * Returns an HTML document, that might already have a basic DOM structure.
 	 *
 	 * __It behaves slightly different from the description in the living standard__:
-	 * - If the first argument is `false` no initial nodes are added (steps 3-7 in the specs are omitted)
+	 * - If the first argument is `false` no initial nodes are added (steps 3-7 in the specs are
+	 * omitted)
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string | false} [title]
 	 * @returns {Document} The HTML document.
+	 * @see {@link #createDocument}
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 	 * @see https://dom.spec.whatwg.org/#html-document
 	 */
@@ -718,7 +734,8 @@ Node.prototype = {
 	 * **The default namespace declarations are ignored by this method.**
 	 * See Namespace Prefix Lookup for details on the algorithm used by this method.
 	 *
-	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._.
+	 * _Note: The implementation seems to be incomplete when compared to the algorithm described
+	 * in the specs._.
 	 *
 	 * @param {string | null} namespaceURI
 	 * @returns {string | null}
@@ -765,12 +782,14 @@ Node.prototype = {
 	},
 	// Introduced in DOM Level 3:
 	/**
-	 * Compares the reference node with a node with regard to their position in the document and according to the document order.
+	 * Compares the reference node with a node with regard to their position in the document and
+	 * according to the document order.
 	 *
 	 * @param {Node} other
 	 * The node to compare the reference node to.
-	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if reference
-	 *                   node and given node are the same.
+	 * @returns {number} Returns how the node is positioned relatively to the reference node
+	 *                   according to the bitmask. 0 if reference node and given node are the
+	 *                   same.
 	 * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
 	 */
 	compareDocumentPosition: function (other) {
@@ -859,7 +878,8 @@ function _visitNode(node, callback) {
  * It should usually be created using `new DOMImplementation().createDocument(...)`
  * or `new DOMImplementation().createHTMLDocument(...)`.
  *
- * The constructor is considered a private API and offers to initially set the `contentType` property via it's options parameter.
+ * The constructor is considered a private API and offers to initially set the `contentType`
+ * property via it's options parameter.
  *
  * @class
  * @param {DocumentOptions} [options]
@@ -875,15 +895,15 @@ function Document(options) {
 	 *
 	 * @type {string}
 	 * @see https://dom.spec.whatwg.org/#concept-document-content-type
-	 * @see DOMImplementation.
-	 * @see MIME_TYPE.
+	 * @see {@link DOMImplementation}
+	 * @see {@link MIME_TYPE}
 	 * @readonly
 	 */
 	this.contentType = opt.contentType || MIME_TYPE.XML_APPLICATION;
 	/**
 	 * @type {'html' | 'xml'}
 	 * @see https://dom.spec.whatwg.org/#concept-document-type
-	 * @see DOMImplementation.
+	 * @see {@link DOMImplementation}
 	 * @readonly
 	 */
 	this.type = isHTMLMimeType(this.contentType) ? 'html' : 'xml';
@@ -1405,10 +1425,11 @@ Document.prototype = {
 	},
 
 	/**
-	 * The `getElementsByClassName` method of `Document` interface returns an array-like object of all child elements which have
-	 * **all** of the given class name(s).
+	 * The `getElementsByClassName` method of `Document` interface returns an array-like object of
+	 * all child elements which have **all** of the given class name(s).
 	 *
-	 * Returns an empty list if `classeNames` is an empty string or only contains HTML white space characters.
+	 * Returns an empty list if `classeNames` is an empty string or only contains HTML white space
+	 * characters.
 	 *
 	 * Warning: This is a live LiveNodeList.
 	 * Changes in the DOM will reflect in the array as the changes occur.
@@ -1416,7 +1437,8 @@ Document.prototype = {
 	 * it will automatically be removed. Be aware of this for iteration purposes.
 	 *
 	 * @param {string} classNames
-	 * Is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace.
+	 * Is a string representing the class name(s) to match; multiple class names are separated by
+	 * (ASCII-)whitespace.
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */
@@ -1453,7 +1475,8 @@ Document.prototype = {
 	 * otherwise no transformation is being applied.
 	 * When `contentType` implies the HTML namespace, it will be set as `namespaceURI`.
 	 *
-	 * __This implementation differs from the specification:__ - The provided name is not checked against the `Name` production,
+	 * __This implementation differs from the specification:__ - The provided name is not checked
+	 * against the `Name` production,
 	 * so no related error will be thrown.
 	 * - There is no interface `HTMLElement`, it is always an `Element`.
 	 * - There is no support for a second argument to indicate using custom elements.
@@ -1517,7 +1540,8 @@ Document.prototype = {
 	 * In HTML Documents `localName` is the lower cased `name`,
 	 * otherwise no transformation is being applied.
 	 *
-	 * __This implementation differs from the specification:__ - The provided name is not checked against the `Name` production,
+	 * __This implementation differs from the specification:__ - The provided name is not checked
+	 * against the `Name` production,
 	 * so no related error will be thrown.
 	 *
 	 * @param {string} name
@@ -1596,7 +1620,8 @@ Element.prototype = {
 		return !!this.getAttributeNode(name);
 	},
 	/**
-	 * Returns element’s first attribute whose qualified name is `name`, and `null` if there is no such attribute.
+	 * Returns element’s first attribute whose qualified name is `name`, and `null`
+	 * if there is no such attribute.
 	 *
 	 * @param {string} name
 	 * @returns {string | null}
@@ -1663,7 +1688,8 @@ Element.prototype = {
 		return this.getAttributeNodeNS(namespaceURI, localName) != null;
 	},
 	/**
-	 * Returns element’s attribute whose namespace is `namespaceURI` and local name is `localName`,
+	 * Returns element’s attribute whose namespace is `namespaceURI` and local name is
+	 * `localName`,
 	 * or `null` if there is no such attribute.
 	 *
 	 * @param {string} namespaceURI
@@ -1675,7 +1701,8 @@ Element.prototype = {
 		return attr ? attr.value : null;
 	},
 	/**
-	 * Sets the value of element’s attribute whose namespace is `namespaceURI` and local name is `localName` to value.
+	 * Sets the value of element’s attribute whose namespace is `namespaceURI` and local name is
+	 * `localName` to value.
 	 *
 	 * @param {string} namespaceURI
 	 * @param {string} qualifiedName
@@ -1709,7 +1736,9 @@ Element.prototype = {
 	 *
 	 * When called on an HTML element in an HTML document,
 	 * `getElementsByTagName` lower-cases the argument before searching for it.
-	 * This is undesirable when trying to match camel-cased SVG elements (such as `<linearGradient>`) in an HTML document.
+	 * This is undesirable when trying to match camel-cased SVG elements (such as
+	 * `<linearGradient>`)
+	 * in an HTML document.
 	 * Instead, use `Element.getElementsByTagNameNS()`,
 	 * which preserves the capitalization of the tag name.
 	 *
@@ -1909,14 +1938,14 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
 	return true;
 }
 /**
- * Well-formed constraint: No < in Attribute Values > The replacement text of any entity referred to directly or indirectly > in
- * an attribute value must not contain a <.
+ * Well-formed constraint: No < in Attribute Values > The replacement text of any entity
+ * referred to directly or indirectly > in an attribute value must not contain a <.
  *
  * @see https://www.w3.org/TR/xml11/#CleanAttrVals
  * @see https://www.w3.org/TR/xml11/#NT-AttValue
  *
- *      Literal whitespace other than space that appear in attribute values are serialized as their entity references, so they
- *      will be preserved.
+ *      Literal whitespace other than space that appear in attribute values are serialized as
+ *      their entity references, so they will be preserved.
  *      (In contrast to whitespace literals in the input which are normalized to spaces)
  * @see https://www.w3.org/TR/xml11/#AVNormalize
  * @see https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes
@@ -2061,16 +2090,22 @@ function serializeToString(node, buf, nodeFilter, visibleNamespaces) {
 			return addSerializedAttribute(buf, node.name, node.value);
 		case TEXT_NODE:
 			/**
-			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,
-			 * except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section.
-			 * If they are needed elsewhere, they must be escaped using either numeric character references or the strings `&amp;` and
-			 * `&lt;` respectively.
-			 * The right angle bracket (>) may be represented using the string " &gt; ", and must, for compatibility,
-			 * be escaped using either `&gt;` or a character reference when it appears in the string `]]>` in content,
+			 * The ampersand character (&) and the left angle bracket (<) must not appear in their
+			 * literal form,
+			 * except when used as markup delimiters, or within a comment, a processing instruction, or
+			 * a CDATA section.
+			 * If they are needed elsewhere, they must be escaped using either numeric character
+			 * references or the strings `&amp;` and `&lt;` respectively.
+			 * The right angle bracket (>) may be represented using the string " &gt; ",
+			 * and must, for compatibility,
+			 * be escaped using either `&gt;` or a character reference when it appears in the string
+			 * `]]>` in content,
 			 * when that string is not marking the end of a CDATA section.
 			 *
-			 * In the content of elements, character data is any string of characters which does not contain the start-delimiter of any
-			 * markup and does not include the CDATA-section-close delimiter, `]]>`.
+			 * In the content of elements, character data is any string of characters which does not
+			 * contain the start-delimiter of any markup and does not include the CDATA-section-close
+			 * delimiter,
+			 * `]]>`.
 			 *
 			 * @see https://www.w3.org/TR/xml/#NT-CharData
 			 * @see https://w3c.github.io/DOM-Parsing/#xml-serializing-a-text-node

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -70,8 +70,7 @@ function arrayIncludes(list) {
 
 /**
  * @param {string} qualifiedName
- * @throws
- * DOMException.
+ * @throws {DOMException}
  * @see https://dom.spec.whatwg.org/#validate
  */
 function validateQualifiedName(qualifiedName) {
@@ -1106,10 +1105,10 @@ function isElementReplacementPossible(doc, child) {
  * @param {Node=} child
  * the node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws
- * DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws
- * DOMException if `child` is provided but is not a child of `parent`.
+ * @throws {DOMException}
+ * For several node combinations that would create a DOM that is not well-formed.
+ * @throws {DOMException}
+ * If `child` is provided but is not a child of `parent`.
  * @private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
@@ -1149,10 +1148,10 @@ function assertPreInsertionValidity1to5(parent, node, child) {
  * @param {Node | undefined} child
  * the node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws
- * DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws
- * DOMException if `child` is provided but is not a child of `parent`.
+ * @throws {DOMException}
+ * For several node combinations that would create a DOM that is not well-formed.
+ * @throws {DOMException}
+ * If `child` is provided but is not a child of `parent`.
  * @private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
@@ -1208,10 +1207,10 @@ function assertPreInsertionValidityInDocument(parent, node, child) {
  * @param {Node | undefined} child
  * the node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws
- * DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws
- * DOMException if `child` is provided but is not a child of `parent`.
+ * @throws {DOMException}
+ * For several node combinations that would create a DOM that is not well-formed.
+ * @throws {DOMException}
+ * If `child` is provided but is not a child of `parent`.
  * @private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @see https://dom.spec.whatwg.org/#concept-node-replace
@@ -1265,10 +1264,10 @@ function assertPreReplacementValidityInDocument(parent, node, child) {
  * @param {Node=} child
  * the node that should become the `nextSibling` of `node`
  * @returns {Node}
- * @throws
- * DOMException for several node combinations that would create a DOM that is not well-formed.
- * @throws
- * DOMException if `child` is provided but is not a child of `parent`.
+ * @throws {DOMException}
+ * For several node combinations that would create a DOM that is not well-formed.
+ * @throws {DOMException}
+ * If `child` is provided but is not a child of `parent`.
  * @private
  * @see https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -12,7 +12,6 @@ var g = require('./grammar');
 
 /**
  * A prerequisite for `[].filter`, to drop elements that are empty
- *
  * @param {string} input
  * @returns {boolean}
  */
@@ -20,10 +19,11 @@ function notEmptyString(input) {
 	return input !== '';
 }
 /**
- * @param {string} input
- * @returns {string[]} (can be empty)
  * @see https://infra.spec.whatwg.org/#split-on-ascii-whitespace
  * @see https://infra.spec.whatwg.org/#ascii-whitespace
+ *
+ * @param {string} input
+ * @returns {string[]} (can be empty)
  */
 function splitOnASCIIWhitespace(input) {
 	// U+0009 TAB, U+000A LF, U+000C FF, U+000D CR, U+0020 SPACE
@@ -45,9 +45,9 @@ function orderedSetReducer(current, element) {
 }
 
 /**
+ * @see https://infra.spec.whatwg.org/#ordered-set
  * @param {string} input
  * @returns {string[]}
- * @see https://infra.spec.whatwg.org/#ordered-set
  */
 function toOrderedSet(input) {
 	if (!input) return [];
@@ -56,7 +56,8 @@ function toOrderedSet(input) {
 }
 
 /**
- * Uses `list.indexOf` to implement something like `Array.prototype.includes`, which we can not rely on being available.
+ * Uses `list.indexOf` to implement something like `Array.prototype.includes`,
+ * which we can not rely on being available.
  *
  * @param {any[]} list
  * @returns {function(any): boolean}
@@ -79,9 +80,11 @@ function validateQualifiedName(qualifiedName) {
 }
 
 /**
+ *
  * @param {string | null} namespace
  * @param {string} qualifiedName
- * @returns {[namespace: string | null, prefix: string | null, localName: string]}
+ *
+ * @returns {[namespace:string|null, prefix:string|null, localName:string]}
  * @see https://dom.spec.whatwg.org/#validate-and-extract
  */
 function validateAndExtract(namespace, qualifiedName) {
@@ -119,8 +122,8 @@ function copy(src, dest) {
 }
 
 /**
- * ^\w+.prototype.([_\w]+)\s*=\s*((?:._{\s_?[\r\n][\s\S]_?^})|\S._?(?=[;\r\n]));?
- * ^\w+.prototype.([_\w]+)\s*=\s*(\S.*?(?=[;\r\n]));?
+^\w+\.prototype\.([_\w]+)\s*=\s*((?:.*\{\s*?[\r\n][\s\S]*?^})|\S.*?(?=[;\r\n]));?
+^\w+\.prototype\.([_\w]+)\s*=\s*(\S.*?(?=[;\r\n]));?
  */
 function _extends(Class, Super) {
 	var pt = Class.prototype;
@@ -187,9 +190,8 @@ var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = (DocumentPosition.DOCUMENT_POSIT
 //helper functions for compareDocumentPosition
 /**
  * Construct a parent chain for a node.
- *
  * @param {Node} node The start node.
- * @returns {Node[]} The parent chain.
+ * @return {Node[]} The parent chain.
  */
 function parentChain(node) {
 	var chain = [];
@@ -202,10 +204,9 @@ function parentChain(node) {
 
 /**
  * Find the common ancestor in two parent chains.
- *
  * @param {Node[]} a A parent chain.
  * @param {Node[]} b A parent chain.
- * @returns {Node} The common ancestor if it exists.
+ * @return {Node} The common ancestor if it exists.
  */
 function commonAncestor(a, b) {
 	if (b.length < a.length) return commonAncestor(b, a);
@@ -218,10 +219,10 @@ function commonAncestor(a, b) {
 }
 
 /**
- * Comparing unrelated nodes must be consistent, so we assign a guid to the compared docs for further reference.
- *
+ * Comparing unrelated nodes must be consistent, so we assign a guid to the
+ * compared docs for further reference.
  * @param {Document} doc The document.
- * @returns {string} The document's guid.
+ * @return {string} The document's guid.
  */
 function docGUID(doc) {
 	if (!doc.guid) doc.guid = Math.random();
@@ -230,8 +231,8 @@ function docGUID(doc) {
 //-- end of helper functions
 
 /**
- * DOM Level 2 Object DOMException
- *
+ * DOM Level 2
+ * Object DOMException
  * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/ecma-script-binding.html
  * @see http://www.w3.org/TR/REC-DOM-Level-1/ecma-script-language-binding.html
  */
@@ -252,24 +253,24 @@ DOMException.prototype = Error.prototype;
 copy(ExceptionCode, DOMException);
 
 /**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The NodeList interface provides the abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented. NodeList objects in the DOM are live.
+ * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177
+ * The NodeList interface provides the abstraction of an ordered collection of nodes, without defining or constraining how this collection is implemented. NodeList objects in the DOM are live.
  * The items in the NodeList are accessible via an integral index, starting from 0.
  */
 function NodeList() {}
 NodeList.prototype = {
 	/**
 	 * The number of nodes in the list. The range of valid child node indices is 0 to length-1 inclusive.
-	 *
 	 * @standard level1
 	 */
 	length: 0,
 	/**
-	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this
-	 * returns null.
-	 *
-	 * @param index Unsigned long Index into the collection.
-	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a valid index.
+	 * Returns the indexth item in the collection. If index is greater than or equal to the number of nodes in the list, this returns null.
 	 * @standard level1
+	 * @param index  unsigned long
+	 *   Index into the collection.
+	 * @return Node
+	 * 	The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 */
 	item: function (index) {
 		return this[index] || null;
@@ -321,13 +322,18 @@ LiveNodeList.prototype.item = function (i) {
 _extends(LiveNodeList, NodeList);
 
 /**
- * Objects implementing the NamedNodeMap interface are used to represent collections of nodes that can be accessed by name. Note
- * that NamedNodeMap does not inherit from NodeList; NamedNodeMaps are not maintained in any particular order. Objects contained
- * in an object implementing NamedNodeMap may also be accessed by an ordinal index, but this is simply to allow convenient
- * enumeration of the contents of a NamedNodeMap, and does not imply that the DOM specifies an order to these Nodes. NamedNodeMap
- * objects in the DOM are live. used for attributes or DocumentType entities
+ * Objects implementing the NamedNodeMap interface are used
+ * to represent collections of nodes that can be accessed by name.
+ * Note that NamedNodeMap does not inherit from NodeList;
+ * NamedNodeMaps are not maintained in any particular order.
+ * Objects contained in an object implementing NamedNodeMap may also be accessed by an ordinal index,
+ * but this is simply to allow convenient enumeration of the contents of a NamedNodeMap,
+ * and does not imply that the DOM specifies an order to these Nodes.
+ * NamedNodeMap objects in the DOM are live.
+ * used for attributes or DocumentType entities
  *
- * This implementation only supports property indices, but does not support named properties, as specified in the living standard.
+ * This implementation only supports property indices, but does not support named properties,
+ * as specified in the living standard.
  *
  * @see https://dom.spec.whatwg.org/#interface-namednodemap
  * @see https://webidl.spec.whatwg.org/#dfn-supported-property-names
@@ -383,10 +389,11 @@ NamedNodeMap.prototype = {
 	item: NodeList.prototype.item,
 
 	/**
-	 * Get an attribute by name (lower case in case of HTML namespace and document)
+	 * get an attribute by name (lower case in case of HTML namespace and document)
 	 *
-	 * @param {string} localName
-	 * @returns {Attr | null}
+	 * @param  {string} localName
+	 * @return {Attr | null}
+	 *
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
 	 */
 	getNamedItem: function (localName) {
@@ -405,10 +412,10 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Set an attribute
+	 * set an attribute
 	 *
 	 * @param {Attr} attr
-	 * @returns {Attr | null}
+	 * @return {Attr | null}
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-set
 	 */
 	setNamedItem: function (attr) {
@@ -425,10 +432,11 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Set an attribute
+	 * set an attribute
 	 *
 	 * @param {Attr} attr
-	 * @returns {Attr | null}
+	 * @return {Attr | null}
+	 *
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-set
 	 */
 	setNamedItemNS: function (attr) {
@@ -436,10 +444,11 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Remove an attribute by name (lower case in case of HTML namespace and document)
+	 * remove an attribute by name (lower case in case of HTML namespace and document)
 	 *
 	 * @param {string} localName
-	 * @returns {Attr | null}
+	 * @return {Attr | null}
+	 *
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditem
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-name
 	 */
@@ -453,11 +462,12 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Remove an attribute by namespace and local name
+	 * remove an attribute by namespace and local name
 	 *
 	 * @param {string | null} namespaceURI
 	 * @param {string} localName
-	 * @returns {Attr | null}
+	 * @return {Attr | null}
+	 *
 	 * @see https://dom.spec.whatwg.org/#dom-namednodemap-removenameditemns
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-remove-by-namespace
 	 */
@@ -471,11 +481,12 @@ NamedNodeMap.prototype = {
 	},
 
 	/**
-	 * Get an attribute by namespace and local name
+	 * get an attribute by namespace and local name
 	 *
 	 * @param {string | null} namespaceURI
 	 * @param {string} localName
-	 * @returns {Attr | null}
+	 * @return {Attr | null}
+	 *
 	 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
 	 */
 	getNamedItemNS: function (namespaceURI, localName) {
@@ -495,12 +506,14 @@ NamedNodeMap.prototype = {
 };
 
 /**
- * The DOMImplementation interface represents an object providing methods which are not dependent on any particular document. Such
- * an object is returned by the `Document.implementation` property.
+ * The DOMImplementation interface represents an object providing methods
+ * which are not dependent on any particular document.
+ * Such an object is returned by the `Document.implementation` property.
  *
- * **The individual methods describe the differences compared to the specs.**
+ * __The individual methods describe the differences compared to the specs.__
  *
- * @class
+ * @constructor
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation MDN
  * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-102161490 DOM Level 1 Core (Initial)
  * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-102161490 DOM Level 2 Core
@@ -511,14 +524,16 @@ function DOMImplementation() {}
 
 DOMImplementation.prototype = {
 	/**
-	 * The DOMImplementation.hasFeature() method returns a Boolean flag indicating if a given feature is supported. The different
-	 * implementations fairly diverged in what kind of features were reported. The latest version of the spec settled to force this
-	 * method to always return true, where the functionality was accurate and in use.
+	 * The DOMImplementation.hasFeature() method returns a Boolean flag indicating if a given feature is supported.
+	 * The different implementations fairly diverged in what kind of features were reported.
+	 * The latest version of the spec settled to force this method to always return true, where the functionality was accurate and in use.
 	 *
 	 * @deprecated It is deprecated and modern browsers return true in all cases.
+	 *
 	 * @param {string} feature
 	 * @param {string} [version]
-	 * @returns {boolean} Always true
+	 * @returns {boolean} always true
+	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/hasFeature MDN
 	 * @see https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#ID-5CED94D7 DOM Level 1 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature DOM Living Standard
@@ -529,19 +544,20 @@ DOMImplementation.prototype = {
 	/**
 	 * Creates an XML Document object of the specified type with its document element.
 	 *
-	 * **It behaves slightly different from the description in the living standard**:
-	 *
+	 * __It behaves slightly different from the description in the living standard__:
 	 * - There is no interface/class `XMLDocument`, it returns a `Document` instance (with it's `type` set to `'xml'`).
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string | null} namespaceURI
 	 * @param {string} qualifiedName
-	 * @param {DocumentType | null} [doctype=null] Default is `null`
-	 * @returns {Document} The XML document
+	 * @param {DocumentType | null} [doctype=null]
+	 * @returns {Document} the XML document
+	 *
 	 * @see #createHTMLDocument
+	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocument MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocument DOM Level 2 Core (initial)
-	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument DOM Level 2 Core
+	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocument  DOM Level 2 Core
 	 */
 	createDocument: function (namespaceURI, qualifiedName, doctype) {
 		var contentType = MIME_TYPE.XML_APPLICATION;
@@ -566,19 +582,21 @@ DOMImplementation.prototype = {
 	/**
 	 * Returns a doctype, with the given `qualifiedName`, `publicId`, and `systemId`.
 	 *
-	 * **This behavior is slightly different from the in the specs**:
-	 *
+	 * __This behavior is slightly different from the in the specs__:
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
-	 * - `publicId` and `systemId` contain the raw data including any possible quotes, so they can always be serialized back to the
-	 *   original value
-	 * - `internalSubset` contains the raw string between `[` and `]` if present, but is not parsed or validated in any form
+	 * - `publicId` and `systemId` contain the raw data including any possible quotes,
+	 *   so they can always be serialized back to the original value
+	 * - `internalSubset` contains the raw string between `[` and `]` if present,
+	 *   but is not parsed or validated in any form
 	 *
 	 * @param {string} qualifiedName
 	 * @param {string} [publicId]
 	 * @param {string} [systemId]
 	 * @param {string} [internalSubset] (from DOM Level 2 Core)
-	 * @returns {DocumentType} Which can either be used with `DOMImplementation.createDocument` on document creation or can be put
-	 *   into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
+	 * @returns {DocumentType} which can either be used with `DOMImplementation.createDocument`
+	 *                         on document creation or can be put into the document
+	 *                         via methods like `Node.insertBefore()` or `Node.replaceChild()`
+	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createDocumentType MDN
 	 * @see https://www.w3.org/TR/DOM-Level-2-Core/core.html#Level-2-Core-DOM-createDocType DOM Level 2 Core
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createdocumenttype DOM Living Standard
@@ -599,13 +617,13 @@ DOMImplementation.prototype = {
 	/**
 	 * Returns an HTML document, that might already have a basic DOM structure.
 	 *
-	 * **It behaves slightly different from the description in the living standard**:
-	 *
+	 * __It behaves slightly different from the description in the living standard__:
 	 * - If the first argument is `false` no initial nodes are added (steps 3-7 in the specs are omitted)
 	 * - `encoding`, `mode`, `origin`, `url` fields are currently not declared.
 	 *
 	 * @param {string | false} [title]
 	 * @returns {Document} The HTML document
+	 *
 	 * @see https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
 	 * @see https://dom.spec.whatwg.org/#html-document
 	 */
@@ -632,7 +650,9 @@ DOMImplementation.prototype = {
 	},
 };
 
-/** @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247 */
+/**
+ * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247
+ */
 function Node() {}
 
 Node.prototype = {
@@ -695,8 +715,9 @@ Node.prototype = {
 		return this.attributes.length > 0;
 	},
 	/**
-	 * Look up the prefix associated to the given namespace URI, starting from this node. **The default namespace declarations are
-	 * ignored by this method.** See Namespace Prefix Lookup for details on the algorithm used by this method.
+	 * Look up the prefix associated to the given namespace URI, starting from this node.
+	 * **The default namespace declarations are ignored by this method.**
+	 * See Namespace Prefix Lookup for details on the algorithm used by this method.
 	 *
 	 * _Note: The implementation seems to be incomplete when compared to the algorithm described in the specs._
 	 *
@@ -745,11 +766,13 @@ Node.prototype = {
 	},
 	// Introduced in DOM Level 3:
 	/**
-	 * Compares the reference node with a node with regard to their position in the document and according to the document order.
+	 * Compares the reference node with a node with regard to their position
+	 * in the document and according to the document order.
 	 *
 	 * @param {Node} other The node to compare the reference node to.
-	 * @returns {number} Returns how the node is positioned relatively to the reference node according to the bitmask. 0 if
-	 *   reference node and given node are the same.
+	 * @return {number} Returns how the node is positioned relatively to the
+	 *    reference node according to the bitmask. 0 if reference node and
+	 *    given node are the same.
 	 * @see https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-compareDocumentPosition
 	 */
 	compareDocumentPosition: function (other) {
@@ -811,8 +834,8 @@ copy(DocumentPosition, Node);
 copy(DocumentPosition, Node.prototype);
 
 /**
- * @param callback Return true for continue,false for break
- * @returns Boolean true: break visit;
+ * @param callback return true for continue,false for break
+ * @return boolean true: break visit;
  */
 function _visitNode(node, callback) {
 	if (callback(node)) {
@@ -829,19 +852,21 @@ function _visitNode(node, callback) {
 
 /**
  * @typedef DocumentOptions
- * @property {string} [contentType=MIME_TYPE.XML_APPLICATION] Default is `MIME_TYPE.XML_APPLICATION`
+ * @property {string} [contentType=MIME_TYPE.XML_APPLICATION]
  */
 /**
  * The Document interface describes the common properties and methods for any kind of document.
  *
- * It should usually be created using `new DOMImplementation().createDocument(...)` or `new
- * DOMImplementation().createHTMLDocument(...)`.
+ * It should usually be created using `new DOMImplementation().createDocument(...)`
+ * or `new DOMImplementation().createHTMLDocument(...)`.
  *
- * The constructor is considered a private API and offers to initially set the `contentType` property via it's options parameter.
+ * The constructor is considered a private API and offers to initially set the `contentType` property
+ * via it's options parameter.
  *
- * @private
- * @class
  * @param {DocumentOptions} [options]
+ * @private
+ * @constructor
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Document
  * @see https://dom.spec.whatwg.org/#interface-document
  */
@@ -853,14 +878,17 @@ function Document(options) {
 	 *
 	 * @type {string}
 	 * @readonly
+	 *
 	 * @see https://dom.spec.whatwg.org/#concept-document-content-type
 	 * @see DOMImplementation
 	 * @see MIME_TYPE
 	 */
 	this.contentType = opt.contentType || MIME_TYPE.XML_APPLICATION;
 	/**
+	 *
 	 * @type {'html' | 'xml'}
 	 * @readonly
+	 *
 	 * @see https://dom.spec.whatwg.org/#concept-document-type
 	 * @see DOMImplementation
 	 */
@@ -886,14 +914,16 @@ function _onRemoveAttribute(doc, el, newAttr, remove) {
 }
 
 /**
- * Updates `el.childNodes`, updating the indexed items and it's `length`. Passing `newChild` means it will be appended. Otherwise
- * it's assumed that an item has been removed, and `el.firstNode` and it's `.nextSibling` are used to walk the current list of
- * child nodes.
+ * Updates `el.childNodes`, updating the indexed items and it's `length`.
+ * Passing `newChild` means it will be appended.
+ * Otherwise it's assumed that an item has been removed,
+ * and `el.firstNode` and it's `.nextSibling` are used
+ * to walk the current list of child nodes.
  *
- * @private
  * @param {Document} doc
  * @param {Node} el
  * @param {Node} [newChild]
+ * @private
  */
 function _onUpdateChild(doc, el, newChild) {
 	if (doc && doc._inc) {
@@ -916,14 +946,16 @@ function _onUpdateChild(doc, el, newChild) {
 }
 
 /**
- * Removes the connections between `parentNode` and `child` and any existing `child.previousSibling` or `child.nextSibling`.
+ * Removes the connections between `parentNode` and `child`
+ * and any existing `child.previousSibling` or `child.nextSibling`.
  *
- * @private
- * @param {Node} parentNode
- * @param {Node} child
- * @returns {Node} The child that was removed.
  * @see https://github.com/xmldom/xmldom/issues/135
  * @see https://github.com/xmldom/xmldom/issues/145
+ *
+ * @param {Node} parentNode
+ * @param {Node} child
+ * @returns {Node} the child that was removed.
+ * @private
  */
 function _removeChild(parentNode, child) {
 	if (parentNode !== child.parentNode) {
@@ -951,7 +983,6 @@ function _removeChild(parentNode, child) {
 
 /**
  * Returns `true` if `node` can be a parent for insertion.
- *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -964,7 +995,6 @@ function hasValidParentNodeType(node) {
 
 /**
  * Returns `true` if `node` can be inserted according to it's `nodeType`.
- *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -982,7 +1012,6 @@ function hasInsertableNodeType(node) {
 
 /**
  * Returns true if `node` is a DOCTYPE node
- *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -992,7 +1021,6 @@ function isDocTypeNode(node) {
 
 /**
  * Returns true if the node is an element
- *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1001,7 +1029,6 @@ function isElementNode(node) {
 }
 /**
  * Returns true if `node` is a text node
- *
  * @param {Node} node
  * @returns {boolean}
  */
@@ -1010,13 +1037,14 @@ function isTextNode(node) {
 }
 
 /**
- * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
- * position of a doctype node on the same level.
+ * Check if en element node can be inserted before `child`, or at the end if child is falsy,
+ * according to the presence and position of a doctype node on the same level.
  *
- * @private https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @param {Document} doc The document node
- * @param {Node} child The node that would become the nextSibling if the element would be inserted
+ * @param {Node} child the node that would become the nextSibling if the element would be inserted
  * @returns {boolean} `true` if an element can be inserted before child
+ * @private
+ * https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
 function isElementInsertionPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1028,13 +1056,14 @@ function isElementInsertionPossible(doc, child) {
 }
 
 /**
- * Check if en element node can be inserted before `child`, or at the end if child is falsy, according to the presence and
- * position of a doctype node on the same level.
+ * Check if en element node can be inserted before `child`, or at the end if child is falsy,
+ * according to the presence and position of a doctype node on the same level.
  *
- * @private https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  * @param {Node} doc The document node
- * @param {Node} child The node that would become the nextSibling if the element would be inserted
+ * @param {Node} child the node that would become the nextSibling if the element would be inserted
  * @returns {boolean} `true` if an element can be inserted before child
+ * @private
+ * https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity
  */
 function isElementReplacementPossible(doc, child) {
 	var parentChildNodes = doc.childNodes || [];
@@ -1051,10 +1080,12 @@ function isElementReplacementPossible(doc, child) {
 }
 
 /**
- * @private Steps 1-5 of the checks before inserting and before replacing a child are the same.
- * @param {Node} parent The parent node to insert `node` into
- * @param {Node} node The node to insert
- * @param {Node} [child] The node that should become the `nextSibling` of `node`
+ * @private
+ * Steps 1-5 of the checks before inserting and before replacing a child are the same.
+ *
+ * @param {Node} parent the parent node to insert `node` into
+ * @param {Node} node the node to insert
+ * @param {Node=} child the node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
@@ -1089,10 +1120,12 @@ function assertPreInsertionValidity1to5(parent, node, child) {
 }
 
 /**
- * @private Step 6 of the checks before inserting and before replacing a child are different.
- * @param {Document} parent The parent node to insert `node` into
- * @param {Node} node The node to insert
- * @param {Node | undefined} child The node that should become the `nextSibling` of `node`
+ * @private
+ * Step 6 of the checks before inserting and before replacing a child are different.
+ *
+ * @param {Document} parent the parent node to insert `node` into
+ * @param {Node} node the node to insert
+ * @param {Node | undefined} child the node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
@@ -1143,10 +1176,12 @@ function assertPreInsertionValidityInDocument(parent, node, child) {
 }
 
 /**
- * @private Step 6 of the checks before inserting and before replacing a child are different.
- * @param {Document} parent The parent node to insert `node` into
- * @param {Node} node The node to insert
- * @param {Node | undefined} child The node that should become the `nextSibling` of `node`
+ * @private
+ * Step 6 of the checks before inserting and before replacing a child are different.
+ *
+ * @param {Document} parent the parent node to insert `node` into
+ * @param {Node} node the node to insert
+ * @param {Node | undefined} child the node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
@@ -1196,9 +1231,9 @@ function assertPreReplacementValidityInDocument(parent, node, child) {
 
 /**
  * @private
- * @param {Node} parent The parent node to insert `node` into
- * @param {Node} node The node to insert
- * @param {Node} [child] The node that should become the `nextSibling` of `node`
+ * @param {Node} parent the parent node to insert `node` into
+ * @param {Node} node the node to insert
+ * @param {Node=} child the node that should become the `nextSibling` of `node`
  * @returns {Node}
  * @throws DOMException for several node combinations that would create a DOM that is not well-formed.
  * @throws DOMException if `child` is provided but is not a child of `parent`.
@@ -1254,14 +1289,15 @@ function _insertBefore(parent, node, child, _inDocumentAssertion) {
 }
 
 /**
- * Appends `newChild` to `parentNode`. If `newChild` is already connected to a `parentNode` it is first removed from it.
+ * Appends `newChild` to `parentNode`.
+ * If `newChild` is already connected to a `parentNode` it is first removed from it.
  *
- * @private
+ * @see https://github.com/xmldom/xmldom/issues/135
+ * @see https://github.com/xmldom/xmldom/issues/145
  * @param {Node} parentNode
  * @param {Node} newChild
  * @returns {Node}
- * @see https://github.com/xmldom/xmldom/issues/135
- * @see https://github.com/xmldom/xmldom/issues/145
+ * @private
  */
 function _appendSingleChild(parentNode, newChild) {
 	if (newChild.parentNode) {
@@ -1283,9 +1319,8 @@ function _appendSingleChild(parentNode, newChild) {
 Document.prototype = {
 	/**
 	 * The implementation that created this document
-	 *
-	 * @type DOMImplementation
 	 * @readonly
+	 * @type DOMImplementation
 	 */
 	implementation: null,
 	nodeName: '#document',
@@ -1293,8 +1328,8 @@ Document.prototype = {
 	/**
 	 * The DocumentType node of the document.
 	 *
-	 * @type DocumentType
 	 * @readonly
+	 * @type DocumentType
 	 */
 	doctype: null,
 	documentElement: null,
@@ -1356,17 +1391,19 @@ Document.prototype = {
 	},
 
 	/**
-	 * The `getElementsByClassName` method of `Document` interface returns an array-like object of all child elements which have
-	 * **all** of the given class name(s).
+	 * The `getElementsByClassName` method of `Document` interface returns an array-like object
+	 * of all child elements which have **all** of the given class name(s).
 	 *
 	 * Returns an empty list if `classeNames` is an empty string or only contains HTML white space characters.
 	 *
-	 * Warning: This is a live LiveNodeList. Changes in the DOM will reflect in the array as the changes occur. If an element
-	 * selected by this array no longer qualifies for the selector, it will automatically be removed. Be aware of this for iteration
-	 * purposes.
 	 *
-	 * @param {string} classNames Is a string representing the class name(s) to match; multiple class names are separated by
-	 *   (ASCII-)whitespace
+	 * Warning: This is a live LiveNodeList.
+	 * Changes in the DOM will reflect in the array as the changes occur.
+	 * If an element selected by this array no longer qualifies for the selector,
+	 * it will automatically be removed. Be aware of this for iteration purposes.
+	 *
+	 * @param {string} classNames is a string representing the class name(s) to match; multiple class names are separated by (ASCII-)whitespace
+	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 	 */
@@ -1398,18 +1435,20 @@ Document.prototype = {
 	},
 
 	/**
-	 * Creates a new `Element` that is owned by this `Document`. In HTML Documents `localName` is the lower cased `tagName`,
-	 * otherwise no transformation is being applied. When `contentType` implies the HTML namespace, it will be set as
-	 * `namespaceURI`.
+	 * Creates a new `Element` that is owned by this `Document`.
+	 * In HTML Documents `localName` is the lower cased `tagName`,
+	 * otherwise no transformation is being applied.
+	 * When `contentType` implies the HTML namespace, it will be set as `namespaceURI`.
 	 *
-	 * **This implementation differs from the specification:**
-	 *
-	 * - The provided name is not checked against the `Name` production, so no related error will be thrown.
+	 * __This implementation differs from the specification:__
+	 * - The provided name is not checked against the `Name` production,
+	 *   so no related error will be thrown.
 	 * - There is no interface `HTMLElement`, it is always an `Element`.
 	 * - There is no support for a second argument to indicate using custom elements.
 	 *
 	 * @param {string} tagName
-	 * @returns {Element}
+	 * @return {Element}
+	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement
 	 * @see https://dom.spec.whatwg.org/#dom-document-createelement
 	 * @see https://dom.spec.whatwg.org/#concept-create-element
@@ -1463,15 +1502,17 @@ Document.prototype = {
 		return node;
 	},
 	/**
-	 * Creates an `Attr` node that is owned by this document. In HTML Documents `localName` is the lower cased `name`, otherwise no
-	 * transformation is being applied.
+	 * Creates an `Attr` node that is owned by this document.
+	 * In HTML Documents `localName` is the lower cased `name`,
+	 * otherwise no transformation is being applied.
 	 *
-	 * **This implementation differs from the specification:**
-	 *
-	 * - The provided name is not checked against the `Name` production, so no related error will be thrown.
+	 * __This implementation differs from the specification:__
+	 * - The provided name is not checked against the `Name` production,
+	 *   so no related error will be thrown.
 	 *
 	 * @param {string} name
-	 * @returns {Attr}
+	 * @return {Attr}
+	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createAttribute
 	 * @see https://dom.spec.whatwg.org/#dom-document-createattribute
 	 */
@@ -1549,7 +1590,7 @@ Element.prototype = {
 	 * Returns element’s first attribute whose qualified name is `name`, and `null` if there is no such attribute.
 	 *
 	 * @param {string} name
-	 * @returns {string | null}
+	 * @return {string | null}
 	 */
 	getAttribute: function (name) {
 		var attr = this.getAttributeNode(name);
@@ -1613,12 +1654,12 @@ Element.prototype = {
 		return this.getAttributeNodeNS(namespaceURI, localName) != null;
 	},
 	/**
-	 * Returns element’s attribute whose namespace is `namespaceURI` and local name is `localName`, or `null` if there is no such
-	 * attribute.
+	 * Returns element’s attribute whose namespace is `namespaceURI` and local name is `localName`,
+	 * or `null` if there is no such attribute.
 	 *
 	 * @param {string} namespaceURI
 	 * @param {string} localName
-	 * @returns {string | null}
+	 * @return {string | null}
 	 */
 	getAttributeNS: function (namespaceURI, localName) {
 		var attr = this.getAttributeNodeNS(namespaceURI, localName);
@@ -1630,6 +1671,7 @@ Element.prototype = {
 	 * @param {string} namespaceURI
 	 * @param {string} qualifiedName
 	 * @param {string} value
+	 *
 	 * @see https://dom.spec.whatwg.org/#dom-element-setattributens
 	 */
 	setAttributeNS: function (namespaceURI, qualifiedName, value) {
@@ -1649,22 +1691,27 @@ Element.prototype = {
 	},
 
 	/**
-	 * Returns a LiveNodeList of elements with the given qualifiedName. Searching for all descendants can be done by passing `*` as
-	 * `qualifiedName`.
+	 * Returns a LiveNodeList of elements with the given qualifiedName.
+	 * Searching for all descendants can be done by passing `*` as `qualifiedName`.
 	 *
-	 * All descendants of the specified element are searched, but not the element itself. The returned list is live, which means it
-	 * updates itself with the DOM tree automatically. Therefore, there is no need to call `Element.getElementsByTagName()` with the
-	 * same element and arguments repeatedly if the DOM changes in between calls.
+	 * All descendants of the specified element are searched, but not the element itself.
+	 * The returned list is live, which means it updates itself with the DOM tree automatically.
+	 * Therefore, there is no need to call `Element.getElementsByTagName()`
+	 * with the same element and arguments repeatedly if the DOM changes in between calls.
 	 *
-	 * When called on an HTML element in an HTML document, `getElementsByTagName` lower-cases the argument before searching for it.
-	 * This is undesirable when trying to match camel-cased SVG elements (such as `<linearGradient>`) in an HTML document. Instead,
-	 * use `Element.getElementsByTagNameNS()`, which preserves the capitalization of the tag name.
+	 * When called on an HTML element in an HTML document,
+	 * `getElementsByTagName` lower-cases the argument before searching for it.
+	 * This is undesirable when trying to match camel-cased SVG elements
+	 * (such as `<linearGradient>`) in an HTML document.
+	 * Instead, use `Element.getElementsByTagNameNS()`,
+	 * which preserves the capitalization of the tag name.
 	 *
-	 * `Element.getElementsByTagName` is similar to `Document.getElementsByTagName()`, except that it only searches for elements
-	 * that are descendants of the specified element.
+	 * `Element.getElementsByTagName` is similar to `Document.getElementsByTagName()`,
+	 * except that it only searches for elements that are descendants of the specified element.
 	 *
 	 * @param {string} qualifiedName
-	 * @returns {LiveNodeList}
+	 * @return {LiveNodeList}
+	 *
 	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByTagName
 	 * @see https://dom.spec.whatwg.org/#concept-getelementsbytagname
 	 */
@@ -1856,11 +1903,13 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
 	return true;
 }
 /**
- * Well-formed constraint: No < in Attribute Values> The replacement text of any entity referred to directly or indirectly in an
- * attribute value must not contain a <.
- *
+ * Well-formed constraint: No < in Attribute Values
+ * > The replacement text of any entity referred to directly or indirectly
+ * > in an attribute value must not contain a <.
  * @see https://www.w3.org/TR/xml11/#CleanAttrVals
- * @see https://www.w3.org/TR/xml11/#NT-AttValue Literal whitespace other than space that appear in attribute values
+ * @see https://www.w3.org/TR/xml11/#NT-AttValue
+ *
+ * Literal whitespace other than space that appear in attribute values
  * are serialized as their entity references, so they will be preserved.
  * (In contrast to whitespace literals in the input which are normalized to spaces)
  * @see https://www.w3.org/TR/xml11/#AVNormalize
@@ -2006,15 +2055,17 @@ function serializeToString(node, buf, nodeFilter, visibleNamespaces) {
 			return addSerializedAttribute(buf, node.name, node.value);
 		case TEXT_NODE:
 			/**
-			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form, except when used as
-			 * markup delimiters, or within a comment, a processing instruction, or a CDATA section. If they are needed elsewhere, they
-			 * must be escaped using either numeric character references or the strings `&amp;` and `&lt;` respectively. The right angle
-			 * bracket (>) may be represented using the string " > ", and must, for compatibility, be escaped using either `&gt;` or a
-			 * character reference when it appears in the string `]]>` in content, when that string is not marking the end of a CDATA
-			 * section.
+			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,
+			 * except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section.
+			 * If they are needed elsewhere, they must be escaped using either numeric character references or the strings
+			 * `&amp;` and `&lt;` respectively.
+			 * The right angle bracket (>) may be represented using the string " &gt; ", and must, for compatibility,
+			 * be escaped using either `&gt;` or a character reference when it appears in the string `]]>` in content,
+			 * when that string is not marking the end of a CDATA section.
 			 *
-			 * In the content of elements, character data is any string of characters which does not contain the start-delimiter of any
-			 * markup and does not include the CDATA-section-close delimiter, `]]>`.
+			 * In the content of elements, character data is any string of characters
+			 * which does not contain the start-delimiter of any markup
+			 * and does not include the CDATA-section-close delimiter, `]]>`.
 			 *
 			 * @see https://www.w3.org/TR/xml/#NT-CharData
 			 * @see https://w3c.github.io/DOM-Parsing/#xml-serializing-a-text-node

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -260,11 +260,12 @@ DOMException.prototype = Error.prototype;
 copy(ExceptionCode, DOMException);
 
 /**
- * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177 The
- *      NodeList interface provides the abstraction of an ordered collection of nodes,
- *      without defining or constraining how this collection is implemented.
- *      NodeList objects in the DOM are live.
- *      The items in the NodeList are accessible via an integral index, starting from 0.
+ * The NodeList interface provides the abstraction of an ordered collection of nodes,
+ * without defining or constraining how this collection is implemented.
+ * NodeList objects in the DOM are live.
+ * The items in the NodeList are accessible via an integral index, starting from 0.
+ *
+ * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-536297177
  */
 function NodeList() {}
 NodeList.prototype = {
@@ -276,14 +277,13 @@ NodeList.prototype = {
 	 */
 	length: 0,
 	/**
-	 * Returns the indexth item in the collection. If index is greater than or equal to the number
-	 * of nodes in the list, this returns null.
+	 * Returns the item at `index`. If index is greater than or equal to the number of nodes in
+	 * the list, this returns null.
 	 *
 	 * @param index
 	 * Unsigned long Index into the collection.
-	 * @returns Node The node at the indexth position in the NodeList, or null if that is not a
-	 *          valid index.
-	 * @standard level1
+	 * @returns The node at position `index` in the NodeList,
+	 *          or null if that is not a valid index.
 	 */
 	item: function (index) {
 		return this[index] || null;
@@ -1736,8 +1736,7 @@ Element.prototype = {
 	 * When called on an HTML element in an HTML document,
 	 * `getElementsByTagName` lower-cases the argument before searching for it.
 	 * This is undesirable when trying to match camel-cased SVG elements (such as
-	 * `<linearGradient>`)
-	 * in an HTML document.
+	 * `<linearGradient>`) in an HTML document.
 	 * Instead, use `Element.getElementsByTagNameNS()`,
 	 * which preserves the capitalization of the tag name.
 	 *
@@ -1937,17 +1936,19 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
 	return true;
 }
 /**
- * Well-formed constraint: No < in Attribute Values > The replacement text of any entity
- * referred to directly or indirectly > in an attribute value must not contain a <.
+ * Literal whitespace other than space that appear in attribute values are serialized as
+ * their entity references, so they will be preserved.
+ * (In contrast to whitespace literals in the input which are normalized to spaces).
+ *
+ * Well-formed constraint: No < in Attribute Values:
+ * > The replacement text of any entity referred to directly or indirectly
+ * > in an attribute value must not contain a <.
  *
  * @see https://www.w3.org/TR/xml11/#CleanAttrVals
  * @see https://www.w3.org/TR/xml11/#NT-AttValue
- *
- *      Literal whitespace other than space that appear in attribute values are serialized as
- *      their entity references, so they will be preserved.
- *      (In contrast to whitespace literals in the input which are normalized to spaces)
  * @see https://www.w3.org/TR/xml11/#AVNormalize
  * @see https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes
+ * @prettierignore
  */
 function addSerializedAttribute(buf, qualifiedName, value) {
 	buf.push(' ', qualifiedName, '="', value.replace(/[<>&"\t\n\r]/g, _xmlEncoder), '"');
@@ -2088,23 +2089,20 @@ function serializeToString(node, buf, nodeFilter, visibleNamespaces) {
 		case ATTRIBUTE_NODE:
 			return addSerializedAttribute(buf, node.name, node.value);
 		case TEXT_NODE:
-			/**
-			 * The ampersand character (&) and the left angle bracket (<) must not appear in their
-			 * literal form,
-			 * except when used as markup delimiters, or within a comment, a processing instruction, or
-			 * a CDATA section.
+			/*
+			 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,
+			 * except when used as markup delimiters, or within a comment, a processing instruction,
+			 * or a CDATA section.
 			 * If they are needed elsewhere, they must be escaped using either numeric character
 			 * references or the strings `&amp;` and `&lt;` respectively.
 			 * The right angle bracket (>) may be represented using the string " &gt; ",
-			 * and must, for compatibility,
-			 * be escaped using either `&gt;` or a character reference when it appears in the string
-			 * `]]>` in content,
+			 * and must, for compatibility, be escaped using either `&gt;`,
+			 * or a character reference when it appears in the string `]]>` in content,
 			 * when that string is not marking the end of a CDATA section.
 			 *
 			 * In the content of elements, character data is any string of characters which does not
 			 * contain the start-delimiter of any markup and does not include the CDATA-section-close
-			 * delimiter,
-			 * `]]>`.
+			 * delimiter, `]]>`.
 			 *
 			 * @see https://www.w3.org/TR/xml/#NT-CharData
 			 * @see https://w3c.github.io/DOM-Parsing/#xml-serializing-a-text-node

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -2166,6 +2166,6 @@ exports.HTML_ENTITIES = freeze({
 /**
  * @deprecated
  * Use `HTML_ENTITIES` instead.
- * @see HTML_ENTITIES.
+ * @see {@link HTML_ENTITIES}
  */
 exports.entityMap = exports.HTML_ENTITIES;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -2162,8 +2162,8 @@ exports.HTML_ENTITIES = freeze({
 });
 
 /**
- * @see HTML_ENTITIES.
  * @deprecated
  * Use `HTML_ENTITIES` instead.
+ * @see HTML_ENTITIES.
  */
 exports.entityMap = exports.HTML_ENTITIES;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -20,17 +20,15 @@ exports.XML_ENTITIES = freeze({
 /**
  * A map of all entities that are detected in an HTML document. They contain all entries from `XML_ENTITIES`.
  *
- * @see XML_ENTITIES.
- * @see DOMParser.parseFromString.
- * @see DOMImplementation.prototype.createHTMLDocument.
+ * @see XML_ENTITIES
+ * @see DOMParser.parseFromString
+ * @see DOMImplementation.prototype.createHTMLDocument
  * @see https://html.spec.whatwg.org/#named-character-references WHATWG HTML(5) Spec
  * @see https://html.spec.whatwg.org/entities.json JSON
  * @see https://www.w3.org/TR/xml-entity-names/ W3C XML Entity Names
  * @see https://www.w3.org/TR/html4/sgml/entities.html W3C HTML4/SGML
- * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Character_entity_references_in_HTML
- *      Wikipedia (HTML)
- * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Entities_representing_special_characters_in_XHTML
- *      Wikpedia (XHTML)
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Character_entity_references_in_HTML Wikipedia (HTML)
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Entities_representing_special_characters_in_XHTML Wikpedia (XHTML)
  */
 exports.HTML_ENTITIES = freeze({
 	Aacute: '\u00C1',
@@ -2161,7 +2159,7 @@ exports.HTML_ENTITIES = freeze({
 });
 
 /**
- * @see HTML_ENTITIES.
- * @deprecated Use `HTML_ENTITIES` instead.
+ * @deprecated Use `HTML_ENTITIES` instead
+ * @see HTML_ENTITIES
  */
 exports.entityMap = exports.HTML_ENTITIES;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -2162,6 +2162,7 @@ exports.HTML_ENTITIES = freeze({
 
 /**
  * @see HTML_ENTITIES.
- * @deprecated Use `HTML_ENTITIES` instead.
+ * @deprecated
+ * Use `HTML_ENTITIES` instead.
  */
 exports.entityMap = exports.HTML_ENTITIES;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -18,7 +18,8 @@ exports.XML_ENTITIES = freeze({
 });
 
 /**
- * A map of all entities that are detected in an HTML document. They contain all entries from `XML_ENTITIES`.
+ * A map of all entities that are detected in an HTML document.
+ * They contain all entries from `XML_ENTITIES`.
  *
  * @see XML_ENTITIES
  * @see DOMParser.parseFromString
@@ -2159,7 +2160,7 @@ exports.HTML_ENTITIES = freeze({
 });
 
 /**
- * @deprecated Use `HTML_ENTITIES` instead
+ * @deprecated use `HTML_ENTITIES` instead
  * @see HTML_ENTITIES
  */
 exports.entityMap = exports.HTML_ENTITIES;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -18,8 +18,7 @@ exports.XML_ENTITIES = freeze({
 });
 
 /**
- * A map of all entities that are detected in an HTML document.
- * They contain all entries from `XML_ENTITIES`.
+ * A map of all entities that are detected in an HTML document. They contain all entries from `XML_ENTITIES`.
  *
  * @see XML_ENTITIES
  * @see DOMParser.parseFromString
@@ -2160,7 +2159,7 @@ exports.HTML_ENTITIES = freeze({
 });
 
 /**
- * @deprecated use `HTML_ENTITIES` instead
+ * @deprecated Use `HTML_ENTITIES` instead
  * @see HTML_ENTITIES
  */
 exports.entityMap = exports.HTML_ENTITIES;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -22,9 +22,9 @@ exports.XML_ENTITIES = freeze({
  * A map of all entities that are detected in an HTML document.
  * They contain all entries from `XML_ENTITIES`.
  *
- * @see XML_ENTITIES.
- * @see DOMParser.parseFromString.
- * @see DOMImplementation.prototype.createHTMLDocument.
+ * @see {@link XML_ENTITIES}
+ * @see {@link DOMParser.parseFromString}
+ * @see {@link DOMImplementation.prototype.createHTMLDocument}
  * @see https://html.spec.whatwg.org/#named-character-references WHATWG HTML(5)
  *      Spec
  * @see https://html.spec.whatwg.org/entities.json JSON

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -7,7 +7,8 @@ var freeze = require('./conventions').freeze;
  *
  * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-predefined-ent W3C XML 1.1
  * @see https://www.w3.org/TR/2008/REC-xml-20081126/#sec-predefined-ent W3C XML 1.0
- * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML Wikipedia
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML
+ *      Wikipedia
  */
 exports.XML_ENTITIES = freeze({
 	amp: '&',
@@ -24,7 +25,8 @@ exports.XML_ENTITIES = freeze({
  * @see XML_ENTITIES.
  * @see DOMParser.parseFromString.
  * @see DOMImplementation.prototype.createHTMLDocument.
- * @see https://html.spec.whatwg.org/#named-character-references WHATWG HTML(5) Spec
+ * @see https://html.spec.whatwg.org/#named-character-references WHATWG HTML(5)
+ *      Spec
  * @see https://html.spec.whatwg.org/entities.json JSON
  * @see https://www.w3.org/TR/xml-entity-names/ W3C XML Entity Names
  * @see https://www.w3.org/TR/html4/sgml/entities.html W3C HTML4/SGML

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -2162,7 +2162,6 @@ exports.HTML_ENTITIES = freeze({
 
 /**
  * @see HTML_ENTITIES.
- * @deprecated
- * Use `HTML_ENTITIES` instead.
+ * @deprecated Use `HTML_ENTITIES` instead.
  */
 exports.entityMap = exports.HTML_ENTITIES;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -20,15 +20,17 @@ exports.XML_ENTITIES = freeze({
 /**
  * A map of all entities that are detected in an HTML document. They contain all entries from `XML_ENTITIES`.
  *
- * @see XML_ENTITIES
- * @see DOMParser.parseFromString
- * @see DOMImplementation.prototype.createHTMLDocument
+ * @see XML_ENTITIES.
+ * @see DOMParser.parseFromString.
+ * @see DOMImplementation.prototype.createHTMLDocument.
  * @see https://html.spec.whatwg.org/#named-character-references WHATWG HTML(5) Spec
  * @see https://html.spec.whatwg.org/entities.json JSON
  * @see https://www.w3.org/TR/xml-entity-names/ W3C XML Entity Names
  * @see https://www.w3.org/TR/html4/sgml/entities.html W3C HTML4/SGML
- * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Character_entity_references_in_HTML Wikipedia (HTML)
- * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Entities_representing_special_characters_in_XHTML Wikpedia (XHTML)
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Character_entity_references_in_HTML
+ *      Wikipedia (HTML)
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Entities_representing_special_characters_in_XHTML
+ *      Wikpedia (XHTML)
  */
 exports.HTML_ENTITIES = freeze({
 	Aacute: '\u00C1',
@@ -2159,7 +2161,7 @@ exports.HTML_ENTITIES = freeze({
 });
 
 /**
- * @deprecated Use `HTML_ENTITIES` instead
- * @see HTML_ENTITIES
+ * @see HTML_ENTITIES.
+ * @deprecated Use `HTML_ENTITIES` instead.
  */
 exports.entityMap = exports.HTML_ENTITIES;

--- a/lib/entities.js
+++ b/lib/entities.js
@@ -21,15 +21,17 @@ exports.XML_ENTITIES = freeze({
  * A map of all entities that are detected in an HTML document.
  * They contain all entries from `XML_ENTITIES`.
  *
- * @see XML_ENTITIES
- * @see DOMParser.parseFromString
- * @see DOMImplementation.prototype.createHTMLDocument
+ * @see XML_ENTITIES.
+ * @see DOMParser.parseFromString.
+ * @see DOMImplementation.prototype.createHTMLDocument.
  * @see https://html.spec.whatwg.org/#named-character-references WHATWG HTML(5) Spec
  * @see https://html.spec.whatwg.org/entities.json JSON
  * @see https://www.w3.org/TR/xml-entity-names/ W3C XML Entity Names
  * @see https://www.w3.org/TR/html4/sgml/entities.html W3C HTML4/SGML
- * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Character_entity_references_in_HTML Wikipedia (HTML)
- * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Entities_representing_special_characters_in_XHTML Wikpedia (XHTML)
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Character_entity_references_in_HTML
+ *      Wikipedia (HTML)
+ * @see https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Entities_representing_special_characters_in_XHTML
+ *      Wikpedia (XHTML)
  */
 exports.HTML_ENTITIES = freeze({
 	Aacute: '\u00C1',
@@ -2160,7 +2162,8 @@ exports.HTML_ENTITIES = freeze({
 });
 
 /**
- * @deprecated use `HTML_ENTITIES` instead
- * @see HTML_ENTITIES
+ * @see HTML_ENTITIES.
+ * @deprecated
+ * Use `HTML_ENTITIES` instead.
  */
 exports.entityMap = exports.HTML_ENTITIES;

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -4,7 +4,7 @@
  * Detects relevant unicode support for regular expressions in the runtime. Should the runtime not accepts the flag `u` or unicode
  * ranges, character classes without unicode handling will be used.
  *
- * @param {typeof RegExp} [RegExpImpl=RegExp] For testing: the RegExp class. Default is `RegExp`
+ * @param {typeof RegExp} [RegExpImpl=RegExp]  For testing: the RegExp class. Default is `RegExp`
  * @returns {boolean}
  * @see https://node.green/#ES2015-syntax-RegExp--y--and--u--flags
  */
@@ -22,7 +22,7 @@ function detectUnicodeSupport(RegExpImpl) {
 var UNICODE_SUPPORT = detectUnicodeSupport();
 
 /**
- * Removes `[`, `]` and any trailing quantifiers from the source of a RegExp
+ * Removes `[`, `]` and any trailing quantifiers from the source of a RegExp.
  *
  * @param {RegExp} regexp
  */
@@ -37,7 +37,7 @@ function chars(regexp) {
  * Creates a new character list regular expression, by removing `search` from the source of `regexp`.
  *
  * @param {RegExp} regexp
- * @param {string} search The character(s) to remove
+ * @param {string} search  The character(s) to remove.
  * @returns {RegExp}
  */
 function chars_without(regexp, search) {

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -1,10 +1,11 @@
 'use strict';
 
 /**
- * Detects relevant unicode support for regular expressions in the runtime. Should the runtime not accepts the flag `u` or unicode
- * ranges, character classes without unicode handling will be used.
+ * Detects relevant unicode support for regular expressions in the runtime.
+ * Should the runtime not accepts the flag `u` or unicode ranges,
+ * character classes without unicode handling will be used.
  *
- * @param {typeof RegExp} [RegExpImpl=RegExp] For testing: the RegExp class. Default is `RegExp`
+ * @param {typeof RegExp} [RegExpImpl=RegExp] for testing: the RegExp class
  * @returns {boolean}
  * @see https://node.green/#ES2015-syntax-RegExp--y--and--u--flags
  */
@@ -23,7 +24,6 @@ var UNICODE_SUPPORT = detectUnicodeSupport();
 
 /**
  * Removes `[`, `]` and any trailing quantifiers from the source of a RegExp
- *
  * @param {RegExp} regexp
  */
 function chars(regexp) {
@@ -34,10 +34,10 @@ function chars(regexp) {
 }
 
 /**
- * Creates a new character list regular expression, by removing `search` from the source of `regexp`.
- *
+ * Creates a new character list regular expression,
+ * by removing `search` from the source of `regexp`.
  * @param {RegExp} regexp
- * @param {string} search The character(s) to remove
+ * @param {string} search the character(s) to remove
  * @returns {RegExp}
  */
 function chars_without(regexp, search) {
@@ -58,7 +58,6 @@ function chars_without(regexp, search) {
 
 /**
  * Combines and Regular expressions correctly by using `RegExp.source`.
- *
  * @param {...(RegExp | string)[]} args
  * @returns {RegExp}
  */
@@ -81,7 +80,6 @@ function reg(args) {
 
 /**
  * Like `reg` but wraps the expression in `(?:`,`)` to create a non tracking group.
- *
  * @param {...(RegExp | string)[]} args
  * @returns {RegExp}
  */
@@ -209,18 +207,20 @@ var NCNameChar = chars_without(NameChar, ':');
 var NCName = reg(NCNameStartChar, NCNameChar, '*');
 
 /**
- * https://www.w3.org/TR/xml-names/#ns-qualnames
- *
- *     [7] QName ::= PrefixedName | UnprefixedName
- *     				  === (NCName ':' NCName) | NCName
- *     				  === NCName (':' NCName)?
- *     [8] PrefixedName ::= Prefix ':' LocalPart
- *     								 === NCName ':' NCName
- *     [9] UnprefixedName ::= LocalPart
- *     									 === NCName
- *     [10] Prefix ::= NCName
- *     [11] LocalPart ::= NCName
- */
+https://www.w3.org/TR/xml-names/#ns-qualnames
+
+```
+[7] QName ::= PrefixedName | UnprefixedName
+				  === (NCName ':' NCName) | NCName
+				  === NCName (':' NCName)?
+[8] PrefixedName ::= Prefix ':' LocalPart
+								 === NCName ':' NCName
+[9] UnprefixedName ::= LocalPart
+									 === NCName
+[10] Prefix ::= NCName
+[11] LocalPart ::= NCName
+```
+*/
 var QName = reg(NCName, regg(':', NCName), '?');
 var QName_exact = reg('^', QName, '$');
 var QName_group = reg('(', QName, ')');

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -4,7 +4,7 @@
  * Detects relevant unicode support for regular expressions in the runtime. Should the runtime not accepts the flag `u` or unicode
  * ranges, character classes without unicode handling will be used.
  *
- * @param {typeof RegExp} [RegExpImpl=RegExp]  For testing: the RegExp class. Default is `RegExp`
+ * @param {typeof RegExp} [RegExpImpl=RegExp] For testing: the RegExp class. Default is `RegExp`
  * @returns {boolean}
  * @see https://node.green/#ES2015-syntax-RegExp--y--and--u--flags
  */
@@ -22,7 +22,7 @@ function detectUnicodeSupport(RegExpImpl) {
 var UNICODE_SUPPORT = detectUnicodeSupport();
 
 /**
- * Removes `[`, `]` and any trailing quantifiers from the source of a RegExp.
+ * Removes `[`, `]` and any trailing quantifiers from the source of a RegExp
  *
  * @param {RegExp} regexp
  */
@@ -37,7 +37,7 @@ function chars(regexp) {
  * Creates a new character list regular expression, by removing `search` from the source of `regexp`.
  *
  * @param {RegExp} regexp
- * @param {string} search  The character(s) to remove.
+ * @param {string} search The character(s) to remove
  * @returns {RegExp}
  */
 function chars_without(regexp, search) {

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -4,7 +4,8 @@
  * Detects relevant unicode support for regular expressions in the runtime. Should the runtime not accepts the flag `u` or unicode
  * ranges, character classes without unicode handling will be used.
  *
- * @param {typeof RegExp} [RegExpImpl=RegExp]  For testing: the RegExp class. Default is `RegExp`
+ * @param {typeof RegExp} [RegExpImpl=RegExp]
+ * For testing: the RegExp class. Default is `RegExp`
  * @returns {boolean}
  * @see https://node.green/#ES2015-syntax-RegExp--y--and--u--flags
  */
@@ -37,7 +38,8 @@ function chars(regexp) {
  * Creates a new character list regular expression, by removing `search` from the source of `regexp`.
  *
  * @param {RegExp} regexp
- * @param {string} search  The character(s) to remove.
+ * @param {string} search
+ * The character(s) to remove.
  * @returns {RegExp}
  */
 function chars_without(regexp, search) {

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -1,11 +1,10 @@
 'use strict';
 
 /**
- * Detects relevant unicode support for regular expressions in the runtime.
- * Should the runtime not accepts the flag `u` or unicode ranges,
- * character classes without unicode handling will be used.
+ * Detects relevant unicode support for regular expressions in the runtime. Should the runtime not accepts the flag `u` or unicode
+ * ranges, character classes without unicode handling will be used.
  *
- * @param {typeof RegExp} [RegExpImpl=RegExp] for testing: the RegExp class
+ * @param {typeof RegExp} [RegExpImpl=RegExp] For testing: the RegExp class. Default is `RegExp`
  * @returns {boolean}
  * @see https://node.green/#ES2015-syntax-RegExp--y--and--u--flags
  */
@@ -24,6 +23,7 @@ var UNICODE_SUPPORT = detectUnicodeSupport();
 
 /**
  * Removes `[`, `]` and any trailing quantifiers from the source of a RegExp
+ *
  * @param {RegExp} regexp
  */
 function chars(regexp) {
@@ -34,10 +34,10 @@ function chars(regexp) {
 }
 
 /**
- * Creates a new character list regular expression,
- * by removing `search` from the source of `regexp`.
+ * Creates a new character list regular expression, by removing `search` from the source of `regexp`.
+ *
  * @param {RegExp} regexp
- * @param {string} search the character(s) to remove
+ * @param {string} search The character(s) to remove
  * @returns {RegExp}
  */
 function chars_without(regexp, search) {
@@ -58,6 +58,7 @@ function chars_without(regexp, search) {
 
 /**
  * Combines and Regular expressions correctly by using `RegExp.source`.
+ *
  * @param {...(RegExp | string)[]} args
  * @returns {RegExp}
  */
@@ -80,6 +81,7 @@ function reg(args) {
 
 /**
  * Like `reg` but wraps the expression in `(?:`,`)` to create a non tracking group.
+ *
  * @param {...(RegExp | string)[]} args
  * @returns {RegExp}
  */
@@ -207,20 +209,18 @@ var NCNameChar = chars_without(NameChar, ':');
 var NCName = reg(NCNameStartChar, NCNameChar, '*');
 
 /**
-https://www.w3.org/TR/xml-names/#ns-qualnames
-
-```
-[7] QName ::= PrefixedName | UnprefixedName
-				  === (NCName ':' NCName) | NCName
-				  === NCName (':' NCName)?
-[8] PrefixedName ::= Prefix ':' LocalPart
-								 === NCName ':' NCName
-[9] UnprefixedName ::= LocalPart
-									 === NCName
-[10] Prefix ::= NCName
-[11] LocalPart ::= NCName
-```
-*/
+ * https://www.w3.org/TR/xml-names/#ns-qualnames
+ *
+ *     [7] QName ::= PrefixedName | UnprefixedName
+ *     				  === (NCName ':' NCName) | NCName
+ *     				  === NCName (':' NCName)?
+ *     [8] PrefixedName ::= Prefix ':' LocalPart
+ *     								 === NCName ':' NCName
+ *     [9] UnprefixedName ::= LocalPart
+ *     									 === NCName
+ *     [10] Prefix ::= NCName
+ *     [11] LocalPart ::= NCName
+ */
 var QName = reg(NCName, regg(':', NCName), '?');
 var QName_exact = reg('^', QName, '$');
 var QName_group = reg('(', QName, ')');

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -4,8 +4,7 @@
  * Detects relevant unicode support for regular expressions in the runtime. Should the runtime not accepts the flag `u` or unicode
  * ranges, character classes without unicode handling will be used.
  *
- * @param {typeof RegExp} [RegExpImpl=RegExp]
- * For testing: the RegExp class. Default is `RegExp`
+ * @param {typeof RegExp} [RegExpImpl=RegExp]  For testing: the RegExp class. Default is `RegExp`
  * @returns {boolean}
  * @see https://node.green/#ES2015-syntax-RegExp--y--and--u--flags
  */
@@ -38,8 +37,7 @@ function chars(regexp) {
  * Creates a new character list regular expression, by removing `search` from the source of `regexp`.
  *
  * @param {RegExp} regexp
- * @param {string} search
- * The character(s) to remove.
+ * @param {string} search  The character(s) to remove.
  * @returns {RegExp}
  */
 function chars_without(regexp, search) {

--- a/lib/grammar.js
+++ b/lib/grammar.js
@@ -5,7 +5,8 @@
  * Should the runtime not accepts the flag `u` or unicode ranges,
  * character classes without unicode handling will be used.
  *
- * @param {typeof RegExp} [RegExpImpl=RegExp] for testing: the RegExp class
+ * @param {typeof RegExp} [RegExpImpl=RegExp]
+ * For testing: the RegExp class.
  * @returns {boolean}
  * @see https://node.green/#ES2015-syntax-RegExp--y--and--u--flags
  */
@@ -23,7 +24,8 @@ function detectUnicodeSupport(RegExpImpl) {
 var UNICODE_SUPPORT = detectUnicodeSupport();
 
 /**
- * Removes `[`, `]` and any trailing quantifiers from the source of a RegExp
+ * Removes `[`, `]` and any trailing quantifiers from the source of a RegExp.
+ *
  * @param {RegExp} regexp
  */
 function chars(regexp) {
@@ -36,8 +38,10 @@ function chars(regexp) {
 /**
  * Creates a new character list regular expression,
  * by removing `search` from the source of `regexp`.
+ *
  * @param {RegExp} regexp
- * @param {string} search the character(s) to remove
+ * @param {string} search
+ * The character(s) to remove.
  * @returns {RegExp}
  */
 function chars_without(regexp, search) {
@@ -58,6 +62,7 @@ function chars_without(regexp, search) {
 
 /**
  * Combines and Regular expressions correctly by using `RegExp.source`.
+ *
  * @param {...(RegExp | string)[]} args
  * @returns {RegExp}
  */
@@ -80,6 +85,7 @@ function reg(args) {
 
 /**
  * Like `reg` but wraps the expression in `(?:`,`)` to create a non tracking group.
+ *
  * @param {...(RegExp | string)[]} args
  * @returns {RegExp}
  */

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -540,25 +540,28 @@ function _copy(source, target) {
 
 /**
  * @typedef ParseUtils
- * @property {function(relativeIndex: number?): string | undefined} char
- * Provides look ahead access to a singe character relative to the current index.
- * @property {function(): number} getIndex
- * Provides read-only access to the current index.
- * @property {function(reg: RegExp): string | null} getMatch
- * Applies the provided regular expression enforcing that it starts at the current index and returns the complete matching string,
- * and moves the current index by the length of the matching string.
- * @property {function(): string} getSource
- * Provides read-only access to the complete source.
- * @property {function(places: number?): void} skip
- * Moves the current index by places (defaults to 1)
- * @property {function(): number} skipBlanks
- * Moves the current index by the amount of white space that directly follows the current index and returns the amount of
- * whitespace chars skipped (0..n), or -1 if the end of the source was reached.
- * @property {function(): string} substringFromIndex
- * Creates a substring from the current index to the end of `source`
- * @property {function(compareWith: string): boolean} substringStartsWith
- * Checks if source contains `compareWith`,
- * starting from the current index.
+ * @property {function(relativeIndex: number?): string | undefined} char                 Provides look ahead access to a singe
+ *                                                                                       character relative to the current index.
+ * @property {function(): number}                                   getIndex             Provides read-only access to the current
+ *                                                                                       index.
+ * @property {function(reg: RegExp): string | null}                 getMatch             Applies the provided regular expression
+ *                                                                                       enforcing that it starts at the current
+ *                                                                                       index and returns the complete matching
+ *                                                                                       string, and moves the current index by
+ *                                                                                       the length of the matching string.
+ * @property {function(): string}                                   getSource            Provides read-only access to the complete
+ *                                                                                       source.
+ * @property {function(places: number?): void}                      skip                 Moves the current index by places
+ *                                                                                       (defaults to 1)
+ * @property {function(): number}                                   skipBlanks           Moves the current index by the amount of
+ *                                                                                       white space that directly follows the
+ *                                                                                       current index and returns the amount of
+ *                                                                                       whitespace chars skipped (0..n), or -1 if
+ *                                                                                       the end of the source was reached.
+ * @property {function(): string}                                   substringFromIndex   Creates a substring from the current
+ *                                                                                       index to the end of `source`
+ * @property {function(compareWith: string): boolean}               substringStartsWith  Checks if source contains `compareWith`,
+ *                                                                                       starting from the current index.
  * @see ParseUtils.
  */
 
@@ -708,15 +711,12 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 /**
  * Called when the parser encounters an element starting with '<!'.
  *
- * @param {string} source
- * The xml.
- * @param {number} start
- * The start index of the '<!'
+ * @param {string}     source        The xml.
+ * @param {number}     start         The start index of the '<!'
  * @param {DOMHandler} domBuilder
  * @param {DOMHandler} errorHandler
  * @returns {number | never} The end index of the element.
- * @throws
- * ParseError in case the element is not well-formed.
+ * @throws ParseError in case the element is not well-formed.
  */
 function parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler) {
 	var p = parseUtils(source, start);

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -215,8 +215,8 @@ function copyLocator(f, t) {
 }
 
 /**
+ * @returns End of the elementStartPart(end of elementEndPart for selfClosed el)
  * @see #appendElement(source,elStartEnd,el,selfClosed,entityReplacer,domBuilder,parseStack);
- * @return end of the elementStartPart(end of elementEndPart for selfClosed el)
  */
 function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, errorHandler, isHTML) {
 	/**
@@ -414,9 +414,7 @@ function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, 
 	}
 }
 
-/**
- * @return true if has new namespace define
- */
+/** @returns True if has new namespace define */
 function appendElement(el, domBuilder, currentNSMap) {
 	var tagName = el.tagName;
 	var localNSMap = null;
@@ -540,31 +538,26 @@ function _copy(source, target) {
 
 /**
  * @typedef ParseUtils
- * @property {function(relativeIndex: number?): string | undefined} char provides look ahead access
- *           to a singe character relative to the current index
- * @property {function(): number} getIndex provides read-only access to the current index
- * @property {function(reg: RegExp): string | null} getMatch applies the provided regular expression
- *           enforcing that it starts at the current index and returns the complete matching string,
- *           and moves the current index by the length of the matching string.
- * @property {function(): string} getSource provides read-only access to the complete source
- * @property {function(places: number?): void} skip moves the current index
- *           by places (defaults to 1)
- * @property {function(): number} skipBlanks moves the current index by the amount of white space
- *           that directly follows the current index and returns the amount of whitespace chars skipped (0..n),
- *           or -1 if the end of the source was reached.
- * @property {function(): string} substringFromIndex creates a substring from the current index to the end of `source`
- * @property {function(compareWith: string): boolean} substringStartsWith checks if source contains `compareWith`,
- *           starting from the current index
- *
+ * @property {function(relativeIndex: number?): string | undefined} char Provides look ahead access to a singe character relative
+ *   to the current index
+ * @property {function(): number} getIndex Provides read-only access to the current index
+ * @property {function(reg: RegExp): string | null} getMatch Applies the provided regular expression enforcing that it starts at
+ *   the current index and returns the complete matching string, and moves the current index by the length of the matching
+ *   string.
+ * @property {function(): string} getSource Provides read-only access to the complete source
+ * @property {function(places: number?): void} skip Moves the current index by places (defaults to 1)
+ * @property {function(): number} skipBlanks Moves the current index by the amount of white space that directly follows the
+ *   current index and returns the amount of whitespace chars skipped (0..n), or -1 if the end of the source was reached.
+ * @property {function(): string} substringFromIndex Creates a substring from the current index to the end of `source`
+ * @property {function(compareWith: string): boolean} substringStartsWith Checks if source contains `compareWith`, starting from
+ *   the current index
  * @see parseUtils
  */
 
 /**
- * A temporary scope for parsing and look ahead operations in `source`,
- * starting from index `start`.
+ * A temporary scope for parsing and look ahead operations in `source`, starting from index `start`.
  *
- * Some operations move the current index by a number of positions,
- * after which `getIndex` returns the new index.
+ * Some operations move the current index by a number of positions, after which `getIndex` returns the new index.
  *
  * @param {string} source
  * @param {number} start
@@ -706,11 +699,12 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 
 /**
  * Called when the parser encounters an element starting with '<!'.
- * @param {string} source the xml
- * @param {number} start the start index of the '<!'
+ *
+ * @param {string} source The xml
+ * @param {number} start The start index of the '<!'
  * @param {DOMHandler} domBuilder
  * @param {DOMHandler} errorHandler
- * @returns {number|never} the end index of the element
+ * @returns {number | never} The end index of the element
  * @throws ParseError in case the element is not well-formed
  */
 function parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler) {

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -540,28 +540,25 @@ function _copy(source, target) {
 
 /**
  * @typedef ParseUtils
- * @property {function(relativeIndex: number?): string | undefined} char                 Provides look ahead access to a singe
- *                                                                                       character relative to the current index.
- * @property {function(): number}                                   getIndex             Provides read-only access to the current
- *                                                                                       index.
- * @property {function(reg: RegExp): string | null}                 getMatch             Applies the provided regular expression
- *                                                                                       enforcing that it starts at the current
- *                                                                                       index and returns the complete matching
- *                                                                                       string, and moves the current index by
- *                                                                                       the length of the matching string.
- * @property {function(): string}                                   getSource            Provides read-only access to the complete
- *                                                                                       source.
- * @property {function(places: number?): void}                      skip                 Moves the current index by places
- *                                                                                       (defaults to 1)
- * @property {function(): number}                                   skipBlanks           Moves the current index by the amount of
- *                                                                                       white space that directly follows the
- *                                                                                       current index and returns the amount of
- *                                                                                       whitespace chars skipped (0..n), or -1 if
- *                                                                                       the end of the source was reached.
- * @property {function(): string}                                   substringFromIndex   Creates a substring from the current
- *                                                                                       index to the end of `source`
- * @property {function(compareWith: string): boolean}               substringStartsWith  Checks if source contains `compareWith`,
- *                                                                                       starting from the current index.
+ * @property {function(relativeIndex: number?): string | undefined} char
+ * Provides look ahead access to a singe character relative to the current index.
+ * @property {function(): number} getIndex
+ * Provides read-only access to the current index.
+ * @property {function(reg: RegExp): string | null} getMatch
+ * Applies the provided regular expression enforcing that it starts at the current index and returns the complete matching string,
+ * and moves the current index by the length of the matching string.
+ * @property {function(): string} getSource
+ * Provides read-only access to the complete source.
+ * @property {function(places: number?): void} skip
+ * Moves the current index by places (defaults to 1)
+ * @property {function(): number} skipBlanks
+ * Moves the current index by the amount of white space that directly follows the current index and returns the amount of
+ * whitespace chars skipped (0..n), or -1 if the end of the source was reached.
+ * @property {function(): string} substringFromIndex
+ * Creates a substring from the current index to the end of `source`
+ * @property {function(compareWith: string): boolean} substringStartsWith
+ * Checks if source contains `compareWith`,
+ * starting from the current index.
  * @see ParseUtils.
  */
 
@@ -711,12 +708,15 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 /**
  * Called when the parser encounters an element starting with '<!'.
  *
- * @param {string}     source        The xml.
- * @param {number}     start         The start index of the '<!'
+ * @param {string} source
+ * The xml.
+ * @param {number} start
+ * The start index of the '<!'
  * @param {DOMHandler} domBuilder
  * @param {DOMHandler} errorHandler
  * @returns {number | never} The end index of the element.
- * @throws ParseError in case the element is not well-formed.
+ * @throws
+ * ParseError in case the element is not well-formed.
  */
 function parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler) {
 	var p = parseUtils(source, start);

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -414,9 +414,7 @@ function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, 
 	}
 }
 
-/**
- * @returns True if has new namespace define.
- */
+/** @returns True if has new namespace define */
 function appendElement(el, domBuilder, currentNSMap) {
 	var tagName = el.tagName;
 	var localNSMap = null;
@@ -540,29 +538,20 @@ function _copy(source, target) {
 
 /**
  * @typedef ParseUtils
- * @property {function(relativeIndex: number?): string | undefined} char                 Provides look ahead access to a singe
- *                                                                                       character relative to the current index.
- * @property {function(): number}                                   getIndex             Provides read-only access to the current
- *                                                                                       index.
- * @property {function(reg: RegExp): string | null}                 getMatch             Applies the provided regular expression
- *                                                                                       enforcing that it starts at the current
- *                                                                                       index and returns the complete matching
- *                                                                                       string, and moves the current index by
- *                                                                                       the length of the matching string.
- * @property {function(): string}                                   getSource            Provides read-only access to the complete
- *                                                                                       source.
- * @property {function(places: number?): void}                      skip                 Moves the current index by places
- *                                                                                       (defaults to 1)
- * @property {function(): number}                                   skipBlanks           Moves the current index by the amount of
- *                                                                                       white space that directly follows the
- *                                                                                       current index and returns the amount of
- *                                                                                       whitespace chars skipped (0..n), or -1 if
- *                                                                                       the end of the source was reached.
- * @property {function(): string}                                   substringFromIndex   Creates a substring from the current
- *                                                                                       index to the end of `source`
- * @property {function(compareWith: string): boolean}               substringStartsWith  Checks if source contains `compareWith`,
- *                                                                                       starting from the current index.
- * @see ParseUtils.
+ * @property {function(relativeIndex: number?): string | undefined} char Provides look ahead access to a singe character relative
+ *   to the current index
+ * @property {function(): number} getIndex Provides read-only access to the current index
+ * @property {function(reg: RegExp): string | null} getMatch Applies the provided regular expression enforcing that it starts at
+ *   the current index and returns the complete matching string, and moves the current index by the length of the matching
+ *   string.
+ * @property {function(): string} getSource Provides read-only access to the complete source
+ * @property {function(places: number?): void} skip Moves the current index by places (defaults to 1)
+ * @property {function(): number} skipBlanks Moves the current index by the amount of white space that directly follows the
+ *   current index and returns the amount of whitespace chars skipped (0..n), or -1 if the end of the source was reached.
+ * @property {function(): string} substringFromIndex Creates a substring from the current index to the end of `source`
+ * @property {function(compareWith: string): boolean} substringStartsWith Checks if source contains `compareWith`, starting from
+ *   the current index
+ * @see parseUtils
  */
 
 /**
@@ -711,12 +700,12 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 /**
  * Called when the parser encounters an element starting with '<!'.
  *
- * @param {string}     source        The xml.
- * @param {number}     start         The start index of the '<!'
+ * @param {string} source The xml
+ * @param {number} start The start index of the '<!'
  * @param {DOMHandler} domBuilder
  * @param {DOMHandler} errorHandler
- * @returns {number | never} The end index of the element.
- * @throws ParseError in case the element is not well-formed.
+ * @returns {number | never} The end index of the element
+ * @throws ParseError in case the element is not well-formed
  */
 function parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler) {
 	var p = parseUtils(source, start);

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -719,8 +719,8 @@ function parseDoctypeInternalSubset(p, errorHandler) {
  * @param {DOMHandler} domBuilder
  * @param {DOMHandler} errorHandler
  * @returns {number | never} The end index of the element.
- * @throws
- * ParseError in case the element is not well-formed.
+ * @throws {ParseError}
+ * In case the element is not well-formed.
  */
 function parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler) {
 	var p = parseUtils(source, start);

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -415,7 +415,7 @@ function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, 
 }
 
 /**
- * @returns True if has new namespace define.
+ * @returns `true` if a new namespace has been defined.
  */
 function appendElement(el, domBuilder, currentNSMap) {
 	var tagName = el.tagName;

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -216,7 +216,7 @@ function copyLocator(f, t) {
 
 /**
  * @returns end of the elementStartPart(end of elementEndPart for selfClosed el)
- * @see #appendElement(source,elStartEnd,el,selfClosed,entityReplacer,domBuilder,parseStack);
+ * @see {@link #appendElement}
  */
 function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, errorHandler, isHTML) {
 	/**
@@ -545,22 +545,23 @@ function _copy(source, target) {
  * @property {function(): number} getIndex
  * Provides read-only access to the current index.
  * @property {function(reg: RegExp): string | null} getMatch
- * Applies the provided regular expression enforcing that it starts at the current index and returns the complete matching string,
+ * Applies the provided regular expression enforcing that it starts at the current index and
+ * returns the complete matching string,
  * and moves the current index by the length of the matching string.
  * @property {function(): string} getSource
  * Provides read-only access to the complete source.
  * @property {function(places: number?): void} skip
  * moves the current index by places (defaults to 1)
  * @property {function(): number} skipBlanks
- * Moves the current index by the amount of white space that directly follows the current index and returns the amount of
- * whitespace chars skipped (0..n),
+ * Moves the current index by the amount of white space that directly follows the current index
+ * and returns the amount of whitespace chars skipped (0..n),
  * or -1 if the end of the source was reached.
  * @property {function(): string} substringFromIndex
  * creates a substring from the current index to the end of `source`
  * @property {function(compareWith: string): boolean} substringStartsWith
  * Checks if source contains `compareWith`,
  * starting from the current index.
- * @see ParseUtils.
+ * @see {@link parseUtils}
  */
 
 /**

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -215,8 +215,8 @@ function copyLocator(f, t) {
 }
 
 /**
- * @returns End of the elementStartPart(end of elementEndPart for selfClosed el)
  * @see #appendElement(source,elStartEnd,el,selfClosed,entityReplacer,domBuilder,parseStack);
+ * @return end of the elementStartPart(end of elementEndPart for selfClosed el)
  */
 function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, errorHandler, isHTML) {
 	/**
@@ -414,7 +414,9 @@ function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, 
 	}
 }
 
-/** @returns True if has new namespace define */
+/**
+ * @return true if has new namespace define
+ */
 function appendElement(el, domBuilder, currentNSMap) {
 	var tagName = el.tagName;
 	var localNSMap = null;
@@ -538,26 +540,31 @@ function _copy(source, target) {
 
 /**
  * @typedef ParseUtils
- * @property {function(relativeIndex: number?): string | undefined} char Provides look ahead access to a singe character relative
- *   to the current index
- * @property {function(): number} getIndex Provides read-only access to the current index
- * @property {function(reg: RegExp): string | null} getMatch Applies the provided regular expression enforcing that it starts at
- *   the current index and returns the complete matching string, and moves the current index by the length of the matching
- *   string.
- * @property {function(): string} getSource Provides read-only access to the complete source
- * @property {function(places: number?): void} skip Moves the current index by places (defaults to 1)
- * @property {function(): number} skipBlanks Moves the current index by the amount of white space that directly follows the
- *   current index and returns the amount of whitespace chars skipped (0..n), or -1 if the end of the source was reached.
- * @property {function(): string} substringFromIndex Creates a substring from the current index to the end of `source`
- * @property {function(compareWith: string): boolean} substringStartsWith Checks if source contains `compareWith`, starting from
- *   the current index
+ * @property {function(relativeIndex: number?): string | undefined} char provides look ahead access
+ *           to a singe character relative to the current index
+ * @property {function(): number} getIndex provides read-only access to the current index
+ * @property {function(reg: RegExp): string | null} getMatch applies the provided regular expression
+ *           enforcing that it starts at the current index and returns the complete matching string,
+ *           and moves the current index by the length of the matching string.
+ * @property {function(): string} getSource provides read-only access to the complete source
+ * @property {function(places: number?): void} skip moves the current index
+ *           by places (defaults to 1)
+ * @property {function(): number} skipBlanks moves the current index by the amount of white space
+ *           that directly follows the current index and returns the amount of whitespace chars skipped (0..n),
+ *           or -1 if the end of the source was reached.
+ * @property {function(): string} substringFromIndex creates a substring from the current index to the end of `source`
+ * @property {function(compareWith: string): boolean} substringStartsWith checks if source contains `compareWith`,
+ *           starting from the current index
+ *
  * @see parseUtils
  */
 
 /**
- * A temporary scope for parsing and look ahead operations in `source`, starting from index `start`.
+ * A temporary scope for parsing and look ahead operations in `source`,
+ * starting from index `start`.
  *
- * Some operations move the current index by a number of positions, after which `getIndex` returns the new index.
+ * Some operations move the current index by a number of positions,
+ * after which `getIndex` returns the new index.
  *
  * @param {string} source
  * @param {number} start
@@ -699,12 +706,11 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 
 /**
  * Called when the parser encounters an element starting with '<!'.
- *
- * @param {string} source The xml
- * @param {number} start The start index of the '<!'
+ * @param {string} source the xml
+ * @param {number} start the start index of the '<!'
  * @param {DOMHandler} domBuilder
  * @param {DOMHandler} errorHandler
- * @returns {number | never} The end index of the element
+ * @returns {number|never} the end index of the element
  * @throws ParseError in case the element is not well-formed
  */
 function parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler) {

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -215,8 +215,8 @@ function copyLocator(f, t) {
 }
 
 /**
+ * @returns end of the elementStartPart(end of elementEndPart for selfClosed el)
  * @see #appendElement(source,elStartEnd,el,selfClosed,entityReplacer,domBuilder,parseStack);
- * @return end of the elementStartPart(end of elementEndPart for selfClosed el)
  */
 function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, errorHandler, isHTML) {
 	/**
@@ -415,7 +415,7 @@ function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, 
 }
 
 /**
- * @return true if has new namespace define
+ * @returns True if has new namespace define.
  */
 function appendElement(el, domBuilder, currentNSMap) {
 	var tagName = el.tagName;
@@ -540,23 +540,27 @@ function _copy(source, target) {
 
 /**
  * @typedef ParseUtils
- * @property {function(relativeIndex: number?): string | undefined} char provides look ahead access
- *           to a singe character relative to the current index
- * @property {function(): number} getIndex provides read-only access to the current index
- * @property {function(reg: RegExp): string | null} getMatch applies the provided regular expression
- *           enforcing that it starts at the current index and returns the complete matching string,
- *           and moves the current index by the length of the matching string.
- * @property {function(): string} getSource provides read-only access to the complete source
- * @property {function(places: number?): void} skip moves the current index
- *           by places (defaults to 1)
- * @property {function(): number} skipBlanks moves the current index by the amount of white space
- *           that directly follows the current index and returns the amount of whitespace chars skipped (0..n),
- *           or -1 if the end of the source was reached.
- * @property {function(): string} substringFromIndex creates a substring from the current index to the end of `source`
- * @property {function(compareWith: string): boolean} substringStartsWith checks if source contains `compareWith`,
- *           starting from the current index
- *
- * @see parseUtils
+ * @property {function(relativeIndex: number?): string | undefined} char
+ * Provides look ahead access to a singe character relative to the current index.
+ * @property {function(): number} getIndex
+ * Provides read-only access to the current index.
+ * @property {function(reg: RegExp): string | null} getMatch
+ * Applies the provided regular expression enforcing that it starts at the current index and returns the complete matching string,
+ * and moves the current index by the length of the matching string.
+ * @property {function(): string} getSource
+ * Provides read-only access to the complete source.
+ * @property {function(places: number?): void} skip
+ * moves the current index by places (defaults to 1)
+ * @property {function(): number} skipBlanks
+ * Moves the current index by the amount of white space that directly follows the current index and returns the amount of
+ * whitespace chars skipped (0..n),
+ * or -1 if the end of the source was reached.
+ * @property {function(): string} substringFromIndex
+ * creates a substring from the current index to the end of `source`
+ * @property {function(compareWith: string): boolean} substringStartsWith
+ * Checks if source contains `compareWith`,
+ * starting from the current index.
+ * @see ParseUtils.
  */
 
 /**
@@ -706,12 +710,16 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 
 /**
  * Called when the parser encounters an element starting with '<!'.
- * @param {string} source the xml
- * @param {number} start the start index of the '<!'
+ *
+ * @param {string} source
+ * The xml.
+ * @param {number} start
+ * the start index of the '<!'
  * @param {DOMHandler} domBuilder
  * @param {DOMHandler} errorHandler
- * @returns {number|never} the end index of the element
- * @throws ParseError in case the element is not well-formed
+ * @returns {number | never} The end index of the element.
+ * @throws
+ * ParseError in case the element is not well-formed.
  */
 function parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler) {
 	var p = parseUtils(source, start);

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -414,7 +414,9 @@ function parseElementStartPart(source, start, el, currentNSMap, entityReplacer, 
 	}
 }
 
-/** @returns True if has new namespace define */
+/**
+ * @returns True if has new namespace define.
+ */
 function appendElement(el, domBuilder, currentNSMap) {
 	var tagName = el.tagName;
 	var localNSMap = null;
@@ -538,20 +540,29 @@ function _copy(source, target) {
 
 /**
  * @typedef ParseUtils
- * @property {function(relativeIndex: number?): string | undefined} char Provides look ahead access to a singe character relative
- *   to the current index
- * @property {function(): number} getIndex Provides read-only access to the current index
- * @property {function(reg: RegExp): string | null} getMatch Applies the provided regular expression enforcing that it starts at
- *   the current index and returns the complete matching string, and moves the current index by the length of the matching
- *   string.
- * @property {function(): string} getSource Provides read-only access to the complete source
- * @property {function(places: number?): void} skip Moves the current index by places (defaults to 1)
- * @property {function(): number} skipBlanks Moves the current index by the amount of white space that directly follows the
- *   current index and returns the amount of whitespace chars skipped (0..n), or -1 if the end of the source was reached.
- * @property {function(): string} substringFromIndex Creates a substring from the current index to the end of `source`
- * @property {function(compareWith: string): boolean} substringStartsWith Checks if source contains `compareWith`, starting from
- *   the current index
- * @see parseUtils
+ * @property {function(relativeIndex: number?): string | undefined} char                 Provides look ahead access to a singe
+ *                                                                                       character relative to the current index.
+ * @property {function(): number}                                   getIndex             Provides read-only access to the current
+ *                                                                                       index.
+ * @property {function(reg: RegExp): string | null}                 getMatch             Applies the provided regular expression
+ *                                                                                       enforcing that it starts at the current
+ *                                                                                       index and returns the complete matching
+ *                                                                                       string, and moves the current index by
+ *                                                                                       the length of the matching string.
+ * @property {function(): string}                                   getSource            Provides read-only access to the complete
+ *                                                                                       source.
+ * @property {function(places: number?): void}                      skip                 Moves the current index by places
+ *                                                                                       (defaults to 1)
+ * @property {function(): number}                                   skipBlanks           Moves the current index by the amount of
+ *                                                                                       white space that directly follows the
+ *                                                                                       current index and returns the amount of
+ *                                                                                       whitespace chars skipped (0..n), or -1 if
+ *                                                                                       the end of the source was reached.
+ * @property {function(): string}                                   substringFromIndex   Creates a substring from the current
+ *                                                                                       index to the end of `source`
+ * @property {function(compareWith: string): boolean}               substringStartsWith  Checks if source contains `compareWith`,
+ *                                                                                       starting from the current index.
+ * @see ParseUtils.
  */
 
 /**
@@ -700,12 +711,12 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 /**
  * Called when the parser encounters an element starting with '<!'.
  *
- * @param {string} source The xml
- * @param {number} start The start index of the '<!'
+ * @param {string}     source        The xml.
+ * @param {number}     start         The start index of the '<!'
  * @param {DOMHandler} domBuilder
  * @param {DOMHandler} errorHandler
- * @returns {number | never} The end index of the element
- * @throws ParseError in case the element is not well-formed
+ * @returns {number | never} The end index of the element.
+ * @throws ParseError in case the element is not well-formed.
  */
 function parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler) {
 	var p = parseUtils(source, start);

--- a/package-lock.json
+++ b/package-lock.json
@@ -905,6 +905,15 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -953,10 +962,25 @@
         "@types/node": "*"
       }
     },
+    "@types/mdast": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
+      "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2"
+      }
+    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -996,6 +1020,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
       "dev": true
     },
     "@types/yargs": {
@@ -1488,6 +1518,12 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "binary-searching": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-searching/-/binary-searching-2.0.5.tgz",
+      "integrity": "sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==",
+      "dev": true
+    },
     "boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -1699,6 +1735,12 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -1877,6 +1919,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2026,6 +2074,15 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
+    "decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dev": true,
+      "requires": {
+        "character-entities": "^2.0.0"
+      }
+    },
     "decompress-response": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
@@ -2087,10 +2144,22 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
       "dev": true
     },
     "diff-sequences": {
@@ -2645,9 +2714,9 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "fast-glob": {
@@ -4753,6 +4822,35 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
+    "mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0"
+      }
+    },
     "meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -4790,6 +4888,238 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "dev": true,
+      "requires": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "dev": true,
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "dev": true,
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "dev": true,
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "dev": true,
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "dev": true,
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "dev": true
+    },
+    "micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "dev": true
+    },
+    "micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "dev": true,
+      "requires": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "dev": true,
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "dev": true
+    },
+    "micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
       "dev": true
     },
     "micromatch": {
@@ -4868,6 +5198,12 @@
         "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
       }
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -5725,6 +6061,17 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "prettier-plugin-jsdoc": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-0.4.2.tgz",
+      "integrity": "sha512-w2jnAQm3z0GAG0bhzVJeehzDtrhGMSxJjit5ApCc2oxWfc7+jmLAkbtdOXaSpfwZz3IWkk+PiQPeRrLNpbM+Mw==",
+      "dev": true,
+      "requires": {
+        "binary-searching": "^2.0.5",
+        "comment-parser": "^1.3.1",
+        "mdast-util-from-markdown": "^1.2.0"
+      }
+    },
     "pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -6044,6 +6391,15 @@
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
+      }
+    },
+    "sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "requires": {
+        "mri": "^1.1.0"
       }
     },
     "safe-buffer": {
@@ -6508,6 +6864,15 @@
         "crypto-random-string": "^2.0.0"
       }
     },
+    "unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -6588,6 +6953,26 @@
       "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
+      }
+    },
+    "uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+          "dev": true
+        }
       }
     },
     "v8-to-istanbul": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -471,6 +471,17 @@
       "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
       "dev": true
     },
+    "@homer0/prettier-plugin-jsdoc": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@homer0/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-6.0.5.tgz",
+      "integrity": "sha512-yfAsz6fmZCToLeUq575ktaGqcoTsLmcbnV7y9UDA4lylcJmI5tKJxkzPcREhO7jjMucCdmL5KOt7zKBDu5v0Mg==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^1.3.1",
+        "prettier": "^2.8.8",
+        "ramda": "0.29.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -1876,6 +1887,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -5809,6 +5826,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
       "dev": true
     },
     "rc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -905,15 +905,6 @@
         "@types/responselike": "^1.0.0"
       }
     },
-    "@types/debug": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-      "dev": true,
-      "requires": {
-        "@types/ms": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -962,25 +953,10 @@
         "@types/node": "*"
       }
     },
-    "@types/mdast": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
-      "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2"
-      }
-    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-      "dev": true
-    },
-    "@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -1020,12 +996,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "@types/unist": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
-      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
       "dev": true
     },
     "@types/yargs": {
@@ -1518,12 +1488,6 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
-    "binary-searching": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/binary-searching/-/binary-searching-2.0.5.tgz",
-      "integrity": "sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==",
-      "dev": true
-    },
     "boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -1735,12 +1699,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
-    "character-entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
-      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true
-    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -1919,12 +1877,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "comment-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
-      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
-      "dev": true
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2074,15 +2026,6 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
-    "decode-named-character-reference": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
-      "dev": true,
-      "requires": {
-        "character-entities": "^2.0.0"
-      }
-    },
     "decompress-response": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
@@ -2144,22 +2087,10 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true
-    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true
-    },
-    "diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
       "dev": true
     },
     "diff-sequences": {
@@ -2714,9 +2645,9 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -4822,35 +4753,6 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
-    "mdast-util-from-markdown": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
-      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
-      "dev": true,
-      "requires": {
-        "@types/mdast": "^3.0.0",
-        "@types/unist": "^2.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "mdast-util-to-string": "^3.1.0",
-        "micromark": "^3.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-decode-string": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "unist-util-stringify-position": "^3.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "mdast-util-to-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
-      "dev": true,
-      "requires": {
-        "@types/mdast": "^3.0.0"
-      }
-    },
     "meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -4888,238 +4790,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
-    },
-    "micromark": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
-      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
-      "dev": true,
-      "requires": {
-        "@types/debug": "^4.0.0",
-        "debug": "^4.0.0",
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-core-commonmark": "^1.0.1",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-combine-extensions": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-sanitize-uri": "^1.0.0",
-        "micromark-util-subtokenize": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.1",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-core-commonmark": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
-      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
-      "dev": true,
-      "requires": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-factory-destination": "^1.0.0",
-        "micromark-factory-label": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-factory-title": "^1.0.0",
-        "micromark-factory-whitespace": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-classify-character": "^1.0.0",
-        "micromark-util-html-tag-name": "^1.0.0",
-        "micromark-util-normalize-identifier": "^1.0.0",
-        "micromark-util-resolve-all": "^1.0.0",
-        "micromark-util-subtokenize": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.1",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-factory-destination": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
-      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
-      "dev": true,
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-factory-label": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
-      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
-      "dev": true,
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-factory-space": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
-      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
-      "dev": true,
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-factory-title": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
-      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
-      "dev": true,
-      "requires": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-factory-whitespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
-      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
-      "dev": true,
-      "requires": {
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-character": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
-      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
-      "dev": true,
-      "requires": {
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-chunked": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
-      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
-      "dev": true,
-      "requires": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-classify-character": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
-      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
-      "dev": true,
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-combine-extensions": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
-      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
-      "dev": true,
-      "requires": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-decode-numeric-character-reference": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
-      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
-      "dev": true,
-      "requires": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-decode-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
-      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
-      "dev": true,
-      "requires": {
-        "decode-named-character-reference": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-decode-numeric-character-reference": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
-      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
-      "dev": true
-    },
-    "micromark-util-html-tag-name": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
-      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
-      "dev": true
-    },
-    "micromark-util-normalize-identifier": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
-      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
-      "dev": true,
-      "requires": {
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-resolve-all": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
-      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
-      "dev": true,
-      "requires": {
-        "micromark-util-types": "^1.0.0"
-      }
-    },
-    "micromark-util-sanitize-uri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
-      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
-      "dev": true,
-      "requires": {
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-encode": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0"
-      }
-    },
-    "micromark-util-subtokenize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
-      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
-      "dev": true,
-      "requires": {
-        "micromark-util-chunked": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
-    "micromark-util-symbol": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
-      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
-      "dev": true
-    },
-    "micromark-util-types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
-      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
       "dev": true
     },
     "micromatch": {
@@ -5198,12 +4868,6 @@
         "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
       }
-    },
-    "mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -6061,17 +5725,6 @@
         "fast-diff": "^1.1.2"
       }
     },
-    "prettier-plugin-jsdoc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-0.4.2.tgz",
-      "integrity": "sha512-w2jnAQm3z0GAG0bhzVJeehzDtrhGMSxJjit5ApCc2oxWfc7+jmLAkbtdOXaSpfwZz3IWkk+PiQPeRrLNpbM+Mw==",
-      "dev": true,
-      "requires": {
-        "binary-searching": "^2.0.5",
-        "comment-parser": "^1.3.1",
-        "mdast-util-from-markdown": "^1.2.0"
-      }
-    },
     "pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -6391,15 +6044,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
-      }
-    },
-    "sade": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-      "dev": true,
-      "requires": {
-        "mri": "^1.1.0"
       }
     },
     "safe-buffer": {
@@ -6864,15 +6508,6 @@
         "crypto-random-string": "^2.0.0"
       }
     },
-    "unist-util-stringify-position": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
-      "dev": true,
-      "requires": {
-        "@types/unist": "^2.0.0"
-      }
-    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -6953,26 +6588,6 @@
       "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
-      }
-    },
-    "uvu": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
-      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
-      "dev": true,
-      "requires": {
-        "dequal": "^2.0.0",
-        "diff": "^5.0.0",
-        "kleur": "^4.0.3",
-        "sade": "^1.7.3"
-      },
-      "dependencies": {
-        "kleur": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-          "dev": true
-        }
       }
     },
     "v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@homer0/prettier-plugin-jsdoc": "6.0.5",
     "auto-changelog": "2.4.0",
     "eslint": "8.44.0",
     "eslint-config-prettier": "8.8.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "nodemon": "3.0.1",
     "np": "7.7.0",
     "prettier": "2.8.8",
-    "prettier-plugin-jsdoc": "0.4.2",
     "rxjs": "7.8.1",
     "xmltest": "1.5.0",
     "yauzl": "2.10.0"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "nodemon": "3.0.1",
     "np": "7.7.0",
     "prettier": "2.8.8",
+    "prettier-plugin-jsdoc": "0.4.2",
     "rxjs": "7.8.1",
     "xmltest": "1.5.0",
     "yauzl": "2.10.0"

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -17,8 +17,9 @@ const INPUT = (first = '', second = '', third = '', fourth = '') => `
 `;
 
 /**
- * Whitespace that can be part of classnames. Some characters (like `\u2028`) will be normalized when parsing, but they can still
- * be added to the dom after parsing.
+ * Whitespace that can be part of classnames.
+ * Some characters (like `\u2028`) will be normalized when parsing,
+ * but they can still be added to the dom after parsing.
  *
  * @see https://www.w3.org/TR/html52/infrastructure.html#set-of-space-separated-tokens
  * @see normalizeLineEndings

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -17,9 +17,8 @@ const INPUT = (first = '', second = '', third = '', fourth = '') => `
 `;
 
 /**
- * Whitespace that can be part of classnames.
- * Some characters (like `\u2028`) will be normalized when parsing,
- * but they can still be added to the dom after parsing.
+ * Whitespace that can be part of classnames. Some characters (like `\u2028`) will be normalized when parsing, but they can still
+ * be added to the dom after parsing.
  *
  * @see https://www.w3.org/TR/html52/infrastructure.html#set-of-space-separated-tokens
  * @see normalizeLineEndings

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -21,7 +21,7 @@ const INPUT = (first = '', second = '', third = '', fourth = '') => `
  * be added to the dom after parsing.
  *
  * @see https://www.w3.org/TR/html52/infrastructure.html#set-of-space-separated-tokens
- * @see NormalizeLineEndings.
+ * @see normalizeLineEndings
  * @see https://www.w3.org/TR/xml11/#sec-line-ends
  */
 const NON_HTML_WHITESPACE =

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -22,7 +22,7 @@ const INPUT = (first = '', second = '', third = '', fourth = '') => `
  * but they can still be added to the dom after parsing.
  *
  * @see https://www.w3.org/TR/html52/infrastructure.html#set-of-space-separated-tokens
- * @see normalizeLineEndings
+ * @see NormalizeLineEndings.
  * @see https://www.w3.org/TR/xml11/#sec-line-ends
  */
 const NON_HTML_WHITESPACE =

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -22,7 +22,7 @@ const INPUT = (first = '', second = '', third = '', fourth = '') => `
  * but they can still be added to the dom after parsing.
  *
  * @see https://www.w3.org/TR/html52/infrastructure.html#set-of-space-separated-tokens
- * @see NormalizeLineEndings.
+ * @see {@link normalizeLineEndings}
  * @see https://www.w3.org/TR/xml11/#sec-line-ends
  */
 const NON_HTML_WHITESPACE =

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -21,7 +21,7 @@ const INPUT = (first = '', second = '', third = '', fourth = '') => `
  * be added to the dom after parsing.
  *
  * @see https://www.w3.org/TR/html52/infrastructure.html#set-of-space-separated-tokens
- * @see normalizeLineEndings
+ * @see NormalizeLineEndings.
  * @see https://www.w3.org/TR/xml11/#sec-line-ends
  */
 const NON_HTML_WHITESPACE =

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -61,14 +61,13 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
 
 /**
  * Creates a string from an error that is easily readable in a snapshot
- *
- * - Put's the message on one line as first line
- * - Picks the first line in the stack trace that is in `libFile`, and strips absolute paths and character position from that stack
- *   entry as second line. the line number in the stack is converted to the error index (to only have relevant changes in
- *   snapshots).
- *
+ * - put's the message on one line as first line
+ * - picks the first line in the stack trace that is in `libFile`,
+ *   and strips absolute paths and character position from that stack entry
+ *   as second line. the line number in the stack is converted to the error index
+ *   (to only have relevant changes in snapshots).
  * @param {Error} error
- * @param {string} libFile The path from the root of the project that should be preserved in the stack
+ * @param {string} libFile the path from the root of the project that should be preserved in the stack
  * @returns {string}
  */
 function toErrorSnapshot(error, libFile) {

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -66,8 +66,9 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
  * absolute paths and character position from that stack entry as second line. the line number in the stack is converted to the
  * error index (to only have relevant changes in snapshots).
  *
- * @param {Error}  error
- * @param {string} libFile  The path from the root of the project that should be preserved in the stack.
+ * @param {Error} error
+ * @param {string} libFile
+ * The path from the root of the project that should be preserved in the stack.
  * @returns {string}
  */
 function toErrorSnapshot(error, libFile) {

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -66,9 +66,8 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
  * absolute paths and character position from that stack entry as second line. the line number in the stack is converted to the
  * error index (to only have relevant changes in snapshots).
  *
- * @param {Error} error
- * @param {string} libFile
- * The path from the root of the project that should be preserved in the stack.
+ * @param {Error}  error
+ * @param {string} libFile  The path from the root of the project that should be preserved in the stack.
  * @returns {string}
  */
 function toErrorSnapshot(error, libFile) {

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -60,14 +60,14 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
 });
 
 /**
- * Creates a string from an error that is easily readable in a snapshot
- * - put's the message on one line as first line
- * - picks the first line in the stack trace that is in `libFile`,
- *   and strips absolute paths and character position from that stack entry
- *   as second line. the line number in the stack is converted to the error index
- *   (to only have relevant changes in snapshots).
+ * Creates a string from an error that is easily readable in a snapshot - put's the message on one line as first line - picks the
+ * first line in the stack trace that is in `libFile`,
+ * and strips absolute paths and character position from that stack entry as second line. the line number in the stack is
+ * converted to the error index (to only have relevant changes in snapshots).
+ *
  * @param {Error} error
- * @param {string} libFile the path from the root of the project that should be preserved in the stack
+ * @param {string} libFile
+ * The path from the root of the project that should be preserved in the stack.
  * @returns {string}
  */
 function toErrorSnapshot(error, libFile) {

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -62,13 +62,12 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
 /**
  * Creates a string from an error that is easily readable in a snapshot
  *
- * - Put's the message on one line as first line
- * - Picks the first line in the stack trace that is in `libFile`, and strips absolute paths and character position from that stack
- *   entry as second line. the line number in the stack is converted to the error index (to only have relevant changes in
- *   snapshots).
+ * - Put's the message on one line as first line - Picks the first line in the stack trace that is in `libFile`, and strips
+ * absolute paths and character position from that stack entry as second line. the line number in the stack is converted to the
+ * error index (to only have relevant changes in snapshots).
  *
- * @param {Error} error
- * @param {string} libFile The path from the root of the project that should be preserved in the stack
+ * @param {Error}  error
+ * @param {string} libFile  The path from the root of the project that should be preserved in the stack.
  * @returns {string}
  */
 function toErrorSnapshot(error, libFile) {

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -60,10 +60,11 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
 });
 
 /**
- * Creates a string from an error that is easily readable in a snapshot - put's the message on one line as first line - picks the
- * first line in the stack trace that is in `libFile`,
- * and strips absolute paths and character position from that stack entry as second line. the line number in the stack is
- * converted to the error index (to only have relevant changes in snapshots).
+ * Creates a string from an error that is easily readable in a snapshot - put's the message on
+ * one line as first line - picks the first line in the stack trace that is in `libFile`,
+ * and strips absolute paths and character position from that stack entry as second line.
+ * the line number in the stack is converted to the error index (to only have relevant changes
+ * in snapshots).
  *
  * @param {Error} error
  * @param {string} libFile

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -61,13 +61,14 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
 
 /**
  * Creates a string from an error that is easily readable in a snapshot
- * - put's the message on one line as first line
- * - picks the first line in the stack trace that is in `libFile`,
- *   and strips absolute paths and character position from that stack entry
- *   as second line. the line number in the stack is converted to the error index
- *   (to only have relevant changes in snapshots).
+ *
+ * - Put's the message on one line as first line
+ * - Picks the first line in the stack trace that is in `libFile`, and strips absolute paths and character position from that stack
+ *   entry as second line. the line number in the stack is converted to the error index (to only have relevant changes in
+ *   snapshots).
+ *
  * @param {Error} error
- * @param {string} libFile the path from the root of the project that should be preserved in the stack
+ * @param {string} libFile The path from the root of the project that should be preserved in the stack
  * @returns {string}
  */
 function toErrorSnapshot(error, libFile) {

--- a/test/error/reported-levels.test.js
+++ b/test/error/reported-levels.test.js
@@ -62,12 +62,13 @@ describe.each(Object.entries(REPORTED))('%s', (name, { source, level, match, ski
 /**
  * Creates a string from an error that is easily readable in a snapshot
  *
- * - Put's the message on one line as first line - Picks the first line in the stack trace that is in `libFile`, and strips
- * absolute paths and character position from that stack entry as second line. the line number in the stack is converted to the
- * error index (to only have relevant changes in snapshots).
+ * - Put's the message on one line as first line
+ * - Picks the first line in the stack trace that is in `libFile`, and strips absolute paths and character position from that stack
+ *   entry as second line. the line number in the stack is converted to the error index (to only have relevant changes in
+ *   snapshots).
  *
- * @param {Error}  error
- * @param {string} libFile  The path from the root of the project that should be preserved in the stack.
+ * @param {Error} error
+ * @param {string} libFile The path from the root of the project that should be preserved in the stack
  * @returns {string}
  */
 function toErrorSnapshot(error, libFile) {

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -4,10 +4,14 @@ const path = require('path');
 
 /**
  * @typedef ErrorReport
- * @property {string} source the XML snippet
- * @property {'error'|'warning'|'fatalError'} level the name of the method triggered
- * @property {?function(msg:string):boolean} match to pick the relevant report when there are multiple
- * @property {?boolean} skippedInHtml Is the error reported when parsing HTML?
+ * @property {string} source
+ * The XML snippet.
+ * @property {'error' | 'warning' | 'fatalError'} level
+ * The name of the method triggered.
+ * @property {?function(msg:string):boolean} match
+ * To pick the relevant report when there are multiple.
+ * @property {?boolean} skippedInHtml
+ * Is the error reported when parsing HTML?
  */
 /**
  * A collection of XML samples and related information that cause the XMLReader
@@ -29,8 +33,7 @@ const REPORTED = {
 	/**
 	 * Well-formedness constraint: Unique Att Spec
 	 *
-	 * An attribute name must not appear more than once
-	 * in the same start-tag or empty-element tag.
+	 * An attribute name must not appear more than once in the same start-tag or empty-element tag.
 	 *
 	 * In the browser:
 	 * - as XML it is reported as `error on line 1 at column 17: Attribute a redefined`
@@ -205,6 +208,7 @@ const REPORTED = {
 	 * - for HTML is yields `<doc a1></xml>` and is not reporting any issue.
 	 *
 	 * But the XML specifications does not allow that:
+	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Attribute
 	 */
@@ -216,6 +220,7 @@ const REPORTED = {
 	/**
 	 * In the browser this is not an issue at all, but just add an attribute without a value.
 	 * But the XML specifications does not allow that:
+	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Attribute
 	 */
@@ -226,10 +231,10 @@ const REPORTED = {
 		skippedInHtml: true,
 	},
 	/**
-	 * Triggered by lib/sax.js:376
-	 * This seems to only be reached when there are two subsequent attributes with a missing value
-	 * In the browser this is not an issue at all, but just add an attribute without a value.
+	 * Triggered by lib/sax.js:376 This seems to only be reached when there are two subsequent attributes with a missing value In the
+	 * browser this is not an issue at all, but just add an attribute without a value.
 	 * But the XML specifications does not allow that:
+	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Attribute
 	 */
@@ -248,10 +253,8 @@ const LINE_TO_ERROR_INDEX = {
 /**
  * To avoid to have exact lines in snapshots, but still being able to verify,
  * that a certain error was reported in the expected order,
- * this method indexes all cases of
- * - thrown errors
- * - calls to one of the errorHandler methods
- * and adds them to the exported LINE_TO_ERROR_INDEX.
+ * this method indexes all cases of - thrown errors - calls to one of the errorHandler methods and adds them to the exported
+ * LINE_TO_ERROR_INDEX.
  *
  * It also checks that every match configured in REPORTED only matches a single line,
  * and adds the related key to the index as `reportedAs`.
@@ -260,7 +263,8 @@ const LINE_TO_ERROR_INDEX = {
  * The result is written to reported.json for easier human introspection.
  * The file is only written, not read by any code, the source code is the only source of truth.
  *
- * @param fileNameInKey the part of the path that is supposed to be part of the key
+ * @param fileNameInKey
+ * The part of the path that is supposed to be part of the key.
  */
 function parseErrorLines(fileNameInKey) {
 	let errorIndex = 0;

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -8,9 +8,9 @@ const path = require('path');
  * The XML snippet.
  * @property {'error' | 'warning' | 'fatalError'} level
  * The name of the method triggered.
- * @property {?function(msg:string):boolean} match
+ * @property {function(msg:string):boolean} [match]
  * To pick the relevant report when there are multiple.
- * @property {?boolean} skippedInHtml
+ * @property {boolean} [skippedInHtml]
  * Is the error reported when parsing HTML?
  */
 /**

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -4,10 +4,10 @@ const path = require('path');
 
 /**
  * @typedef ErrorReport
- * @property {string} source The XML snippet
- * @property {'error' | 'warning' | 'fatalError'} level The name of the method triggered
- * @property {?function(msg:string):boolean} match To pick the relevant report when there are multiple
- * @property {boolean | null} skippedInHtml Is the error reported when parsing HTML?
+ * @property {string}                             source         The XML snippet.
+ * @property {'error' | 'warning' | 'fatalError'} level          The name of the method triggered.
+ * @property {?function(msg:string):boolean}      match          To pick the relevant report when there are multiple.
+ * @property {boolean | null}                     skippedInHtml  Is the error reported when parsing HTML?
  */
 /** A collection of XML samples and related information that cause the XMLReader to call methods on `errorHandler`. */
 const REPORTED = {
@@ -214,8 +214,8 @@ const REPORTED = {
 		skippedInHtml: true,
 	},
 	/**
-	 * Triggered by lib/sax.js:376 This seems to only be reached when there are two subsequent attributes with a missing value In
-	 * the browser this is not an issue at all, but just add an attribute without a value. But the XML specifications does not allow
+	 * Triggered by lib/sax.js:376 This seems to only be reached when there are two subsequent attributes with a missing value In the
+	 * browser this is not an issue at all, but just add an attribute without a value. But the XML specifications does not allow
 	 * that:
 	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
@@ -237,8 +237,7 @@ const LINE_TO_ERROR_INDEX = {
  * To avoid to have exact lines in snapshots, but still being able to verify, that a certain error was reported in the expected
  * order, this method indexes all cases of
  *
- * - Thrown errors
- * - Calls to one of the errorHandler methods and adds them to the exported LINE_TO_ERROR_INDEX.
+ * - Thrown errors - Calls to one of the errorHandler methods and adds them to the exported LINE_TO_ERROR_INDEX.
  *
  * It also checks that every match configured in REPORTED only matches a single line, and adds the related key to the index as
  * `reportedAs`. Any failing check will throw, so it prevents the tests from being executed.
@@ -246,7 +245,7 @@ const LINE_TO_ERROR_INDEX = {
  * The result is written to reported.json for easier human introspection. The file is only written, not read by any code, the
  * source code is the only source of truth.
  *
- * @param fileNameInKey The part of the path that is supposed to be part of the key
+ * @param fileNameInKey  The part of the path that is supposed to be part of the key.
  */
 function parseErrorLines(fileNameInKey) {
 	let errorIndex = 0;

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -4,14 +4,10 @@ const path = require('path');
 
 /**
  * @typedef ErrorReport
- * @property {string} source
- * The XML snippet.
- * @property {'error' | 'warning' | 'fatalError'} level
- * The name of the method triggered.
- * @property {?function(msg:string):boolean} match
- * To pick the relevant report when there are multiple.
- * @property {boolean | null} skippedInHtml
- * Is the error reported when parsing HTML?
+ * @property {string}                             source         The XML snippet.
+ * @property {'error' | 'warning' | 'fatalError'} level          The name of the method triggered.
+ * @property {?function(msg:string):boolean}      match          To pick the relevant report when there are multiple.
+ * @property {boolean | null}                     skippedInHtml  Is the error reported when parsing HTML?
  */
 /** A collection of XML samples and related information that cause the XMLReader to call methods on `errorHandler`. */
 const REPORTED = {
@@ -249,8 +245,7 @@ const LINE_TO_ERROR_INDEX = {
  * The result is written to reported.json for easier human introspection. The file is only written, not read by any code, the
  * source code is the only source of truth.
  *
- * @param fileNameInKey
- * The part of the path that is supposed to be part of the key.
+ * @param fileNameInKey  The part of the path that is supposed to be part of the key.
  */
 function parseErrorLines(fileNameInKey) {
 	let errorIndex = 0;

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -4,16 +4,19 @@ const path = require('path');
 
 /**
  * @typedef ErrorReport
- * @property {string} source The XML snippet
- * @property {'error' | 'warning' | 'fatalError'} level The name of the method triggered
- * @property {?function(msg:string):boolean} match To pick the relevant report when there are multiple
- * @property {boolean | null} skippedInHtml Is the error reported when parsing HTML?
+ * @property {string} source the XML snippet
+ * @property {'error'|'warning'|'fatalError'} level the name of the method triggered
+ * @property {?function(msg:string):boolean} match to pick the relevant report when there are multiple
+ * @property {?boolean} skippedInHtml Is the error reported when parsing HTML?
  */
-/** A collection of XML samples and related information that cause the XMLReader to call methods on `errorHandler`. */
+/**
+ * A collection of XML samples and related information that cause the XMLReader
+ * to call methods on `errorHandler`.
+ */
 const REPORTED = {
 	/**
-	 * Entities need to be in the entityMap to be converted as part of parsing. xmldom currently doesn't parse entities declared in
-	 * DTD.
+	 * Entities need to be in the entityMap to be converted as part of parsing.
+	 * xmldom currently doesn't parse entities declared in DTD.
 	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#wf-entdeclared
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#wf-entdeclared
@@ -26,15 +29,16 @@ const REPORTED = {
 	/**
 	 * Well-formedness constraint: Unique Att Spec
 	 *
-	 * An attribute name must not appear more than once in the same start-tag or empty-element tag.
+	 * An attribute name must not appear more than once
+	 * in the same start-tag or empty-element tag.
 	 *
 	 * In the browser:
+	 * - as XML it is reported as `error on line 1 at column 17: Attribute a redefined`
+	 * - as HTML only the first definition is considered
 	 *
-	 * - As XML it is reported as `error on line 1 at column 17: Attribute a redefined`
-	 * - As HTML only the first definition is considered
-	 *
-	 * In xmldom the behavior is different for namespaces (picks first) than for other attributes (picks last), which can be a
-	 * security issue.
+	 * In xmldom the behavior is different for namespaces (picks first)
+	 * than for other attributes (picks last),
+	 * which can be a security issue.
 	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#uniqattspec
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#uniqattspec
@@ -45,8 +49,9 @@ const REPORTED = {
 		match: (msg) => /Attribute .* redefined/.test(msg),
 	},
 	/**
-	 * This sample doesn't follow the specified grammar. In the browser it is reported as `error on line 1 at column 14: expected
-	 * '>'`, but still adds the root level element to the dom.
+	 * This sample doesn't follow the specified grammar.
+	 * In the browser it is reported as `error on line 1 at column 14: expected '>'`,
+	 * but still adds the root level element to the dom.
 	 */
 	SYNTAX_EndTagNotComplete: {
 		source: '<xml></xml',
@@ -54,8 +59,9 @@ const REPORTED = {
 		match: (msg) => /end tag name/.test(msg) && /is not complete/.test(msg),
 	},
 	/**
-	 * This sample doesn't follow the specified grammar. In the browser it is reported as `error on line 1 at column 21: expected
-	 * '>'`, but still adds the root level element and inner tag to the dom.
+	 * This sample doesn't follow the specified grammar.
+	 * In the browser it is reported as `error on line 1 at column 21: expected '>'`,
+	 * but still adds the root level element and inner tag to the dom.
 	 */
 	SYNTAX_EndTagMaybeNotComplete: {
 		source: '<xml><inner></inner </xml>',
@@ -64,8 +70,8 @@ const REPORTED = {
 		match: (msg) => /end tag name/.test(msg) && /maybe not complete/.test(msg),
 	},
 	/**
-	 * This sample doesn't follow the specified grammar. In the browser it is reported as `error on line 1 at column 6: Comment not
-	 * terminated`.
+	 * This sample doesn't follow the specified grammar.
+	 * In the browser it is reported as `error on line 1 at column 6: Comment not terminated`.
 	 */
 	WF_UnclosedComment: {
 		source: '<xml></xml><!--',
@@ -73,10 +79,13 @@ const REPORTED = {
 		match: (msg) => /comment is not well-formed/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:596, caught in 208 This sample doesn't follow the specified grammar. In the browser:
+	 * Triggered by lib/sax.js:596, caught in 208
+	 * This sample doesn't follow the specified grammar.
+	 * In the browser:
+	 * - as XML it is reported as
+	 * `error on line 1 at column 2: StartTag: invalid element name`
+	 * - as HTML it is accepted as characters
 	 *
-	 * - As XML it is reported as `error on line 1 at column 2: StartTag: invalid element name`
-	 * - As HTML it is accepted as characters
 	 */
 	SYNTAX_InvalidTagName: {
 		source: '<xml><123 /></xml>',
@@ -84,10 +93,12 @@ const REPORTED = {
 		match: (msg) => /invalid tagName/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:602, caught in 208 This sample doesn't follow the specified grammar. In the browser:
-	 *
-	 * - As XML it is reported as `error on line 1 at column 6: error parsing attribute name`
-	 * - As HTML it is accepted as attribute name
+	 * Triggered by lib/sax.js:602, caught in 208
+	 * This sample doesn't follow the specified grammar.
+	 * In the browser:
+	 * - as XML it is reported as
+	 * `error on line 1 at column 6: error parsing attribute name`
+	 * - as HTML it is accepted as attribute name
 	 */
 	SYNTAX_InvalidAttributeName: {
 		source: '<xml><child 123=""/></xml>',
@@ -95,8 +106,8 @@ const REPORTED = {
 		match: (msg) => /invalid attribute/.test(msg),
 	},
 	/**
-	 * This sample doesn't follow the specified grammar. In the browser it is reported as `error on line 1 at column 5: Couldn't
-	 * find end of Start Tag xml`.
+	 * This sample doesn't follow the specified grammar.
+	 * In the browser it is reported as `error on line 1 at column 5: Couldn't find end of Start Tag xml`.
 	 */
 	SYNTAX_UnexpectedEndOfInput: {
 		source: '<xml',
@@ -104,10 +115,11 @@ const REPORTED = {
 		match: (msg) => /unexpected end of input/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:392, caught in 208 This sample doesn't follow the specified grammar. In the browser:
-	 *
-	 * - In XML it is reported as `error on line 1 at column 8: error parsing attribute name`
-	 * - In HTML it produces `<xml><a <="" xml=""></a></xml>` (invalid XML?)
+	 * Triggered by lib/sax.js:392, caught in 208
+	 * This sample doesn't follow the specified grammar.
+	 * In the browser:
+	 * - in XML it is reported as `error on line 1 at column 8: error parsing attribute name`
+	 * - in HTML it produces `<xml><a <="" xml=""></a></xml>` (invalid XML?)
 	 */
 	SYNTAX_ElementClosingNotConnected: {
 		source: '<xml><a/ </xml>',
@@ -115,8 +127,9 @@ const REPORTED = {
 		match: (msg) => /must be connected/.test(msg),
 	},
 	/**
-	 * In the Browser (for XML) this is reported as `error on line 1 at column 6: Extra content at the end of the document` for HTML
-	 * it's added to the DOM without anything being reported.
+	 * In the Browser (for XML) this is reported as
+	 * `error on line 1 at column 6: Extra content at the end of the document`
+	 * for HTML it's added to the DOM without anything being reported.
 	 */
 	WF_UnclosedXmlAttribute: {
 		source: '<xml>',
@@ -126,9 +139,10 @@ const REPORTED = {
 	},
 	/**
 	 * In the browser:
-	 *
-	 * - For XML it is reported as `error on line 1 at column 10: Specification mandates value for attribute attr`
-	 * - For HTML is uses the attribute as one with no value and adds `"value"` to the attribute name and is not reporting any issue.
+	 * - for XML it is reported as
+	 * `error on line 1 at column 10: Specification mandates value for attribute attr`
+	 * - for HTML is uses the attribute as one with no value and adds `"value"` to the attribute name
+	 *   and is not reporting any issue.
 	 */
 	WF_AttributeValueMustAfterEqual: {
 		source: '<xml attr"value" />',
@@ -137,9 +151,8 @@ const REPORTED = {
 	},
 	/**
 	 * In the browser:
-	 *
-	 * - For XML it is reported as `error on line 1 at column 11: AttValue: " or ' expected`
-	 * - For HTML is wraps `value"` with quotes and is not reporting any issue.
+	 * - for XML it is reported as `error on line 1 at column 11: AttValue: " or ' expected`
+	 * - for HTML is wraps `value"` with quotes and is not reporting any issue.
 	 */
 	WF_AttributeMissingStartingQuote: {
 		source: '<xml attr=value" />',
@@ -147,12 +160,12 @@ const REPORTED = {
 		match: (msg) => /missed start quot/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:264, caught in 208. TODO: Comment indicates fatalError, change to use errorHandler.fatalError?
+	 * Triggered by lib/sax.js:264, caught in 208.
+	 * TODO: Comment indicates fatalError, change to use errorHandler.fatalError?
 	 *
 	 * In the browser:
-	 *
-	 * - For XML it is reported as `error on line 1 at column 20: AttValue: ' expected`
-	 * - For HTML nothing is added to the DOM.
+	 * - for XML it is reported as `error on line 1 at column 20: AttValue: ' expected`
+	 * - for HTML nothing is added to the DOM.
 	 */
 	SYNTAX_AttributeMissingEndingQuote: {
 		source: '<xml><child attr="value /></xml>',
@@ -160,10 +173,10 @@ const REPORTED = {
 		match: (msg) => /attribute value no end .* match/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:324 In the browser:
-	 *
-	 * - For XML it is reported as `error on line 1 at column 11: AttValue: " or ' expected`
-	 * - For HTML is wraps `value/` with quotes and is not reporting any issue.
+	 * Triggered by lib/sax.js:324
+	 * In the browser:
+	 * - for XML it is reported as `error on line 1 at column 11: AttValue: " or ' expected`
+	 * - for HTML is wraps `value/` with quotes and is not reporting any issue.
 	 */
 	WF_AttributeMissingQuote: {
 		source: '<xml attr=value/>',
@@ -171,13 +184,15 @@ const REPORTED = {
 		match: (msg) => / missed quot/.test(msg) && /!!/.test(msg) === false,
 	},
 	/**
-	 * Triggered by lib/sax.js:354 This is the only warning reported in this sample. For some reason the "attribute" that is
-	 * reported as missing quotes has the name `&`. This case is also present in 2 tests in test/html/normalize.test.js
+	 * Triggered by lib/sax.js:354
+	 * This is the only warning reported in this sample.
+	 * For some reason the "attribute" that is reported as missing quotes
+	 * has the name `&`.
+	 * This case is also present in 2 tests in test/html/normalize.test.js
 	 *
 	 * In the browser:
-	 *
-	 * - For XML it is reported as `error on line 1 at column 8: AttValue: " or ' expected`
-	 * - For HTML is yields `<xml a="&amp;" b="&amp;"></xml>` and is not reporting any issue.
+	 * - for XML it is reported as `error on line 1 at column 8: AttValue: " or ' expected`
+	 * - for HTML is yields `<xml a="&amp;" b="&amp;"></xml>` and is not reporting any issue.
 	 */
 	WF_AttributeMissingQuote2: {
 		source: `<xml a=& b="&"/>`,
@@ -186,12 +201,10 @@ const REPORTED = {
 	},
 	/**
 	 * In the browser:
-	 *
-	 * - For XML it is reported as `error on line 1 at column 9: AttValue: " or ' expected`
-	 * - For HTML is yields `<doc a1></xml>` and is not reporting any issue.
+	 * - for XML it is reported as `error on line 1 at column 9: AttValue: " or ' expected`
+	 * - for HTML is yields `<doc a1></xml>` and is not reporting any issue.
 	 *
 	 * But the XML specifications does not allow that:
-	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Attribute
 	 */
@@ -201,9 +214,8 @@ const REPORTED = {
 		match: (msg) => /attribute value missed!!/.test(msg),
 	},
 	/**
-	 * In the browser this is not an issue at all, but just add an attribute without a value. But the XML specifications does not
-	 * allow that:
-	 *
+	 * In the browser this is not an issue at all, but just add an attribute without a value.
+	 * But the XML specifications does not allow that:
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Attribute
 	 */
@@ -214,10 +226,10 @@ const REPORTED = {
 		skippedInHtml: true,
 	},
 	/**
-	 * Triggered by lib/sax.js:376 This seems to only be reached when there are two subsequent attributes with a missing value In
-	 * the browser this is not an issue at all, but just add an attribute without a value. But the XML specifications does not allow
-	 * that:
-	 *
+	 * Triggered by lib/sax.js:376
+	 * This seems to only be reached when there are two subsequent attributes with a missing value
+	 * In the browser this is not an issue at all, but just add an attribute without a value.
+	 * But the XML specifications does not allow that:
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Attribute
 	 */
@@ -234,19 +246,21 @@ const LINE_TO_ERROR_INDEX = {
 };
 
 /**
- * To avoid to have exact lines in snapshots, but still being able to verify, that a certain error was reported in the expected
- * order, this method indexes all cases of
+ * To avoid to have exact lines in snapshots, but still being able to verify,
+ * that a certain error was reported in the expected order,
+ * this method indexes all cases of
+ * - thrown errors
+ * - calls to one of the errorHandler methods
+ * and adds them to the exported LINE_TO_ERROR_INDEX.
  *
- * - Thrown errors
- * - Calls to one of the errorHandler methods and adds them to the exported LINE_TO_ERROR_INDEX.
+ * It also checks that every match configured in REPORTED only matches a single line,
+ * and adds the related key to the index as `reportedAs`.
+ * Any failing check will throw, so it prevents the tests from being executed.
  *
- * It also checks that every match configured in REPORTED only matches a single line, and adds the related key to the index as
- * `reportedAs`. Any failing check will throw, so it prevents the tests from being executed.
+ * The result is written to reported.json for easier human introspection.
+ * The file is only written, not read by any code, the source code is the only source of truth.
  *
- * The result is written to reported.json for easier human introspection. The file is only written, not read by any code, the
- * source code is the only source of truth.
- *
- * @param fileNameInKey The part of the path that is supposed to be part of the key
+ * @param fileNameInKey the part of the path that is supposed to be part of the key
  */
 function parseErrorLines(fileNameInKey) {
 	let errorIndex = 0;

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -4,10 +4,14 @@ const path = require('path');
 
 /**
  * @typedef ErrorReport
- * @property {string}                             source         The XML snippet.
- * @property {'error' | 'warning' | 'fatalError'} level          The name of the method triggered.
- * @property {?function(msg:string):boolean}      match          To pick the relevant report when there are multiple.
- * @property {boolean | null}                     skippedInHtml  Is the error reported when parsing HTML?
+ * @property {string} source
+ * The XML snippet.
+ * @property {'error' | 'warning' | 'fatalError'} level
+ * The name of the method triggered.
+ * @property {?function(msg:string):boolean} match
+ * To pick the relevant report when there are multiple.
+ * @property {boolean | null} skippedInHtml
+ * Is the error reported when parsing HTML?
  */
 /** A collection of XML samples and related information that cause the XMLReader to call methods on `errorHandler`. */
 const REPORTED = {
@@ -245,7 +249,8 @@ const LINE_TO_ERROR_INDEX = {
  * The result is written to reported.json for easier human introspection. The file is only written, not read by any code, the
  * source code is the only source of truth.
  *
- * @param fileNameInKey  The part of the path that is supposed to be part of the key.
+ * @param fileNameInKey
+ * The part of the path that is supposed to be part of the key.
  */
 function parseErrorLines(fileNameInKey) {
 	let errorIndex = 0;

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -33,7 +33,8 @@ const REPORTED = {
 	/**
 	 * Well-formedness constraint: Unique Att Spec
 	 *
-	 * An attribute name must not appear more than once in the same start-tag or empty-element tag.
+	 * An attribute name must not appear more than once in the same start-tag or empty-element
+	 * tag.
 	 *
 	 * In the browser:
 	 * - as XML it is reported as `error on line 1 at column 17: Attribute a redefined`
@@ -204,7 +205,8 @@ const REPORTED = {
 	},
 	/**
 	 * In the browser:
-	 * - for XML it is reported as `error on line 1 at column 9: AttValue: " or ' expected`
+	 * - for XML it is reported as `error on line 1 at column 9: AttValue: " or '
+	 * expected`
 	 * - for HTML is yields `<doc a1></xml>` and is not reporting any issue.
 	 *
 	 * But the XML specifications does not allow that:
@@ -231,8 +233,9 @@ const REPORTED = {
 		skippedInHtml: true,
 	},
 	/**
-	 * Triggered by lib/sax.js:376 This seems to only be reached when there are two subsequent attributes with a missing value In the
-	 * browser this is not an issue at all, but just add an attribute without a value.
+	 * Triggered by lib/sax.js:376 This seems to only be reached when there are two subsequent
+	 * attributes with a missing value In the browser this is not an issue at all,
+	 * but just add an attribute without a value.
 	 * But the XML specifications does not allow that:
 	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
@@ -253,8 +256,8 @@ const LINE_TO_ERROR_INDEX = {
 /**
  * To avoid to have exact lines in snapshots, but still being able to verify,
  * that a certain error was reported in the expected order,
- * this method indexes all cases of - thrown errors - calls to one of the errorHandler methods and adds them to the exported
- * LINE_TO_ERROR_INDEX.
+ * this method indexes all cases of - thrown errors - calls to one of the errorHandler methods
+ * and adds them to the exported LINE_TO_ERROR_INDEX.
  *
  * It also checks that every match configured in REPORTED only matches a single line,
  * and adds the related key to the index as `reportedAs`.

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -4,10 +4,10 @@ const path = require('path');
 
 /**
  * @typedef ErrorReport
- * @property {string}                             source         The XML snippet.
- * @property {'error' | 'warning' | 'fatalError'} level          The name of the method triggered.
- * @property {?function(msg:string):boolean}      match          To pick the relevant report when there are multiple.
- * @property {boolean | null}                     skippedInHtml  Is the error reported when parsing HTML?
+ * @property {string} source The XML snippet
+ * @property {'error' | 'warning' | 'fatalError'} level The name of the method triggered
+ * @property {?function(msg:string):boolean} match To pick the relevant report when there are multiple
+ * @property {boolean | null} skippedInHtml Is the error reported when parsing HTML?
  */
 /** A collection of XML samples and related information that cause the XMLReader to call methods on `errorHandler`. */
 const REPORTED = {
@@ -214,8 +214,8 @@ const REPORTED = {
 		skippedInHtml: true,
 	},
 	/**
-	 * Triggered by lib/sax.js:376 This seems to only be reached when there are two subsequent attributes with a missing value In the
-	 * browser this is not an issue at all, but just add an attribute without a value. But the XML specifications does not allow
+	 * Triggered by lib/sax.js:376 This seems to only be reached when there are two subsequent attributes with a missing value In
+	 * the browser this is not an issue at all, but just add an attribute without a value. But the XML specifications does not allow
 	 * that:
 	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
@@ -237,7 +237,8 @@ const LINE_TO_ERROR_INDEX = {
  * To avoid to have exact lines in snapshots, but still being able to verify, that a certain error was reported in the expected
  * order, this method indexes all cases of
  *
- * - Thrown errors - Calls to one of the errorHandler methods and adds them to the exported LINE_TO_ERROR_INDEX.
+ * - Thrown errors
+ * - Calls to one of the errorHandler methods and adds them to the exported LINE_TO_ERROR_INDEX.
  *
  * It also checks that every match configured in REPORTED only matches a single line, and adds the related key to the index as
  * `reportedAs`. Any failing check will throw, so it prevents the tests from being executed.
@@ -245,7 +246,7 @@ const LINE_TO_ERROR_INDEX = {
  * The result is written to reported.json for easier human introspection. The file is only written, not read by any code, the
  * source code is the only source of truth.
  *
- * @param fileNameInKey  The part of the path that is supposed to be part of the key.
+ * @param fileNameInKey The part of the path that is supposed to be part of the key
  */
 function parseErrorLines(fileNameInKey) {
 	let errorIndex = 0;

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -4,19 +4,16 @@ const path = require('path');
 
 /**
  * @typedef ErrorReport
- * @property {string} source the XML snippet
- * @property {'error'|'warning'|'fatalError'} level the name of the method triggered
- * @property {?function(msg:string):boolean} match to pick the relevant report when there are multiple
- * @property {?boolean} skippedInHtml Is the error reported when parsing HTML?
+ * @property {string} source The XML snippet
+ * @property {'error' | 'warning' | 'fatalError'} level The name of the method triggered
+ * @property {?function(msg:string):boolean} match To pick the relevant report when there are multiple
+ * @property {boolean | null} skippedInHtml Is the error reported when parsing HTML?
  */
-/**
- * A collection of XML samples and related information that cause the XMLReader
- * to call methods on `errorHandler`.
- */
+/** A collection of XML samples and related information that cause the XMLReader to call methods on `errorHandler`. */
 const REPORTED = {
 	/**
-	 * Entities need to be in the entityMap to be converted as part of parsing.
-	 * xmldom currently doesn't parse entities declared in DTD.
+	 * Entities need to be in the entityMap to be converted as part of parsing. xmldom currently doesn't parse entities declared in
+	 * DTD.
 	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#wf-entdeclared
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#wf-entdeclared
@@ -29,16 +26,15 @@ const REPORTED = {
 	/**
 	 * Well-formedness constraint: Unique Att Spec
 	 *
-	 * An attribute name must not appear more than once
-	 * in the same start-tag or empty-element tag.
+	 * An attribute name must not appear more than once in the same start-tag or empty-element tag.
 	 *
 	 * In the browser:
-	 * - as XML it is reported as `error on line 1 at column 17: Attribute a redefined`
-	 * - as HTML only the first definition is considered
 	 *
-	 * In xmldom the behavior is different for namespaces (picks first)
-	 * than for other attributes (picks last),
-	 * which can be a security issue.
+	 * - As XML it is reported as `error on line 1 at column 17: Attribute a redefined`
+	 * - As HTML only the first definition is considered
+	 *
+	 * In xmldom the behavior is different for namespaces (picks first) than for other attributes (picks last), which can be a
+	 * security issue.
 	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#uniqattspec
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#uniqattspec
@@ -49,9 +45,8 @@ const REPORTED = {
 		match: (msg) => /Attribute .* redefined/.test(msg),
 	},
 	/**
-	 * This sample doesn't follow the specified grammar.
-	 * In the browser it is reported as `error on line 1 at column 14: expected '>'`,
-	 * but still adds the root level element to the dom.
+	 * This sample doesn't follow the specified grammar. In the browser it is reported as `error on line 1 at column 14: expected
+	 * '>'`, but still adds the root level element to the dom.
 	 */
 	SYNTAX_EndTagNotComplete: {
 		source: '<xml></xml',
@@ -59,9 +54,8 @@ const REPORTED = {
 		match: (msg) => /end tag name/.test(msg) && /is not complete/.test(msg),
 	},
 	/**
-	 * This sample doesn't follow the specified grammar.
-	 * In the browser it is reported as `error on line 1 at column 21: expected '>'`,
-	 * but still adds the root level element and inner tag to the dom.
+	 * This sample doesn't follow the specified grammar. In the browser it is reported as `error on line 1 at column 21: expected
+	 * '>'`, but still adds the root level element and inner tag to the dom.
 	 */
 	SYNTAX_EndTagMaybeNotComplete: {
 		source: '<xml><inner></inner </xml>',
@@ -70,8 +64,8 @@ const REPORTED = {
 		match: (msg) => /end tag name/.test(msg) && /maybe not complete/.test(msg),
 	},
 	/**
-	 * This sample doesn't follow the specified grammar.
-	 * In the browser it is reported as `error on line 1 at column 6: Comment not terminated`.
+	 * This sample doesn't follow the specified grammar. In the browser it is reported as `error on line 1 at column 6: Comment not
+	 * terminated`.
 	 */
 	WF_UnclosedComment: {
 		source: '<xml></xml><!--',
@@ -79,13 +73,10 @@ const REPORTED = {
 		match: (msg) => /comment is not well-formed/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:596, caught in 208
-	 * This sample doesn't follow the specified grammar.
-	 * In the browser:
-	 * - as XML it is reported as
-	 * `error on line 1 at column 2: StartTag: invalid element name`
-	 * - as HTML it is accepted as characters
+	 * Triggered by lib/sax.js:596, caught in 208 This sample doesn't follow the specified grammar. In the browser:
 	 *
+	 * - As XML it is reported as `error on line 1 at column 2: StartTag: invalid element name`
+	 * - As HTML it is accepted as characters
 	 */
 	SYNTAX_InvalidTagName: {
 		source: '<xml><123 /></xml>',
@@ -93,12 +84,10 @@ const REPORTED = {
 		match: (msg) => /invalid tagName/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:602, caught in 208
-	 * This sample doesn't follow the specified grammar.
-	 * In the browser:
-	 * - as XML it is reported as
-	 * `error on line 1 at column 6: error parsing attribute name`
-	 * - as HTML it is accepted as attribute name
+	 * Triggered by lib/sax.js:602, caught in 208 This sample doesn't follow the specified grammar. In the browser:
+	 *
+	 * - As XML it is reported as `error on line 1 at column 6: error parsing attribute name`
+	 * - As HTML it is accepted as attribute name
 	 */
 	SYNTAX_InvalidAttributeName: {
 		source: '<xml><child 123=""/></xml>',
@@ -106,8 +95,8 @@ const REPORTED = {
 		match: (msg) => /invalid attribute/.test(msg),
 	},
 	/**
-	 * This sample doesn't follow the specified grammar.
-	 * In the browser it is reported as `error on line 1 at column 5: Couldn't find end of Start Tag xml`.
+	 * This sample doesn't follow the specified grammar. In the browser it is reported as `error on line 1 at column 5: Couldn't
+	 * find end of Start Tag xml`.
 	 */
 	SYNTAX_UnexpectedEndOfInput: {
 		source: '<xml',
@@ -115,11 +104,10 @@ const REPORTED = {
 		match: (msg) => /unexpected end of input/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:392, caught in 208
-	 * This sample doesn't follow the specified grammar.
-	 * In the browser:
-	 * - in XML it is reported as `error on line 1 at column 8: error parsing attribute name`
-	 * - in HTML it produces `<xml><a <="" xml=""></a></xml>` (invalid XML?)
+	 * Triggered by lib/sax.js:392, caught in 208 This sample doesn't follow the specified grammar. In the browser:
+	 *
+	 * - In XML it is reported as `error on line 1 at column 8: error parsing attribute name`
+	 * - In HTML it produces `<xml><a <="" xml=""></a></xml>` (invalid XML?)
 	 */
 	SYNTAX_ElementClosingNotConnected: {
 		source: '<xml><a/ </xml>',
@@ -127,9 +115,8 @@ const REPORTED = {
 		match: (msg) => /must be connected/.test(msg),
 	},
 	/**
-	 * In the Browser (for XML) this is reported as
-	 * `error on line 1 at column 6: Extra content at the end of the document`
-	 * for HTML it's added to the DOM without anything being reported.
+	 * In the Browser (for XML) this is reported as `error on line 1 at column 6: Extra content at the end of the document` for HTML
+	 * it's added to the DOM without anything being reported.
 	 */
 	WF_UnclosedXmlAttribute: {
 		source: '<xml>',
@@ -139,10 +126,9 @@ const REPORTED = {
 	},
 	/**
 	 * In the browser:
-	 * - for XML it is reported as
-	 * `error on line 1 at column 10: Specification mandates value for attribute attr`
-	 * - for HTML is uses the attribute as one with no value and adds `"value"` to the attribute name
-	 *   and is not reporting any issue.
+	 *
+	 * - For XML it is reported as `error on line 1 at column 10: Specification mandates value for attribute attr`
+	 * - For HTML is uses the attribute as one with no value and adds `"value"` to the attribute name and is not reporting any issue.
 	 */
 	WF_AttributeValueMustAfterEqual: {
 		source: '<xml attr"value" />',
@@ -151,8 +137,9 @@ const REPORTED = {
 	},
 	/**
 	 * In the browser:
-	 * - for XML it is reported as `error on line 1 at column 11: AttValue: " or ' expected`
-	 * - for HTML is wraps `value"` with quotes and is not reporting any issue.
+	 *
+	 * - For XML it is reported as `error on line 1 at column 11: AttValue: " or ' expected`
+	 * - For HTML is wraps `value"` with quotes and is not reporting any issue.
 	 */
 	WF_AttributeMissingStartingQuote: {
 		source: '<xml attr=value" />',
@@ -160,12 +147,12 @@ const REPORTED = {
 		match: (msg) => /missed start quot/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:264, caught in 208.
-	 * TODO: Comment indicates fatalError, change to use errorHandler.fatalError?
+	 * Triggered by lib/sax.js:264, caught in 208. TODO: Comment indicates fatalError, change to use errorHandler.fatalError?
 	 *
 	 * In the browser:
-	 * - for XML it is reported as `error on line 1 at column 20: AttValue: ' expected`
-	 * - for HTML nothing is added to the DOM.
+	 *
+	 * - For XML it is reported as `error on line 1 at column 20: AttValue: ' expected`
+	 * - For HTML nothing is added to the DOM.
 	 */
 	SYNTAX_AttributeMissingEndingQuote: {
 		source: '<xml><child attr="value /></xml>',
@@ -173,10 +160,10 @@ const REPORTED = {
 		match: (msg) => /attribute value no end .* match/.test(msg),
 	},
 	/**
-	 * Triggered by lib/sax.js:324
-	 * In the browser:
-	 * - for XML it is reported as `error on line 1 at column 11: AttValue: " or ' expected`
-	 * - for HTML is wraps `value/` with quotes and is not reporting any issue.
+	 * Triggered by lib/sax.js:324 In the browser:
+	 *
+	 * - For XML it is reported as `error on line 1 at column 11: AttValue: " or ' expected`
+	 * - For HTML is wraps `value/` with quotes and is not reporting any issue.
 	 */
 	WF_AttributeMissingQuote: {
 		source: '<xml attr=value/>',
@@ -184,15 +171,13 @@ const REPORTED = {
 		match: (msg) => / missed quot/.test(msg) && /!!/.test(msg) === false,
 	},
 	/**
-	 * Triggered by lib/sax.js:354
-	 * This is the only warning reported in this sample.
-	 * For some reason the "attribute" that is reported as missing quotes
-	 * has the name `&`.
-	 * This case is also present in 2 tests in test/html/normalize.test.js
+	 * Triggered by lib/sax.js:354 This is the only warning reported in this sample. For some reason the "attribute" that is
+	 * reported as missing quotes has the name `&`. This case is also present in 2 tests in test/html/normalize.test.js
 	 *
 	 * In the browser:
-	 * - for XML it is reported as `error on line 1 at column 8: AttValue: " or ' expected`
-	 * - for HTML is yields `<xml a="&amp;" b="&amp;"></xml>` and is not reporting any issue.
+	 *
+	 * - For XML it is reported as `error on line 1 at column 8: AttValue: " or ' expected`
+	 * - For HTML is yields `<xml a="&amp;" b="&amp;"></xml>` and is not reporting any issue.
 	 */
 	WF_AttributeMissingQuote2: {
 		source: `<xml a=& b="&"/>`,
@@ -201,10 +186,12 @@ const REPORTED = {
 	},
 	/**
 	 * In the browser:
-	 * - for XML it is reported as `error on line 1 at column 9: AttValue: " or ' expected`
-	 * - for HTML is yields `<doc a1></xml>` and is not reporting any issue.
+	 *
+	 * - For XML it is reported as `error on line 1 at column 9: AttValue: " or ' expected`
+	 * - For HTML is yields `<doc a1></xml>` and is not reporting any issue.
 	 *
 	 * But the XML specifications does not allow that:
+	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Attribute
 	 */
@@ -214,8 +201,9 @@ const REPORTED = {
 		match: (msg) => /attribute value missed!!/.test(msg),
 	},
 	/**
-	 * In the browser this is not an issue at all, but just add an attribute without a value.
-	 * But the XML specifications does not allow that:
+	 * In the browser this is not an issue at all, but just add an attribute without a value. But the XML specifications does not
+	 * allow that:
+	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Attribute
 	 */
@@ -226,10 +214,10 @@ const REPORTED = {
 		skippedInHtml: true,
 	},
 	/**
-	 * Triggered by lib/sax.js:376
-	 * This seems to only be reached when there are two subsequent attributes with a missing value
-	 * In the browser this is not an issue at all, but just add an attribute without a value.
-	 * But the XML specifications does not allow that:
+	 * Triggered by lib/sax.js:376 This seems to only be reached when there are two subsequent attributes with a missing value In
+	 * the browser this is not an issue at all, but just add an attribute without a value. But the XML specifications does not allow
+	 * that:
+	 *
 	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Attribute
 	 * @see https://www.w3.org/TR/2006/REC-xml11-20060816/#NT-Attribute
 	 */
@@ -246,21 +234,19 @@ const LINE_TO_ERROR_INDEX = {
 };
 
 /**
- * To avoid to have exact lines in snapshots, but still being able to verify,
- * that a certain error was reported in the expected order,
- * this method indexes all cases of
- * - thrown errors
- * - calls to one of the errorHandler methods
- * and adds them to the exported LINE_TO_ERROR_INDEX.
+ * To avoid to have exact lines in snapshots, but still being able to verify, that a certain error was reported in the expected
+ * order, this method indexes all cases of
  *
- * It also checks that every match configured in REPORTED only matches a single line,
- * and adds the related key to the index as `reportedAs`.
- * Any failing check will throw, so it prevents the tests from being executed.
+ * - Thrown errors
+ * - Calls to one of the errorHandler methods and adds them to the exported LINE_TO_ERROR_INDEX.
  *
- * The result is written to reported.json for easier human introspection.
- * The file is only written, not read by any code, the source code is the only source of truth.
+ * It also checks that every match configured in REPORTED only matches a single line, and adds the related key to the index as
+ * `reportedAs`. Any failing check will throw, so it prevents the tests from being executed.
  *
- * @param fileNameInKey the part of the path that is supposed to be part of the key
+ * The result is written to reported.json for easier human introspection. The file is only written, not read by any code, the
+ * source code is the only source of truth.
+ *
+ * @param fileNameInKey The part of the path that is supposed to be part of the key
  */
 function parseErrorLines(fileNameInKey) {
 	let errorIndex = 0;

--- a/test/error/xml-reader-dom-handler-errors.test.js
+++ b/test/error/xml-reader-dom-handler-errors.test.js
@@ -36,7 +36,7 @@ const UNCALLED_METHODS = new Set([
 
 /**
  * Some methods DOMParser/XMLReader calls during parsing are not guarded by try/catch, hence an error happening in those will stop
- * the parsing process. There is a test to verify this error handling. If it changes this list might need to be changed as well.
+ * the parsing process. There is a test to verify this error handling. If it changes this list might need to be changed as well
  *
  * @type {Set<string>}
  */
@@ -80,9 +80,9 @@ function StubDOMHandlerWith(throwingMethod, ErrorClass) {
  *
  * There is of course no guarantee that it triggers all the places where XMLReader calls DOMHandler. For example not all possible
  * warning and error cases are present in this file, but some, so that the methods are triggered. For testing all the cases of the
- * different error levels, there are samples per case in.
+ * different error levels, there are samples per case in
  *
- * @see REPORTED.
+ * @see REPORTED
  */
 const ALL_METHODS = `<?xml version="1.1"?>
 <!DOCTYPE name >

--- a/test/error/xml-reader-dom-handler-errors.test.js
+++ b/test/error/xml-reader-dom-handler-errors.test.js
@@ -12,8 +12,8 @@ const { __DOMHandler, DOMParser } = require('../../lib/dom-parser');
 const DOMHandlerMethods = Object.keys(__DOMHandler.prototype).sort();
 
 /**
- * XMLReader is currently not calling all methods "implemented" by DOMHandler (some are just empty), If this changes the first
- * test will fail.
+ * XMLReader is currently not calling all methods "implemented" by DOMHandler (some are just empty),
+ * If this changes the first test will fail.
  *
  * @type {Set<string>}
  */
@@ -35,8 +35,10 @@ const UNCALLED_METHODS = new Set([
 ]);
 
 /**
- * Some methods DOMParser/XMLReader calls during parsing are not guarded by try/catch, hence an error happening in those will stop
- * the parsing process. There is a test to verify this error handling. If it changes this list might need to be changed as well
+ * Some methods DOMParser/XMLReader calls during parsing are not guarded by try/catch,
+ * hence an error happening in those will stop the parsing process.
+ * There is a test to verify this error handling.
+ * If it changes this list might need to be changed as well
  *
  * @type {Set<string>}
  */
@@ -47,8 +49,9 @@ class TestError extends Error {}
 function noop() {}
 
 /**
- * A subclass of DOMHandler that mocks all methods for later inspection. As part of the constructor it can be told which method is
- * supposed to throw an error and which error constructor to use.
+ * A subclass of DOMHandler that mocks all methods for later inspection.
+ * As part of the constructor it can be told which method is supposed to throw an error
+ * and which error constructor to use.
  *
  * The `methods` property provides the list of all mocks.
  */
@@ -76,12 +79,14 @@ function StubDOMHandlerWith(throwingMethod, ErrorClass) {
 }
 
 /**
- * This sample is triggering all method calls from XMLReader to DOMHandler at least once. This is verified in a test.
+ * This sample is triggering all method calls from XMLReader to DOMHandler at least once.
+ * This is verified in a test.
  *
- * There is of course no guarantee that it triggers all the places where XMLReader calls DOMHandler. For example not all possible
- * warning and error cases are present in this file, but some, so that the methods are triggered. For testing all the cases of the
- * different error levels, there are samples per case in
- *
+ * There is of course no guarantee that it triggers all the places where XMLReader calls DOMHandler.
+ * For example not all possible warning and error cases are present in this file,
+ * but some, so that the methods are triggered.
+ * For testing all the cases of the different error levels,
+ * there are samples per case in
  * @see REPORTED
  */
 const ALL_METHODS = `<?xml version="1.1"?>

--- a/test/error/xml-reader-dom-handler-errors.test.js
+++ b/test/error/xml-reader-dom-handler-errors.test.js
@@ -36,7 +36,7 @@ const UNCALLED_METHODS = new Set([
 
 /**
  * Some methods DOMParser/XMLReader calls during parsing are not guarded by try/catch, hence an error happening in those will stop
- * the parsing process. There is a test to verify this error handling. If it changes this list might need to be changed as well
+ * the parsing process. There is a test to verify this error handling. If it changes this list might need to be changed as well.
  *
  * @type {Set<string>}
  */
@@ -80,9 +80,9 @@ function StubDOMHandlerWith(throwingMethod, ErrorClass) {
  *
  * There is of course no guarantee that it triggers all the places where XMLReader calls DOMHandler. For example not all possible
  * warning and error cases are present in this file, but some, so that the methods are triggered. For testing all the cases of the
- * different error levels, there are samples per case in
+ * different error levels, there are samples per case in.
  *
- * @see REPORTED
+ * @see REPORTED.
  */
 const ALL_METHODS = `<?xml version="1.1"?>
 <!DOCTYPE name >

--- a/test/error/xml-reader-dom-handler-errors.test.js
+++ b/test/error/xml-reader-dom-handler-errors.test.js
@@ -38,7 +38,7 @@ const UNCALLED_METHODS = new Set([
  * Some methods DOMParser/XMLReader calls during parsing are not guarded by try/catch,
  * hence an error happening in those will stop the parsing process.
  * There is a test to verify this error handling.
- * If it changes this list might need to be changed as well
+ * If it changes this list might need to be changed as well.
  *
  * @type {Set<string>}
  */
@@ -86,8 +86,9 @@ function StubDOMHandlerWith(throwingMethod, ErrorClass) {
  * For example not all possible warning and error cases are present in this file,
  * but some, so that the methods are triggered.
  * For testing all the cases of the different error levels,
- * there are samples per case in
- * @see REPORTED
+ * there are samples per case in.
+ *
+ * @see REPORTED.
  */
 const ALL_METHODS = `<?xml version="1.1"?>
 <!DOCTYPE name >

--- a/test/error/xml-reader-dom-handler-errors.test.js
+++ b/test/error/xml-reader-dom-handler-errors.test.js
@@ -12,8 +12,8 @@ const { __DOMHandler, DOMParser } = require('../../lib/dom-parser');
 const DOMHandlerMethods = Object.keys(__DOMHandler.prototype).sort();
 
 /**
- * XMLReader is currently not calling all methods "implemented" by DOMHandler (some are just empty),
- * If this changes the first test will fail.
+ * XMLReader is currently not calling all methods "implemented" by DOMHandler (some are just empty), If this changes the first
+ * test will fail.
  *
  * @type {Set<string>}
  */
@@ -35,10 +35,8 @@ const UNCALLED_METHODS = new Set([
 ]);
 
 /**
- * Some methods DOMParser/XMLReader calls during parsing are not guarded by try/catch,
- * hence an error happening in those will stop the parsing process.
- * There is a test to verify this error handling.
- * If it changes this list might need to be changed as well
+ * Some methods DOMParser/XMLReader calls during parsing are not guarded by try/catch, hence an error happening in those will stop
+ * the parsing process. There is a test to verify this error handling. If it changes this list might need to be changed as well
  *
  * @type {Set<string>}
  */
@@ -49,9 +47,8 @@ class TestError extends Error {}
 function noop() {}
 
 /**
- * A subclass of DOMHandler that mocks all methods for later inspection.
- * As part of the constructor it can be told which method is supposed to throw an error
- * and which error constructor to use.
+ * A subclass of DOMHandler that mocks all methods for later inspection. As part of the constructor it can be told which method is
+ * supposed to throw an error and which error constructor to use.
  *
  * The `methods` property provides the list of all mocks.
  */
@@ -79,14 +76,12 @@ function StubDOMHandlerWith(throwingMethod, ErrorClass) {
 }
 
 /**
- * This sample is triggering all method calls from XMLReader to DOMHandler at least once.
- * This is verified in a test.
+ * This sample is triggering all method calls from XMLReader to DOMHandler at least once. This is verified in a test.
  *
- * There is of course no guarantee that it triggers all the places where XMLReader calls DOMHandler.
- * For example not all possible warning and error cases are present in this file,
- * but some, so that the methods are triggered.
- * For testing all the cases of the different error levels,
- * there are samples per case in
+ * There is of course no guarantee that it triggers all the places where XMLReader calls DOMHandler. For example not all possible
+ * warning and error cases are present in this file, but some, so that the methods are triggered. For testing all the cases of the
+ * different error levels, there are samples per case in
+ *
  * @see REPORTED
  */
 const ALL_METHODS = `<?xml version="1.1"?>

--- a/test/error/xml-reader-dom-handler-errors.test.js
+++ b/test/error/xml-reader-dom-handler-errors.test.js
@@ -12,7 +12,8 @@ const { __DOMHandler, DOMParser } = require('../../lib/dom-parser');
 const DOMHandlerMethods = Object.keys(__DOMHandler.prototype).sort();
 
 /**
- * XMLReader is currently not calling all methods "implemented" by DOMHandler (some are just empty),
+ * XMLReader is currently not calling all methods "implemented" by DOMHandler (some are just
+ * empty),
  * If this changes the first test will fail.
  *
  * @type {Set<string>}
@@ -82,13 +83,14 @@ function StubDOMHandlerWith(throwingMethod, ErrorClass) {
  * This sample is triggering all method calls from XMLReader to DOMHandler at least once.
  * This is verified in a test.
  *
- * There is of course no guarantee that it triggers all the places where XMLReader calls DOMHandler.
+ * There is of course no guarantee that it triggers all the places where XMLReader calls
+ * DOMHandler.
  * For example not all possible warning and error cases are present in this file,
  * but some, so that the methods are triggered.
  * For testing all the cases of the different error levels,
  * there are samples per case in.
  *
- * @see REPORTED.
+ * @see {@link REPORTED}
  */
 const ALL_METHODS = `<?xml version="1.1"?>
 <!DOCTYPE name >

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -1,21 +1,25 @@
 'use strict';
 const { DOMParser } = require('../lib/dom-parser');
 
-/** @typedef ErrorLevel {'warn' | 'error' | 'fatalError'} */
+/**
+ * {'warn' | 'error' | 'fatalError'}
+ *
+ * @typedef ErrorLevel
+ */
 
 /**
  * Helper method for configuring an instance of DOMParser. Calling it without any arguments allows to assert on `errors` after
  * using the parser. every field of the first argument is options and allows to specify test specific behavior.
  *
- * - `errorHandler`: The `errorHandler` to pass to DOMParser constructor options, default stores a list of all entries per `key` in
- *   `errors` and does not log or throw.
+ * - `errorHandler`: The `errorHandler` to pass to DOMParser constructor options, default stores a list of all entries per `key`
+ * in `errors` and does not log or throw.
  * - `errors`: the object for the `errorHandler` to use, is also returned with the same name for later assertions, default is an
- *   empty object
- * - `locator`: Whether to record node locations in the XML string, default is true
+ * empty object - `locator`: Whether to record node locations in the XML string, default is true.
  *
- * @param options {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string, object][],
- *   locator?: boolean }}
- * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, object][] }}
+ * @param options  {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string,
+ *                 object][],
+ *                 locator?: boolean }}
+ * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, Object][] }}
  */
 function getTestParser({ onError, errors = [], locator = true } = {}) {
 	onError =

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -1,25 +1,21 @@
 'use strict';
 const { DOMParser } = require('../lib/dom-parser');
 
-/**
- * {'warn' | 'error' | 'fatalError'}
- *
- * @typedef ErrorLevel
- */
+/** @typedef ErrorLevel {'warn' | 'error' | 'fatalError'} */
 
 /**
  * Helper method for configuring an instance of DOMParser. Calling it without any arguments allows to assert on `errors` after
  * using the parser. every field of the first argument is options and allows to specify test specific behavior.
  *
- * - `errorHandler`: The `errorHandler` to pass to DOMParser constructor options, default stores a list of all entries per `key`
- * in `errors` and does not log or throw.
+ * - `errorHandler`: The `errorHandler` to pass to DOMParser constructor options, default stores a list of all entries per `key` in
+ *   `errors` and does not log or throw.
  * - `errors`: the object for the `errorHandler` to use, is also returned with the same name for later assertions, default is an
- * empty object - `locator`: Whether to record node locations in the XML string, default is true.
+ *   empty object
+ * - `locator`: Whether to record node locations in the XML string, default is true
  *
- * @param options  {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string,
- *                 object][],
- *                 locator?: boolean }}
- * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, Object][] }}
+ * @param options {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string, object][],
+ *   locator?: boolean }}
+ * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, object][] }}
  */
 function getTestParser({ onError, errors = [], locator = true } = {}) {
 	onError =

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -1,27 +1,21 @@
 'use strict';
 const { DOMParser } = require('../lib/dom-parser');
 
-/**
- * @typedef ErrorLevel {'warn' | 'error' | 'fatalError'}
- */
+/** @typedef ErrorLevel {'warn' | 'error' | 'fatalError'} */
 
 /**
- * Helper method for configuring an instance of DOMParser.
- * Calling it without any arguments allows to assert on `errors` after using the parser.
- * every field of the first argument is options and allows to specify test specific behavior.
- * - `errorHandler`: The `errorHandler` to pass to DOMParser constructor options,
- * 									default stores a list of all entries per `key` in `errors` and does not log or throw.
- * - `errors`: the object for the `errorHandler` to use,
- * 						is also returned with the same name for later assertions,
- * 						default is an empty object
+ * Helper method for configuring an instance of DOMParser. Calling it without any arguments allows to assert on `errors` after
+ * using the parser. every field of the first argument is options and allows to specify test specific behavior.
+ *
+ * - `errorHandler`: The `errorHandler` to pass to DOMParser constructor options, default stores a list of all entries per `key` in
+ *   `errors` and does not log or throw.
+ * - `errors`: the object for the `errorHandler` to use, is also returned with the same name for later assertions, default is an
+ *   empty object
  * - `locator`: Whether to record node locations in the XML string, default is true
  *
- * @param options {{
- * 					onError?: function (level:string, msg:string, context:DOMHandler),
- * 					errors?: [ErrorLevel, string, object][],
- * 					locator?: boolean
- *				}}
- * @returns {{parser: DOMParser, errors: [ErrorLevel, string, object][]}}
+ * @param options {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string, object][],
+ *   locator?: boolean }}
+ * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, object][] }}
  */
 function getTestParser({ onError, errors = [], locator = true } = {}) {
 	onError =

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -16,10 +16,9 @@ const { DOMParser } = require('../lib/dom-parser');
  * - `errors`: the object for the `errorHandler` to use, is also returned with the same name for later assertions, default is an
  * empty object - `locator`: Whether to record node locations in the XML string, default is true.
  *
- * @param options
- * {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string,
- * object][],
- * locator?: boolean }}
+ * @param options  {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string,
+ *                 object][],
+ *                 locator?: boolean }}
  * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, Object][] }}
  */
 function getTestParser({ onError, errors = [], locator = true } = {}) {

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -2,7 +2,9 @@
 const { DOMParser } = require('../lib/dom-parser');
 
 /**
- * @typedef ErrorLevel {'warn' | 'error' | 'fatalError'}
+ * {'warn' | 'error' | 'fatalError'}
+ *
+ * @typedef ErrorLevel
  */
 
 /**
@@ -10,18 +12,17 @@ const { DOMParser } = require('../lib/dom-parser');
  * Calling it without any arguments allows to assert on `errors` after using the parser.
  * every field of the first argument is options and allows to specify test specific behavior.
  * - `errorHandler`: The `errorHandler` to pass to DOMParser constructor options,
- * 									default stores a list of all entries per `key` in `errors` and does not log or throw.
+ * default stores a list of all entries per `key` in `errors` and does not log or throw.
  * - `errors`: the object for the `errorHandler` to use,
- * 						is also returned with the same name for later assertions,
- * 						default is an empty object
- * - `locator`: Whether to record node locations in the XML string, default is true
+ * is also returned with the same name for later assertions,
+ * default is an empty object - `locator`: Whether to record node locations in the XML string, default is true.
  *
- * @param options {{
- * 					onError?: function (level:string, msg:string, context:DOMHandler),
- * 					errors?: [ErrorLevel, string, object][],
- * 					locator?: boolean
- *				}}
- * @returns {{parser: DOMParser, errors: [ErrorLevel, string, object][]}}
+ * @param options
+ * {{
+ * onError?: function (level:string, msg:string, context:DOMHandler),
+ * errors?: [ErrorLevel, string, object][],
+ * locator?: boolean }}
+ * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, Object][] }}
  */
 function getTestParser({ onError, errors = [], locator = true } = {}) {
 	onError =

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -1,21 +1,27 @@
 'use strict';
 const { DOMParser } = require('../lib/dom-parser');
 
-/** @typedef ErrorLevel {'warn' | 'error' | 'fatalError'} */
+/**
+ * @typedef ErrorLevel {'warn' | 'error' | 'fatalError'}
+ */
 
 /**
- * Helper method for configuring an instance of DOMParser. Calling it without any arguments allows to assert on `errors` after
- * using the parser. every field of the first argument is options and allows to specify test specific behavior.
- *
- * - `errorHandler`: The `errorHandler` to pass to DOMParser constructor options, default stores a list of all entries per `key` in
- *   `errors` and does not log or throw.
- * - `errors`: the object for the `errorHandler` to use, is also returned with the same name for later assertions, default is an
- *   empty object
+ * Helper method for configuring an instance of DOMParser.
+ * Calling it without any arguments allows to assert on `errors` after using the parser.
+ * every field of the first argument is options and allows to specify test specific behavior.
+ * - `errorHandler`: The `errorHandler` to pass to DOMParser constructor options,
+ * 									default stores a list of all entries per `key` in `errors` and does not log or throw.
+ * - `errors`: the object for the `errorHandler` to use,
+ * 						is also returned with the same name for later assertions,
+ * 						default is an empty object
  * - `locator`: Whether to record node locations in the XML string, default is true
  *
- * @param options {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string, object][],
- *   locator?: boolean }}
- * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, object][] }}
+ * @param options {{
+ * 					onError?: function (level:string, msg:string, context:DOMHandler),
+ * 					errors?: [ErrorLevel, string, object][],
+ * 					locator?: boolean
+ *				}}
+ * @returns {{parser: DOMParser, errors: [ErrorLevel, string, object][]}}
  */
 function getTestParser({ onError, errors = [], locator = true } = {}) {
 	onError =

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -15,7 +15,8 @@ const { DOMParser } = require('../lib/dom-parser');
  * default stores a list of all entries per `key` in `errors` and does not log or throw.
  * - `errors`: the object for the `errorHandler` to use,
  * is also returned with the same name for later assertions,
- * default is an empty object - `locator`: Whether to record node locations in the XML string, default is true.
+ * default is an empty object - `locator`: Whether to record node locations in the XML string,
+ * default is true.
  *
  * @param options
  * {{

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -16,9 +16,10 @@ const { DOMParser } = require('../lib/dom-parser');
  * - `errors`: the object for the `errorHandler` to use, is also returned with the same name for later assertions, default is an
  * empty object - `locator`: Whether to record node locations in the XML string, default is true.
  *
- * @param options  {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string,
- *                 object][],
- *                 locator?: boolean }}
+ * @param options
+ * {{ onError?: function (level:string, msg:string, context:DOMHandler), errors?: [ErrorLevel, string,
+ * object][],
+ * locator?: boolean }}
  * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, Object][] }}
  */
 function getTestParser({ onError, errors = [], locator = true } = {}) {

--- a/test/grammar/utils.js
+++ b/test/grammar/utils.js
@@ -4,7 +4,6 @@
  * methods in this file should make it easier to do that.
  */
 /**
- *
  * @param {string} from
  * @param {string} to
  * @returns {string}

--- a/test/grammar/utils.js
+++ b/test/grammar/utils.js
@@ -1,10 +1,6 @@
 'use strict';
+/** See https://stackoverflow.com/a/488640/684134 methods in this file should make it easier to do that. */
 /**
- * See https://stackoverflow.com/a/488640/684134
- * methods in this file should make it easier to do that.
- */
-/**
- *
  * @param {string} from
  * @param {string} to
  * @returns {string}

--- a/test/grammar/utils.js
+++ b/test/grammar/utils.js
@@ -1,6 +1,10 @@
 'use strict';
-/** See https://stackoverflow.com/a/488640/684134 methods in this file should make it easier to do that. */
 /**
+ * See https://stackoverflow.com/a/488640/684134
+ * methods in this file should make it easier to do that.
+ */
+/**
+ *
  * @param {string} from
  * @param {string} to
  * @returns {string}

--- a/test/grammar/xml.grammar.js
+++ b/test/grammar/xml.grammar.js
@@ -5,7 +5,9 @@ const fs = require('fs');
 
 const onError = () => {};
 const collected = {};
-/** @returns {Document} */
+/**
+ * @returns {Document}
+ */
 const parseSpecFile = (filename) => {
 	var doc = new DOMParser({ onError }).parseFromString(fs.readFileSync(__dirname + `/${filename}`, 'utf-8'), MIME_TYPE.HTML);
 	const scraps = doc.getElementsByClassName('scrap');

--- a/test/grammar/xml.grammar.js
+++ b/test/grammar/xml.grammar.js
@@ -5,9 +5,7 @@ const fs = require('fs');
 
 const onError = () => {};
 const collected = {};
-/**
- * @returns {Document}
- */
+/** @returns {Document} */
 const parseSpecFile = (filename) => {
 	var doc = new DOMParser({ onError }).parseFromString(fs.readFileSync(__dirname + `/${filename}`, 'utf-8'), MIME_TYPE.HTML);
 	const scraps = doc.getElementsByClassName('scrap');

--- a/test/parse/namespace.test.js
+++ b/test/parse/namespace.test.js
@@ -7,7 +7,8 @@ const { DOMParser } = require('../../lib/dom-parser');
 /**
  * Returns an array containing only one occurrence of every sting in `values` (like in a Set).
  *
- * @param values  {string}
+ * @param values
+ * {string}
  */
 const uniqArray = (...values) => [...new Set(values)];
 

--- a/test/parse/namespace.test.js
+++ b/test/parse/namespace.test.js
@@ -7,7 +7,7 @@ const { DOMParser } = require('../../lib/dom-parser');
 /**
  * Returns an array containing only one occurrence of every sting in `values` (like in a Set).
  *
- * @param values {string}
+ * @param values  {string}
  */
 const uniqArray = (...values) => [...new Set(values)];
 

--- a/test/parse/namespace.test.js
+++ b/test/parse/namespace.test.js
@@ -7,7 +7,7 @@ const { DOMParser } = require('../../lib/dom-parser');
 /**
  * Returns an array containing only one occurrence of every sting in `values` (like in a Set).
  *
- * @param values  {string}
+ * @param values {string}
  */
 const uniqArray = (...values) => [...new Set(values)];
 

--- a/test/parse/namespace.test.js
+++ b/test/parse/namespace.test.js
@@ -7,8 +7,7 @@ const { DOMParser } = require('../../lib/dom-parser');
 /**
  * Returns an array containing only one occurrence of every sting in `values` (like in a Set).
  *
- * @param values
- * {string}
+ * @param values  {string}
  */
 const uniqArray = (...values) => [...new Set(values)];
 

--- a/test/parse/namespace.test.js
+++ b/test/parse/namespace.test.js
@@ -7,7 +7,8 @@ const { DOMParser } = require('../../lib/dom-parser');
 /**
  * Returns an array containing only one occurrence of every sting in `values` (like in a Set).
  *
- * @param values {string}
+ * @param values
+ * {string}
  */
 const uniqArray = (...values) => [...new Set(values)];
 

--- a/test/parse/namespace.test.js
+++ b/test/parse/namespace.test.js
@@ -5,10 +5,10 @@ const { MIME_TYPE } = require('../../lib/conventions');
 const { DOMParser } = require('../../lib/dom-parser');
 
 /**
- * Returns an array containing only one occurrence of every sting in `values` (like in a Set).
+ * Returns an array containing only one occurrence of every sting in `values`
+ * (like in a Set).
  *
- * @param values
- * {string}
+ * @param {string} values
  */
 const uniqArray = (...values) => [...new Set(values)];
 

--- a/test/xmltest/generate-snapshot.js
+++ b/test/xmltest/generate-snapshot.js
@@ -5,9 +5,9 @@ const { replaceNonTextChars } = require('xmltest');
 /**
  * Generate minimal snapshot representation by not adding empty lists to the snapshots.
  *
- * @param actual    {string | undefined | {toString: function(): string}}
- * @param errors    {[ErrorLevel, string][]}
- * @param expected  {string?} (optional) compared to actual-only added to output if different.
+ * @param actual {string | undefined | {toString: function(): string}}
+ * @param errors {[ErrorLevel, string][]}
+ * @param expected {string?} (optional) compared to actual-only added to output if different
  * @returns {{ actual?: string } & Partial<Record<ErrorLevel, string[]>>}
  */
 const generateSnapshot = (actual, errors, expected) => {

--- a/test/xmltest/generate-snapshot.js
+++ b/test/xmltest/generate-snapshot.js
@@ -8,7 +8,7 @@ const { replaceNonTextChars } = require('xmltest');
  * @param {string | undefined | {toString: function(): string}} actual
  * @param {[ErrorLevel, string][]} errors
  * @param {string} [expected]
- *  compared to actual-only added to output if different.
+ * Compared to actual-only added to output if different.
  * @returns {{ actual?: string } & Partial<Record<ErrorLevel, string[]>>}
  */
 const generateSnapshot = (actual, errors, expected) => {

--- a/test/xmltest/generate-snapshot.js
+++ b/test/xmltest/generate-snapshot.js
@@ -3,13 +3,12 @@
 const { replaceNonTextChars } = require('xmltest');
 
 /**
- * Generate minimal snapshot representation by not adding empty lists to the
- * snapshots.
+ * Generate minimal snapshot representation by not adding empty lists to the snapshots.
  *
  * @param actual {string | undefined | {toString: function(): string}}
  * @param errors {[ErrorLevel, string][]}
  * @param expected {string?} (optional) compared to actual-only added to output if different
- * @returns {{actual?: string} & Partial<Record<ErrorLevel, string[]>>}
+ * @returns {{ actual?: string } & Partial<Record<ErrorLevel, string[]>>}
  */
 const generateSnapshot = (actual, errors, expected) => {
 	const actualForSnapshot = replaceNonTextChars(actual);

--- a/test/xmltest/generate-snapshot.js
+++ b/test/xmltest/generate-snapshot.js
@@ -5,9 +5,12 @@ const { replaceNonTextChars } = require('xmltest');
 /**
  * Generate minimal snapshot representation by not adding empty lists to the snapshots.
  *
- * @param actual    {string | undefined | {toString: function(): string}}
- * @param errors    {[ErrorLevel, string][]}
- * @param expected  {string?} (optional) compared to actual-only added to output if different.
+ * @param actual
+ * {string | undefined | {toString: function(): string}}
+ * @param errors
+ * {[ErrorLevel, string][]}
+ * @param expected
+ * {string?} (optional) compared to actual-only added to output if different.
  * @returns {{ actual?: string } & Partial<Record<ErrorLevel, string[]>>}
  */
 const generateSnapshot = (actual, errors, expected) => {

--- a/test/xmltest/generate-snapshot.js
+++ b/test/xmltest/generate-snapshot.js
@@ -5,9 +5,9 @@ const { replaceNonTextChars } = require('xmltest');
 /**
  * Generate minimal snapshot representation by not adding empty lists to the snapshots.
  *
- * @param actual {string | undefined | {toString: function(): string}}
- * @param errors {[ErrorLevel, string][]}
- * @param expected {string?} (optional) compared to actual-only added to output if different
+ * @param actual    {string | undefined | {toString: function(): string}}
+ * @param errors    {[ErrorLevel, string][]}
+ * @param expected  {string?} (optional) compared to actual-only added to output if different.
  * @returns {{ actual?: string } & Partial<Record<ErrorLevel, string[]>>}
  */
 const generateSnapshot = (actual, errors, expected) => {

--- a/test/xmltest/generate-snapshot.js
+++ b/test/xmltest/generate-snapshot.js
@@ -3,13 +3,15 @@
 const { replaceNonTextChars } = require('xmltest');
 
 /**
- * Generate minimal snapshot representation by not adding empty lists to the
- * snapshots.
+ * Generate minimal snapshot representation by not adding empty lists to the snapshots.
  *
- * @param actual {string | undefined | {toString: function(): string}}
- * @param errors {[ErrorLevel, string][]}
- * @param expected {string?} (optional) compared to actual-only added to output if different
- * @returns {{actual?: string} & Partial<Record<ErrorLevel, string[]>>}
+ * @param actual
+ * {string | undefined | {toString: function(): string}}
+ * @param errors
+ * {[ErrorLevel, string][]}
+ * @param expected
+ * {string?} (optional) compared to actual-only added to output if different.
+ * @returns {{ actual?: string } & Partial<Record<ErrorLevel, string[]>>}
  */
 const generateSnapshot = (actual, errors, expected) => {
 	const actualForSnapshot = replaceNonTextChars(actual);

--- a/test/xmltest/generate-snapshot.js
+++ b/test/xmltest/generate-snapshot.js
@@ -5,12 +5,9 @@ const { replaceNonTextChars } = require('xmltest');
 /**
  * Generate minimal snapshot representation by not adding empty lists to the snapshots.
  *
- * @param actual
- * {string | undefined | {toString: function(): string}}
- * @param errors
- * {[ErrorLevel, string][]}
- * @param expected
- * {string?} (optional) compared to actual-only added to output if different.
+ * @param actual    {string | undefined | {toString: function(): string}}
+ * @param errors    {[ErrorLevel, string][]}
+ * @param expected  {string?} (optional) compared to actual-only added to output if different.
  * @returns {{ actual?: string } & Partial<Record<ErrorLevel, string[]>>}
  */
 const generateSnapshot = (actual, errors, expected) => {

--- a/test/xmltest/generate-snapshot.js
+++ b/test/xmltest/generate-snapshot.js
@@ -3,12 +3,13 @@
 const { replaceNonTextChars } = require('xmltest');
 
 /**
- * Generate minimal snapshot representation by not adding empty lists to the snapshots.
+ * Generate minimal snapshot representation by not adding empty lists to the
+ * snapshots.
  *
  * @param actual {string | undefined | {toString: function(): string}}
  * @param errors {[ErrorLevel, string][]}
  * @param expected {string?} (optional) compared to actual-only added to output if different
- * @returns {{ actual?: string } & Partial<Record<ErrorLevel, string[]>>}
+ * @returns {{actual?: string} & Partial<Record<ErrorLevel, string[]>>}
  */
 const generateSnapshot = (actual, errors, expected) => {
 	const actualForSnapshot = replaceNonTextChars(actual);

--- a/test/xmltest/generate-snapshot.js
+++ b/test/xmltest/generate-snapshot.js
@@ -5,12 +5,10 @@ const { replaceNonTextChars } = require('xmltest');
 /**
  * Generate minimal snapshot representation by not adding empty lists to the snapshots.
  *
- * @param actual
- * {string | undefined | {toString: function(): string}}
- * @param errors
- * {[ErrorLevel, string][]}
- * @param expected
- * {string?} (optional) compared to actual-only added to output if different.
+ * @param {string | undefined | {toString: function(): string}} actual
+ * @param {[ErrorLevel, string][]} errors
+ * @param {string} [expected]
+ *  compared to actual-only added to output if different.
  * @returns {{ actual?: string } & Partial<Record<ErrorLevel, string[]>>}
  */
 const generateSnapshot = (actual, errors, expected) => {


### PR DESCRIPTION
This PR includes a commit that adds the prettier-plugin-jsdoc dependency to the project.
The plugin will improve the readability and maintainability of our JSDoc comments and ensure a consistent style across the project.