### PR TITLE
docs: click to copy install command in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,9 @@ This project was forked from it's [original source](https://github.com/jindw/xml
 
 ### Install:
 
-> npm install @xmldom/xmldom
+``` 
+npm install @xmldom/xmldom
+```
 
 ### Example:
 


### PR DESCRIPTION
Put install command in distinct block with triple backtick to easily copy/paste in order to save time (dozen seconds or so).