### PR TITLE
revert: "chore(deps): update codecov/codecov-action action to v4 (#534)"

### DIFF
--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -36,7 +36,7 @@ jobs:
     - run: npm run test -- --coverage
       if: matrix.node-version == 16
     - if: matrix.node-version == 16
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
This reverts commit dbd84c6e877897e296b7a570386232deb42b2af7.

It looks like the version that was marked as a prerelease has been removed or untagged.