### PR TITLE
fix(dom): prevent iteration over deleted items

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -273,7 +273,7 @@ NodeList.prototype = {
 	 * 	The node at the indexth position in the NodeList, or null if that is not a valid index.
 	 */
 	item: function (index) {
-		return this[index] || null;
+		return index >= 0 && index < this.length ? this[index] : null;
 	},
 	toString: function (nodeFilter) {
 		for (var buf = [], i = 0; i < this.length; i++) {
@@ -306,17 +306,23 @@ function LiveNodeList(node, refresh) {
 }
 function _updateLiveList(list) {
 	var inc = list._node._inc || list._node.ownerDocument._inc;
-	if (list._inc != inc) {
+	if (list._inc !== inc) {
 		var ls = list._refresh(list._node);
-		//console.log(ls.length)
 		__set__(list, 'length', ls.length);
+		if (!list.$$length || ls.length < list.$$length) {
+			for (var i = ls.length; i in list; i++) {
+				if (Object.prototype.hasOwnProperty.call(list, i)) {
+					delete list[i];
+				}
+			}
+		}
 		copy(ls, list);
 		list._inc = inc;
 	}
 }
 LiveNodeList.prototype.item = function (i) {
 	_updateLiveList(this);
-	return this[i];
+	return this[i] || null;
 };
 
 _extends(LiveNodeList, NodeList);
@@ -2254,12 +2260,14 @@ try {
 	//ie8
 }
 
+exports._updateLiveList = _updateLiveList;
 exports.Attr = Attr;
 exports.Document = Document;
 exports.DocumentType = DocumentType;
 exports.DOMException = DOMException;
 exports.DOMImplementation = DOMImplementation;
 exports.Element = Element;
+exports.LiveNodeList = LiveNodeList;
 exports.NamedNodeMap = NamedNodeMap;
 exports.Node = Node;
 exports.NodeList = NodeList;

--- a/test/dom/node-list.test.js
+++ b/test/dom/node-list.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { describe, expect, test } = require('@jest/globals');
-const { NodeList, LiveNodeList, Node, DOMImplementation } = require('../../lib/dom');
+const { NodeList, LiveNodeList, DOMImplementation } = require('../../lib/dom');
 
 describe('NodeList', () => {
 	describe('item', () => {

--- a/test/dom/node-list.test.js
+++ b/test/dom/node-list.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { describe, expect, test } = require('@jest/globals');
+const { NodeList, LiveNodeList, Node, DOMImplementation } = require('../../lib/dom');
+
+describe('NodeList', () => {
+	describe('item', () => {
+		test('should return null for items outside length', () => {
+			const it = new NodeList();
+			expect(it.length).toBe(0);
+			expect(it.item(-1)).toBe(null);
+			expect(it.item(0)).toBe(null);
+		});
+		test('should return item for existing item', () => {
+			const it = new NodeList();
+			const item = {};
+			it[0] = item;
+			it.length = 1;
+			expect(it.item(0)).toBe(item);
+		});
+	});
+});
+
+describe('_updateLiveList', () => {
+	test('should remove item from LiveNodeList after length is reduced', () => {
+		const doc = new DOMImplementation().createDocument(null, 'xml');
+		const node = doc.createElement('listNode');
+		const child = doc.createElement('child');
+		node.appendChild(child);
+		const refresh = jest.fn(() => [child]);
+		const list = new LiveNodeList(node, refresh);
+		expect(list[0]).toBe(child);
+		expect(list.length).toBe(1);
+		expect(refresh).toHaveBeenCalledTimes(1);
+
+		doc._inc++;
+		expect(list.item(0)).toBe(child);
+		expect(refresh).toHaveBeenCalledTimes(2);
+		expect(list[0]).toBe(child);
+		expect(list.length).toBe(1);
+
+		refresh.mockReturnValueOnce([]);
+		doc._inc++;
+		expect(list.item(0)).toBe(null);
+		expect(refresh).toHaveBeenCalledTimes(3);
+		expect(list[0]).toBe(undefined);
+		expect(list.length).toBe(0);
+	});
+});


### PR DESCRIPTION
- `NodeList.item` now checks the `length` attribute before accessing the item at a provided index and returns `null` it the index is out of range
- when updating `LiveNodeList` (as part of accessing the `item` method) and the new `length` is shorter then the current one, any references on indexes following the index starting from `length` are `delete`d, and `null` is returned instead of `undefined`
- added some exports to the `lib/dom.js` module to enable testing

fixes #499