### PR TITLE
feat: add DOM level 4 child element properties

### DIFF
--- a/fuzz/__snapshots__/regression.test.js.snap
+++ b/fuzz/__snapshots__/regression.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`dom-parser.html.target.js crash-doctype-in-element.xml 1`] = `-1`;
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -201,38 +201,6 @@ function copy(src, dest) {
 	}
 }
 
-/**
- * Extends a class with the properties and methods of a super class.
- * It uses a form of prototypal inheritance, and establishes the `constructor` property
- * correctly(?).
- *
- * It is not clear to the current maintainers if this implementation is making sense,
- * since it creates an intermediate prototype function,
- * which all properties of `Super` are copied onto using `_copy`.
- *
- * @param {Object} Class
- * The class that is to be extended.
- * @param {Object} Super
- * The super class from which properties and methods are inherited.
- * @private
- */
-function _extends(Class, Super) {
-	var pt = Class.prototype;
-	if (!(pt instanceof Super)) {
-		function t() {}
-		t.prototype = Super.prototype;
-		t = new t();
-		copy(pt, t);
-		Class.prototype = pt = t;
-	}
-	if (pt.constructor != Class) {
-		if (typeof Class != 'function') {
-			console.error('unknown Class:' + Class);
-		}
-		pt.constructor = Class;
-	}
-}
-
 var NodeType = {};
 var ELEMENT_NODE = (NodeType.ELEMENT_NODE = 1);
 var ATTRIBUTE_NODE = (NodeType.ATTRIBUTE_NODE = 2);
@@ -405,6 +373,7 @@ NodeList.prototype[Symbol.iterator] = function () {
  * @constructs LiveNodeList
  */
 function LiveNodeList(node, refresh) {
+	NodeList.call(this);
 	this._node = node;
 	this._refresh = refresh;
 	_updateLiveList(this);
@@ -441,12 +410,14 @@ function _updateLiveList(list) {
  * @returns {Node | null}
  * The node at position `index` in the LiveNodeList, or null if that is not a valid index.
  */
-LiveNodeList.prototype.item = function (i) {
-	_updateLiveList(this);
-	return this[i] || null;
+LiveNodeList.prototype = {
+	__proto__: NodeList.prototype,
+	constructor: LiveNodeList,
+	item: function (i) {
+		_updateLiveList(this);
+		return this[i] || null;
+	},
 };
-
-_extends(LiveNodeList, NodeList);
 
 /**
  * Objects implementing the NamedNodeMap interface are used to represent collections of nodes
@@ -1561,7 +1532,7 @@ function _visitNode(node, callback) {
  * @see https://dom.spec.whatwg.org/#interface-document
  */
 function Document(symbol, options) {
-	checkSymbol(symbol);
+	Node.call(this, symbol);
 
 	var opt = options || {};
 	this.ownerDocument = this;
@@ -1630,7 +1601,8 @@ function _onRemoveAttribute(doc, el, newAttr, remove) {
  * Updates `parent.childNodes`, adjusting the indexed items and its `length`.
  * If `newChild` is provided and has no nextSibling, it will be appended.
  * Otherwise, it's assumed that an item has been removed or inserted,
- * and `parent.firstNode` and its `.nextSibling` to re-indexing all child nodes of `parent`.
+ * and `parent.firstNode` and its `.nextSibling` are used to re-index all child nodes of
+ * `parent`.
  *
  * @param {Document} doc
  * The parent document of `el`.
@@ -2060,7 +2032,7 @@ function _insertBefore(parent, node, child, _inDocumentAssertion) {
 	do {
 		newFirst.parentNode = parent;
 	} while (newFirst !== newLast && (newFirst = newFirst.nextSibling));
-	_onUpdateChild(parent.ownerDocument || parent, parent, node);
+	_onUpdateChild(parent.ownerDocument || parent, parent, node.nodeType === DOCUMENT_FRAGMENT_NODE ? null : node);
 	if (node.nodeType == DOCUMENT_FRAGMENT_NODE) {
 		node.firstChild = node.lastChild = null;
 	}
@@ -2069,6 +2041,8 @@ function _insertBefore(parent, node, child, _inDocumentAssertion) {
 }
 
 Document.prototype = {
+	__proto__: Node.prototype,
+	constructor: Document,
 	/**
 	 * The implementation that created this document.
 	 *
@@ -2086,6 +2060,41 @@ Document.prototype = {
 	 */
 	doctype: null,
 	documentElement: null,
+
+	get children() {
+		return new LiveNodeList(this, childrenRefresh);
+	},
+
+	/**
+	 * The number of child elements of the current document.
+	 *
+	 * @type {number}
+	 * @readonly
+	 */
+	get childElementCount() {
+		return this.children.length;
+	},
+
+	/**
+	 * The first child element of the current document.
+	 *
+	 * @type {Element | null}
+	 * @readonly
+	 */
+	get firstElementChild() {
+		return this.children.item(0);
+	},
+
+	/**
+	 * The last child element of the current document.
+	 *
+	 * @type {Element | null}
+	 * @readonly
+	 */
+	get lastElementChild() {
+		return this.children.item(this.children.length - 1);
+	},
+
 	_inc: 1,
 
 	insertBefore: function (newChild, refChild) {
@@ -2348,14 +2357,15 @@ Document.prototype = {
 		return node;
 	},
 };
-_extends(Document, Node);
 
 function Element(symbol) {
-	checkSymbol(symbol);
-
+	Node.call(this, symbol);
 	this._nsMap = Object.create(null);
 }
 Element.prototype = {
+	__proto__: Node.prototype,
+	constructor: Element,
+
 	nodeType: ELEMENT_NODE,
 	/**
 	 * The attributes of this element.
@@ -2363,6 +2373,61 @@ Element.prototype = {
 	 * @type {NamedNodeMap | null}
 	 */
 	attributes: null,
+
+	get children() {
+		return new LiveNodeList(this, childrenRefresh);
+	},
+
+	/**
+	 * The number of child elements of this element.
+	 *
+	 * @type {number}
+	 * @readonly
+	 */
+	get childElementCount() {
+		return this.children.length;
+	},
+
+	/**
+	 * An element's first child Element, or null if there are no child elements.
+	 *
+	 * @type {Element | null}
+	 * @readonly
+	 */
+	get firstElementChild() {
+		return this.children.item(0);
+	},
+
+	/**
+	 * An element's last child Element, or null if there are no child elements.
+	 *
+	 * @type {Element | null}
+	 * @readonly
+	 */
+	get lastElementChild() {
+		return this.children.item(this.children.length - 1);
+	},
+
+	/**
+	 * The first preceding sibling that is an element; otherwise null.
+	 *
+	 * @type {Element | null}
+	 * @readonly
+	 */
+	get previousElementSibling() {
+		return this.parentNode ? this.parentNode.children.item(this.parentNode.children.indexOf(this) - 1) : null;
+	},
+
+	/**
+	 * The first following sibling that is an element; otherwise null.
+	 *
+	 * @type {Element | null}
+	 * @readonly
+	 */
+	get nextElementSibling() {
+		return this.parentNode ? this.parentNode.children.item(this.parentNode.children.indexOf(this) + 1) : null;
+	},
+
 	getQualifiedName: function () {
 		return this.prefix ? this.prefix + ':' + this.localName : this.localName;
 	},
@@ -2591,21 +2656,25 @@ Document.prototype.getElementsByClassName = Element.prototype.getElementsByClass
 Document.prototype.getElementsByTagName = Element.prototype.getElementsByTagName;
 Document.prototype.getElementsByTagNameNS = Element.prototype.getElementsByTagNameNS;
 
-_extends(Element, Node);
 function Attr(symbol) {
-	checkSymbol(symbol);
+	Node.call(this, symbol);
 
 	this.namespaceURI = null;
 	this.prefix = null;
 	this.ownerElement = null;
 }
-Attr.prototype.nodeType = ATTRIBUTE_NODE;
-_extends(Attr, Node);
+Attr.prototype = {
+	__proto__: Node.prototype,
+	constructor: Attr,
+	nodeType: ATTRIBUTE_NODE,
+};
 
 function CharacterData(symbol) {
-	checkSymbol(symbol);
+	Node.call(this, symbol);
 }
 CharacterData.prototype = {
+	__proto__: Node.prototype,
+	constructor: CharacterData,
 	data: '',
 	substringData: function (offset, count) {
 		return this.data.substring(offset, offset + count);
@@ -2629,11 +2698,13 @@ CharacterData.prototype = {
 		this.length = text.length;
 	},
 };
-_extends(CharacterData, Node);
+
 function Text(symbol) {
-	checkSymbol(symbol);
+	CharacterData.call(this, symbol);
 }
 Text.prototype = {
+	__proto__: CharacterData.prototype,
+	constructor: Text,
 	nodeName: '#text',
 	nodeType: TEXT_NODE,
 	splitText: function (offset) {
@@ -2649,61 +2720,115 @@ Text.prototype = {
 		return newNode;
 	},
 };
-_extends(Text, CharacterData);
+
 function Comment(symbol) {
-	checkSymbol(symbol);
+	CharacterData.call(this, symbol);
 }
 Comment.prototype = {
+	__proto__: CharacterData.prototype,
+	constructor: Comment,
 	nodeName: '#comment',
 	nodeType: COMMENT_NODE,
 };
-_extends(Comment, CharacterData);
 
 function CDATASection(symbol) {
-	checkSymbol(symbol);
+	Text.call(this, symbol);
 }
 CDATASection.prototype = {
+	__proto__: Text.prototype,
+	constructor: CDATASection,
 	nodeName: '#cdata-section',
 	nodeType: CDATA_SECTION_NODE,
 };
-_extends(CDATASection, Text);
 
 function DocumentType(symbol) {
-	checkSymbol(symbol);
+	Node.call(this, symbol);
 }
-DocumentType.prototype.nodeType = DOCUMENT_TYPE_NODE;
-_extends(DocumentType, Node);
+DocumentType.prototype = {
+	__proto__: Node.prototype,
+	constructor: DocumentType,
+	nodeType: DOCUMENT_TYPE_NODE,
+};
 
 function Notation(symbol) {
-	checkSymbol(symbol);
+	Node.call(this, symbol);
 }
-Notation.prototype.nodeType = NOTATION_NODE;
-_extends(Notation, Node);
+Notation.prototype = {
+	__proto__: Node.prototype,
+	constructor: Notation,
+	nodeType: NOTATION_NODE,
+};
 
 function Entity(symbol) {
-	checkSymbol(symbol);
+	Node.call(this, symbol);
 }
-Entity.prototype.nodeType = ENTITY_NODE;
-_extends(Entity, Node);
+Entity.prototype = {
+	__proto__: Node.prototype,
+	constructor: Entity,
+	nodeType: ENTITY_NODE,
+};
 
 function EntityReference(symbol) {
-	checkSymbol(symbol);
+	Node.call(this, symbol);
 }
-EntityReference.prototype.nodeType = ENTITY_REFERENCE_NODE;
-_extends(EntityReference, Node);
+EntityReference.prototype = {
+	__proto__: Node.prototype,
+	constructor: EntityReference,
+	nodeType: ENTITY_REFERENCE_NODE,
+};
 
 function DocumentFragment(symbol) {
-	checkSymbol(symbol);
+	Node.call(this, symbol);
 }
-DocumentFragment.prototype.nodeName = '#document-fragment';
-DocumentFragment.prototype.nodeType = DOCUMENT_FRAGMENT_NODE;
-_extends(DocumentFragment, Node);
+DocumentFragment.prototype = {
+	__proto__: Node.prototype,
+	constructor: DocumentFragment,
+	nodeName: '#document-fragment',
+	nodeType: DOCUMENT_FRAGMENT_NODE,
+
+	get children() {
+		return new LiveNodeList(this, childrenRefresh);
+	},
+
+	/**
+	 * The amount of child elements the `DocumentFragment` has.
+	 *
+	 * @type {number}
+	 * @readonly
+	 */
+	get childElementCount() {
+		return this.children.length;
+	},
+	/**
+	 * The Element that is the first child of the `DocumentFragment` object, or null if there is
+	 * none.
+	 *
+	 * @type {Element | null}
+	 * @readonly
+	 */
+	get firstElementChild() {
+		return this.children.item(0);
+	},
+	/**
+	 * The Element that is the last child of the `DocumentFragment` object, or null if there is
+	 * none.
+	 *
+	 * @type {Element | null}
+	 * @readonly
+	 */
+	get lastElementChild() {
+		return this.children.item(this.children.length - 1);
+	},
+};
 
 function ProcessingInstruction(symbol) {
-	checkSymbol(symbol);
+	CharacterData.call(this, symbol);
 }
-ProcessingInstruction.prototype.nodeType = PROCESSING_INSTRUCTION_NODE;
-_extends(ProcessingInstruction, CharacterData);
+ProcessingInstruction.prototype = {
+	__proto__: CharacterData.prototype,
+	constructor: ProcessingInstruction,
+	nodeType: PROCESSING_INSTRUCTION_NODE,
+};
 function XMLSerializer() {}
 /**
  * Returns the result of serializing `node` to XML.
@@ -3144,22 +3269,6 @@ try {
 					return node.nodeValue;
 			}
 		}
-
-		Object.defineProperty(Element.prototype, 'children', {
-			get: function () {
-				return new LiveNodeList(this, childrenRefresh);
-			},
-		});
-		Object.defineProperty(Document.prototype, 'children', {
-			get: function () {
-				return new LiveNodeList(this, childrenRefresh);
-			},
-		});
-		Object.defineProperty(DocumentFragment.prototype, 'children', {
-			get: function () {
-				return new LiveNodeList(this, childrenRefresh);
-			},
-		});
 
 		__set__ = function (object, key, value) {
 			//console.log(value)

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"eslint-plugin-n": "17.24.0",
 				"eslint-plugin-prettier": "5.5.5",
 				"get-stream": "6.0.1",
-				"jest": "29.7.0",
+				"jest": "30.3.0",
 				"nodemon": "3.1.14",
 				"np": "8.0.4",
 				"prettier": "3.8.1",
@@ -38,71 +38,48 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/highlight": "^7.22.13",
-				"chalk": "^2.4.2"
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/code-frame/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.20.tgz",
-			"integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-			"integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.0",
-				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-module-transforms": "^7.23.0",
-				"@babel/helpers": "^7.23.2",
-				"@babel/parser": "^7.23.0",
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.2",
-				"@babel/types": "^7.23.0",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -118,29 +95,32 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+			"version": "7.29.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.23.0",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"@jridgewell/trace-mapping": "^0.3.17",
-				"jsesc": "^2.5.1"
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-			"integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.22.9",
-				"@babel/helper-validator-option": "^7.22.15",
-				"browserslist": "^4.21.9",
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-validator-option": "^7.27.1",
+				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -153,6 +133,7 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
@@ -161,65 +142,43 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true
-		},
-		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
+			"license": "ISC"
 		},
-		"node_modules/@babel/helper-function-name": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
 			"dev": true,
-			"dependencies": {
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.23.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.22.5"
-			},
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.22.15"
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-			"integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-simple-access": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/helper-validator-identifier": "^7.22.20"
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -229,112 +188,68 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
 			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-simple-access": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.22.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.22.5"
-			},
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-			"integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-			"integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.2",
-				"@babel/types": "^7.23.0"
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -347,6 +262,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
 			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -359,6 +275,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
 			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -371,8 +288,41 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
 			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-attributes": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -383,6 +333,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
 			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -395,6 +346,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
 			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -403,12 +355,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-			"integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -422,6 +375,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
 			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -434,6 +388,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
 			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -446,6 +401,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
 			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.10.4"
 			},
@@ -458,6 +414,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
 			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -470,6 +427,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
 			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
 			},
@@ -482,8 +440,25 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
 			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -494,6 +469,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
 			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			},
@@ -505,12 +481,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
-			"integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+			"integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -520,49 +497,48 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/code-frame": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.0",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.0",
-				"@babel/types": "^7.23.0",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0"
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0",
+				"debug": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -572,7 +548,8 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@bconnorwhite/module": {
 			"version": "2.0.2",
@@ -644,6 +621,40 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -792,11 +803,115 @@
 			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true
 		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
 			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"camelcase": "^5.3.1",
 				"find-up": "^4.1.0",
@@ -813,6 +928,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -822,344 +938,487 @@
 			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
 			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
-			"integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+			"integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"chalk": "^4.1.2",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/core": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+			"integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/reporters": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/console": "30.3.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/reporters": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-changed-files": "^29.7.0",
-				"jest-config": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-resolve-dependencies": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@jest/environment": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
-			"dev": true,
-			"dependencies": {
-				"expect": "^29.7.0",
-				"jest-snapshot": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-			"dev": true,
-			"dependencies": {
-				"jest-get-type": "^29.6.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@sinonjs/fake-timers": "^10.0.2",
-				"@types/node": "*",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/globals": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-			"dev": true,
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/reporters": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
-			"dev": true,
-			"dependencies": {
-				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"istanbul-lib-coverage": "^3.0.0",
-				"istanbul-lib-instrument": "^6.0.0",
-				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
-				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"slash": "^3.0.0",
-				"string-length": "^4.0.1",
-				"strip-ansi": "^6.0.0",
-				"v8-to-istanbul": "^9.0.1"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependenciesMeta": {
-				"node-notifier": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@jest/schemas": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-			"dev": true,
-			"dependencies": {
-				"@sinclair/typebox": "^0.27.8"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/source-map": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.9"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/test-result": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
-			"integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
-			"dev": true,
-			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"collect-v8-coverage": "^1.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/test-sequencer": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-			"dev": true,
-			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-changed-files": "30.3.0",
+				"jest-config": "30.3.0",
+				"jest-haste-map": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.3.0",
+				"jest-resolve-dependencies": "30.3.0",
+				"jest-runner": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"jest-watcher": "30.3.0",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/core/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/diff-sequences": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+			"integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+			"integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/node": "*",
+				"jest-mock": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+			"integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "30.3.0",
+				"jest-snapshot": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect-utils": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+			"integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+			"integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"@sinonjs/fake-timers": "^15.0.0",
+				"@types/node": "*",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/get-type": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+			"integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/globals": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+			"integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.3.0",
+				"@jest/expect": "30.3.0",
+				"@jest/types": "30.3.0",
+				"jest-mock": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/reporters": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+			"integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"collect-v8-coverage": "^1.0.2",
+				"exit-x": "^0.2.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^6.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^5.0.0",
+				"istanbul-reports": "^3.1.3",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-worker": "30.3.0",
+				"slash": "^3.0.0",
+				"string-length": "^4.0.2",
+				"v8-to-istanbul": "^9.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/brace-expansion": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/snapshot-utils": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+			"integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.3.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/source-map": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+			"integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"callsites": "^3.1.0",
+				"graceful-fs": "^4.2.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/test-result": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+			"integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"collect-v8-coverage": "^1.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/test-sequencer": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+			"integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.3.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+			"integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"babel-plugin-istanbul": "^6.1.1",
-				"chalk": "^4.0.0",
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.3.0",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.1",
+				"chalk": "^4.1.2",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pirates": "^4.0.4",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.3.0",
+				"pirates": "^4.0.7",
 				"slash": "^3.0.0",
-				"write-file-atomic": "^4.0.2"
+				"write-file-atomic": "^5.0.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/transform/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@jest/transform/node_modules/write-file-atomic": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.7"
+				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
 				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
 			"dev": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.19",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1172,6 +1431,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "^1.4.3",
+				"@emnapi/runtime": "^1.4.3",
+				"@tybys/wasm-util": "^0.10.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -1207,6 +1479,17 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@pkgr/core": {
@@ -1293,10 +1576,11 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-			"dev": true
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "4.6.0",
@@ -1311,21 +1595,23 @@
 			}
 		},
 		"node_modules/@sinonjs/commons": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-			"integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"type-detect": "4.0.8"
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+			"version": "15.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.0.tgz",
+			"integrity": "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^3.0.0"
+				"@sinonjs/commons": "^3.0.1"
 			}
 		},
 		"node_modules/@szmarczak/http-timer": {
@@ -1340,11 +1626,23 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@types/babel__core": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.2.tgz",
-			"integrity": "sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==",
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
 			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/babel__core": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.20.7",
 				"@babel/types": "^7.20.7",
@@ -1354,31 +1652,34 @@
 			}
 		},
 		"node_modules/@types/babel__generator": {
-			"version": "7.6.5",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.5.tgz",
-			"integrity": "sha512-h9yIuWbJKdOPLJTbmSpPzkF67e659PbQDba7ifWm5BJ8xTv+sDmS7rFmywkWOvXedGTivCdeGSIIX8WLcRTz8w==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"node_modules/@types/babel__template": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.2.tgz",
-			"integrity": "sha512-/AVzPICMhMOMYoSx9MoKpGDKdBRsIXMNByh1PXSZoa+v6ZoLa8xxtsT/uLQ/NJm0XVAWl/BvId4MlDeXJaeIZQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"node_modules/@types/babel__traverse": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.2.tgz",
-			"integrity": "sha512-ojlGK1Hsfce93J0+kn3H5R73elidKUaZonirN33GSmgTUMpzI/MIFfSpF3haANe3G1bEBS9/9/QEqwTzwqFsKw==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.20.7"
+				"@babel/types": "^7.28.2"
 			}
 		},
 		"node_modules/@types/cacheable-request": {
@@ -1393,15 +1694,6 @@
 				"@types/responselike": "^1.0.0"
 			}
 		},
-		"node_modules/@types/graceful-fs": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
-			"integrity": "sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/http-cache-semantics": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -1409,25 +1701,28 @@
 			"dev": true
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
-			"dev": true
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/istanbul-lib-report": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-			"integrity": "sha512-gPQuzaPR5h/djlAv2apEG1HVOyj1IUs7GpfMZixU0/0KXT3pm64ylHuMUI1/Akh+sq/iikxg6Z2j+fcMDXaaTQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/istanbul-lib-coverage": "*"
 			}
 		},
 		"node_modules/@types/istanbul-reports": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-			"integrity": "sha512-kv43F9eb3Lhj+lr/Hn6OcLCs/sSM8bt+fIaP11rCYngfV6NVjzWXJ17owQtDQTL9tQ8WSLUrGsSJ6rJz0F1w1A==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
 			}
@@ -1469,31 +1764,304 @@
 			}
 		},
 		"node_modules/@types/stack-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-			"dev": true
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/yargs": {
-			"version": "17.0.25",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.25.tgz",
-			"integrity": "sha512-gy7iPgwnzNvxgAEi2bXOHWCVOG6f7xsprVJH4MjlAWeBmJ7vh/Y1kwMtUrs64ztf24zVIRCpr3n/z6gm9QIkgg==",
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/yargs-parser": "*"
 			}
 		},
 		"node_modules/@types/yargs-parser": {
-			"version": "21.0.1",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
-			"integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
-			"dev": true
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@ungap/structured-clone": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-			"dev": true
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-android-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@napi-rs/wasm-runtime": "^0.2.11"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/abbrev": {
 			"version": "1.1.1",
@@ -1908,10 +2476,11 @@
 			}
 		},
 		"node_modules/anymatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
@@ -1925,6 +2494,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -1980,110 +2550,102 @@
 			}
 		},
 		"node_modules/babel-jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+			"integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/transform": "^29.7.0",
-				"@types/babel__core": "^7.1.14",
-				"babel-plugin-istanbul": "^6.1.1",
-				"babel-preset-jest": "^29.6.3",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
+				"@jest/transform": "30.3.0",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.1",
+				"babel-preset-jest": "30.3.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
 				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.8.0"
+				"@babel/core": "^7.11.0 || ^8.0.0-0"
 			}
 		},
 		"node_modules/babel-plugin-istanbul": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
 			"dev": true,
+			"license": "BSD-3-Clause",
+			"workspaces": [
+				"test/babel-8"
+			],
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-instrument": "^5.0.4",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
 				"test-exclude": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-			"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@babel/parser": "^7.14.7",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-coverage": "^3.2.0",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">=12"
 			}
 		},
 		"node_modules/babel-plugin-jest-hoist": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+			"integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.3.3",
-				"@babel/types": "^7.3.3",
-				"@types/babel__core": "^7.1.14",
-				"@types/babel__traverse": "^7.0.6"
+				"@types/babel__core": "^7.20.5"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/babel-preset-current-node-syntax": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-			"integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-bigint": "^7.8.3",
-				"@babel/plugin-syntax-class-properties": "^7.8.3",
-				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5",
+				"@babel/plugin-syntax-import-attributes": "^7.24.7",
+				"@babel/plugin-syntax-import-meta": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.3",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-				"@babel/plugin-syntax-top-level-await": "^7.8.3"
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+				"@babel/plugin-syntax-top-level-await": "^7.14.5"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0"
+				"@babel/core": "^7.0.0 || ^8.0.0-0"
 			}
 		},
 		"node_modules/babel-preset-jest": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+			"integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"babel-plugin-jest-hoist": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0"
+				"babel-plugin-jest-hoist": "30.3.0",
+				"babel-preset-current-node-syntax": "^1.2.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0"
+				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -2111,6 +2673,19 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.16",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
+			"integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/big-integer": {
 			"version": "1.6.51",
@@ -2313,9 +2888,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.0.tgz",
-			"integrity": "sha512-v+Jcv64L2LbfTC6OnRcaxtqJNJuQAVhZKSJfR/6hn7lhnChUXl4amwVviqN1k411BB+3rRoKMitELRn1CojeRA==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2331,11 +2906,13 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001539",
-				"electron-to-chromium": "^1.4.530",
-				"node-releases": "^2.0.13",
-				"update-browserslist-db": "^1.0.13"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -2349,6 +2926,7 @@
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
 			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"node-int64": "^0.4.0"
 			}
@@ -2390,7 +2968,8 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/builtins": {
 			"version": "1.0.3",
@@ -2469,14 +3048,15 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001541",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
-			"integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
+			"version": "1.0.30001787",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+			"integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2491,13 +3071,15 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			]
+			],
+			"license": "CC-BY-4.0"
 		},
 		"node_modules/chalk": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -2568,6 +3150,7 @@
 			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
 			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			}
@@ -2621,10 +3204,11 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
-			"dev": true
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/clean-stack": {
 			"version": "4.2.0",
@@ -2763,6 +3347,7 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -2798,6 +3383,7 @@
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"iojs": ">= 1.0.0",
 				"node": ">= 0.12.0"
@@ -2813,10 +3399,11 @@
 			}
 		},
 		"node_modules/collect-v8-coverage": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
-			"dev": true
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+			"integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
@@ -2915,7 +3502,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cosmiconfig": {
 			"version": "8.3.6",
@@ -2960,27 +3548,6 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/create-jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
-			"integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-			"dev": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-config": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"prompts": "^2.0.1"
-			},
-			"bin": {
-				"create-jest": "bin/create-jest.js"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -3106,10 +3673,11 @@
 			}
 		},
 		"node_modules/dedent": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
-			"integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
 			"dev": true,
+			"license": "MIT",
 			"peerDependencies": {
 				"babel-plugin-macros": "^3.1.0"
 			},
@@ -3139,6 +3707,7 @@
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3371,17 +3940,9 @@
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/diff-sequences": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-			"dev": true,
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -3442,10 +4003,11 @@
 			"dev": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.534",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.534.tgz",
-			"integrity": "sha512-ikY7wAMtMt3jTnHsHG0YLl4MKJiKz2tgidenGSNgwUX2StBLNZ8VCxflD9tZK/ceTs4j8gDC9+6LQQ6iGkK04g==",
-			"dev": true
+			"version": "1.5.334",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
+			"integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/elegant-spinner": {
 			"version": "1.0.1",
@@ -3461,6 +4023,7 @@
 			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
 			"integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -3506,10 +4069,11 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -3938,6 +4502,7 @@
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -4011,15 +4576,6 @@
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
-		"node_modules/exit": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/exit-hook": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-3.2.0.tgz",
@@ -4032,20 +4588,32 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+		"node_modules/exit-x": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+			"integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/expect": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+			"integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/expect-utils": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"@jest/expect-utils": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/external-editor": {
@@ -4117,6 +4685,7 @@
 			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
 			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"bser": "2.1.1"
 			}
@@ -4193,6 +4762,36 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/form-data-encoder": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
@@ -4209,11 +4808,12 @@
 			"dev": true
 		},
 		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -4236,6 +4836,7 @@
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -4245,6 +4846,7 @@
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
@@ -4254,6 +4856,7 @@
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -4342,15 +4945,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/globby": {
@@ -4538,7 +5132,8 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.1",
@@ -4712,10 +5307,11 @@
 			}
 		},
 		"node_modules/import-local": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-			"integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+			"integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
@@ -5203,6 +5799,7 @@
 			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
 			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -5472,23 +6069,25 @@
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/istanbul-lib-instrument": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
-			"integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@babel/parser": "^7.14.7",
-				"@istanbuljs/schema": "^0.1.2",
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
 				"istanbul-lib-coverage": "^3.2.0",
 				"semver": "^7.5.4"
 			},
@@ -5497,13 +6096,11 @@
 			}
 		},
 		"node_modules/istanbul-lib-instrument/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -5516,6 +6113,7 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
 			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"istanbul-lib-coverage": "^3.0.0",
 				"make-dir": "^4.0.0",
@@ -5530,6 +6128,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -5539,6 +6138,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -5547,24 +6147,26 @@
 			}
 		},
 		"node_modules/istanbul-lib-source-maps": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
 				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0",
-				"source-map": "^0.6.1"
+				"istanbul-lib-coverage": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=10"
 			}
 		},
 		"node_modules/istanbul-reports": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-			"integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
@@ -5573,22 +6175,39 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
 			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"@jest/core": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"import-local": "^3.0.2",
-				"jest-cli": "^29.7.0"
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/jest": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+			"integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.3.0",
+				"@jest/types": "30.3.0",
+				"import-local": "^3.2.0",
+				"jest-cli": "30.3.0"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -5600,17 +6219,18 @@
 			}
 		},
 		"node_modules/jest-changed-files": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
-			"integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+			"integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"execa": "^5.0.0",
-				"jest-util": "^29.7.0",
+				"execa": "^5.1.1",
+				"jest-util": "30.3.0",
 				"p-limit": "^3.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-changed-files/node_modules/p-limit": {
@@ -5618,6 +6238,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -5629,34 +6250,35 @@
 			}
 		},
 		"node_modules/jest-circus": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
-			"integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+			"integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.3.0",
+				"@jest/expect": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
+				"chalk": "^4.1.2",
 				"co": "^4.6.0",
-				"dedent": "^1.0.0",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^29.7.0",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"dedent": "^1.6.0",
+				"is-generator-fn": "^2.1.0",
+				"jest-each": "30.3.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
 				"p-limit": "^3.1.0",
-				"pretty-format": "^29.7.0",
-				"pure-rand": "^6.0.0",
+				"pretty-format": "30.3.0",
+				"pure-rand": "^7.0.0",
 				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
+				"stack-utils": "^2.0.6"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-circus/node_modules/p-limit": {
@@ -5664,6 +6286,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -5675,28 +6298,28 @@
 			}
 		},
 		"node_modules/jest-cli": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
-			"integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+			"integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"create-jest": "^29.7.0",
-				"exit": "^0.1.2",
-				"import-local": "^3.0.2",
-				"jest-config": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"yargs": "^17.3.1"
+				"@jest/core": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
+				"chalk": "^4.1.2",
+				"exit-x": "^0.2.2",
+				"import-local": "^3.2.0",
+				"jest-config": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"yargs": "^17.7.2"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -5708,43 +6331,49 @@
 			}
 		},
 		"node_modules/jest-config": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+			"integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/test-sequencer": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-jest": "^29.7.0",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"deepmerge": "^4.2.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-circus": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"micromatch": "^4.0.4",
+				"@babel/core": "^7.27.4",
+				"@jest/get-type": "30.1.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/test-sequencer": "30.3.0",
+				"@jest/types": "30.3.0",
+				"babel-jest": "30.3.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"deepmerge": "^4.3.1",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-circus": "30.3.0",
+				"jest-docblock": "30.2.0",
+				"jest-environment-node": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.3.0",
+				"jest-runner": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
 				"parse-json": "^5.2.0",
-				"pretty-format": "^29.7.0",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"@types/node": "*",
+				"esbuild-register": ">=3.4.0",
 				"ts-node": ">=9.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/node": {
+					"optional": true
+				},
+				"esbuild-register": {
 					"optional": true
 				},
 				"ts-node": {
@@ -5752,160 +6381,250 @@
 				}
 			}
 		},
-		"node_modules/jest-diff": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+		"node_modules/jest-config/node_modules/brace-expansion": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"chalk": "^4.0.0",
-				"diff-sequences": "^29.6.3",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/jest-config/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-config/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/jest-config/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/jest-diff": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+			"integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.3.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-docblock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+			"integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"detect-newline": "^3.0.0"
+				"detect-newline": "^3.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-each": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
-			"integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+			"integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"pretty-format": "^29.7.0"
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.3.0",
+				"chalk": "^4.1.2",
+				"jest-util": "30.3.0",
+				"pretty-format": "30.3.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+			"integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-get-type": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-			"dev": true,
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-haste-map": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+			"integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/graceful-fs": "^4.1.3",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"anymatch": "^3.0.3",
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"micromatch": "^4.0.4",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.3.0",
+				"jest-worker": "30.3.0",
+				"picomatch": "^4.0.3",
 				"walker": "^1.0.8"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"optionalDependencies": {
-				"fsevents": "^2.3.2"
+				"fsevents": "^2.3.3"
+			}
+		},
+		"node_modules/jest-haste-map/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-leak-detector": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+			"integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
+				"@jest/get-type": "30.1.0",
+				"pretty-format": "30.3.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-matcher-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+			"integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"chalk": "^4.0.0",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.3.0",
+				"pretty-format": "30.3.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.3.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
+				"stack-utils": "^2.0.6"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-util": "^29.7.0"
+				"jest-util": "30.3.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-pnp-resolver": {
@@ -5913,6 +6632,7 @@
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
 			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			},
@@ -5926,77 +6646,81 @@
 			}
 		},
 		"node_modules/jest-regex-util": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-resolve": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+			"integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"resolve": "^1.20.0",
-				"resolve.exports": "^2.0.0",
-				"slash": "^3.0.0"
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"jest-pnp-resolver": "^1.2.3",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"slash": "^3.0.0",
+				"unrs-resolver": "^1.7.11"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-resolve-dependencies": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+			"integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"jest-regex-util": "^29.6.3",
-				"jest-snapshot": "^29.7.0"
+				"jest-regex-util": "30.0.1",
+				"jest-snapshot": "30.3.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-runner": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+			"integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/environment": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/console": "30.3.0",
+				"@jest/environment": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
+				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"graceful-fs": "^4.2.9",
-				"jest-docblock": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-leak-detector": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-resolve": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"jest-worker": "^29.7.0",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-docblock": "30.2.0",
+				"jest-environment-node": "30.3.0",
+				"jest-haste-map": "30.3.0",
+				"jest-leak-detector": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-resolve": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-watcher": "30.3.0",
+				"jest-worker": "30.3.0",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-runner/node_modules/p-limit": {
@@ -6004,6 +6728,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -6015,77 +6740,126 @@
 			}
 		},
 		"node_modules/jest-runtime": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+			"integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/globals": "^29.7.0",
-				"@jest/source-map": "^29.6.3",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/globals": "30.3.0",
+				"@jest/source-map": "30.0.1",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"cjs-module-lexer": "^1.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"chalk": "^4.1.2",
+				"cjs-module-lexer": "^2.1.0",
+				"collect-v8-coverage": "^1.0.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/brace-expansion": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+			"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/jest-snapshot": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+			"integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
+				"@babel/core": "^7.27.4",
+				"@babel/generator": "^7.27.5",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-syntax-typescript": "^7.27.1",
+				"@babel/types": "^7.27.3",
+				"@jest/expect-utils": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"@jest/snapshot-utils": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
+				"babel-preset-current-node-syntax": "^1.2.0",
+				"chalk": "^4.1.2",
+				"expect": "30.3.0",
+				"graceful-fs": "^4.2.11",
+				"jest-diff": "30.3.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
+				"pretty-format": "30.3.0",
+				"semver": "^7.7.2",
+				"synckit": "^0.11.8"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-snapshot/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -6094,37 +6868,68 @@
 			}
 		},
 		"node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/jest-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-validate": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+			"integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.3.0",
+				"camelcase": "^6.3.0",
+				"chalk": "^4.1.2",
 				"leven": "^3.1.0",
-				"pretty-format": "^29.7.0"
+				"pretty-format": "30.3.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-validate/node_modules/camelcase": {
@@ -6132,6 +6937,7 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
 			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -6140,37 +6946,40 @@
 			}
 		},
 		"node_modules/jest-watcher": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+			"integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"jest-util": "^29.7.0",
-				"string-length": "^4.0.1"
+				"jest-util": "30.3.0",
+				"string-length": "^4.0.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-worker": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+			"integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
-				"jest-util": "^29.7.0",
+				"@ungap/structured-clone": "^1.3.0",
+				"jest-util": "30.3.0",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
+				"supports-color": "^8.1.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-worker/node_modules/has-flag": {
@@ -6178,6 +6987,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -6187,6 +6997,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -6201,7 +7012,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "3.14.2",
@@ -6218,15 +7030,16 @@
 			}
 		},
 		"node_modules/jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=6"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -6258,6 +7071,7 @@
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -6283,15 +7097,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/latest-version": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
@@ -6312,6 +7117,7 @@
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -6871,6 +7677,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
 			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.5.3"
 			},
@@ -6882,13 +7689,11 @@
 			}
 		},
 		"node_modules/make-dir/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -6901,6 +7706,7 @@
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
 			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"dependencies": {
 				"tmpl": "1.0.5"
 			}
@@ -7021,6 +7827,16 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7032,6 +7848,22 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
+		},
+		"node_modules/napi-postinstall": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"napi-postinstall": "lib/cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/napi-postinstall"
+			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -7118,13 +7950,15 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
-			"dev": true
+			"version": "2.0.37",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+			"integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nodemon": {
 			"version": "3.1.14",
@@ -7997,6 +8831,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
 		"node_modules/package-json/node_modules/@sindresorhus/is": {
 			"version": "5.6.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
@@ -8257,11 +9098,29 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -8279,10 +9138,11 @@
 			"dev": true
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"dev": true
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.2",
@@ -8298,10 +9158,11 @@
 			}
 		},
 		"node_modules/pirates": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-			"integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
@@ -8357,17 +9218,18 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/pretty-format/node_modules/ansi-styles": {
@@ -8375,6 +9237,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -8389,19 +9252,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/prompts": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-			"dev": true,
-			"dependencies": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.5"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/proto-list": {
@@ -8452,9 +9302,9 @@
 			}
 		},
 		"node_modules/pure-rand": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
-			"integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8465,7 +9315,8 @@
 					"type": "opencollective",
 					"url": "https://opencollective.com/fast-check"
 				}
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -8535,10 +9386,11 @@
 			}
 		},
 		"node_modules/react-is": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-			"dev": true
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/read-file-safe": {
 			"version": "1.0.10",
@@ -8762,27 +9614,11 @@
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/resolve": {
-			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-			"dev": true,
-			"dependencies": {
-				"is-core-module": "^2.13.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			},
-			"bin": {
-				"resolve": "bin/resolve"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/resolve-alpn": {
@@ -8828,15 +9664,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-			}
-		},
-		"node_modules/resolve.exports": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
-			"integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/responselike": {
@@ -8988,6 +9815,7 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -9076,17 +9904,12 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/sisteransi": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-			"dev": true
-		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -9114,6 +9937,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
 			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -9155,13 +9979,15 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/stack-utils": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
 			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"escape-string-regexp": "^2.0.0"
 			},
@@ -9174,6 +10000,7 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
 			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -9192,6 +10019,7 @@
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
 			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"char-regex": "^1.0.2",
 				"strip-ansi": "^6.0.0"
@@ -9214,6 +10042,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -9226,11 +10070,26 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-bom": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
 			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -9302,18 +10161,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/symbol-observable": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -9353,6 +10200,7 @@
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
 			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@istanbuljs/schema": "^0.1.2",
 				"glob": "^7.1.4",
@@ -9402,16 +10250,8 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-			"dev": true
-		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -9497,6 +10337,7 @@
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -9596,6 +10437,41 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/unrs-resolver": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"napi-postinstall": "^0.3.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unrs-resolver"
+			},
+			"optionalDependencies": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+				"@unrs/resolver-binding-android-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-x64": "1.11.1",
+				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+			}
+		},
 		"node_modules/untildify": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -9606,9 +10482,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"funding": [
 				{
@@ -9624,9 +10500,10 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
 			},
 			"bin": {
 				"update-browserslist-db": "cli.js"
@@ -9703,24 +10580,19 @@
 			"dev": true
 		},
 		"node_modules/v8-to-istanbul": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-			"integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.12",
 				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^1.6.0"
+				"convert-source-map": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=10.12.0"
 			}
-		},
-		"node_modules/v8-to-istanbul/node_modules/convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-			"dev": true
 		},
 		"node_modules/vali-date": {
 			"version": "1.0.0",
@@ -9755,6 +10627,7 @@
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
 			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"makeerror": "1.0.12"
 			}
@@ -9859,6 +10732,7 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -9871,11 +10745,67 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/wrap-ansi/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -9891,6 +10821,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -9902,7 +10833,8 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
@@ -9955,6 +10887,7 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
@@ -9970,6 +10903,7 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -9997,6 +10931,7 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=12"
 			}
@@ -10035,61 +10970,39 @@
 			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
 			"dev": true
 		},
-		"@ampproject/remapping": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"dev": true,
-			"requires": {
-				"@jridgewell/gen-mapping": "^0.3.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			}
-		},
 		"@babel/code-frame": {
-			"version": "7.22.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.22.13",
-				"chalk": "^2.4.2"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.20.tgz",
-			"integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
-			"integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"requires": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.0",
-				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-module-transforms": "^7.23.0",
-				"@babel/helpers": "^7.23.2",
-				"@babel/parser": "^7.23.0",
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.2",
-				"@babel/types": "^7.23.0",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -10098,26 +11011,27 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-			"integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+			"version": "7.29.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.23.0",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"@jridgewell/trace-mapping": "^0.3.17",
-				"jsesc": "^2.5.1"
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-			"integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.22.9",
-				"@babel/helper-validator-option": "^7.22.15",
-				"browserslist": "^4.21.9",
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-validator-option": "^7.27.1",
+				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -10139,135 +11053,75 @@
 				}
 			}
 		},
-		"@babel/helper-environment-visitor": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+		"@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
 			"dev": true
 		},
-		"@babel/helper-function-name": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.23.0"
-			}
-		},
-		"@babel/helper-hoist-variables": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.22.5"
-			}
-		},
 		"@babel/helper-module-imports": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.22.15"
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
-			"integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-simple-access": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/helper-validator-identifier": "^7.22.20"
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/traverse": "^7.28.6"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
 			"dev": true
 		},
-		"@babel/helper-simple-access": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.22.5"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.22.5"
-			}
-		},
 		"@babel/helper-string-parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
 			"dev": true
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-			"integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
 			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-			"integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.2",
-				"@babel/types": "^7.23.0"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
-			"dev": true
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.29.0"
+			}
 		},
 		"@babel/plugin-syntax-async-generators": {
 			"version": "7.8.4",
@@ -10296,6 +11150,24 @@
 				"@babel/helper-plugin-utils": "^7.12.13"
 			}
 		},
+		"@babel/plugin-syntax-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
+		"@babel/plugin-syntax-import-attributes": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.28.6"
+			}
+		},
 		"@babel/plugin-syntax-import-meta": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -10315,12 +11187,12 @@
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-			"integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			}
 		},
 		"@babel/plugin-syntax-logical-assignment-operators": {
@@ -10377,6 +11249,15 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/plugin-syntax-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			}
+		},
 		"@babel/plugin-syntax-top-level-await": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
@@ -10387,52 +11268,48 @@
 			}
 		},
 		"@babel/plugin-syntax-typescript": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
-			"integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+			"integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			}
 		},
 		"@babel/template": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/parser": "^7.22.15",
-				"@babel/types": "^7.22.15"
+				"@babel/code-frame": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-			"integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.0",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.0",
-				"@babel/types": "^7.23.0",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0"
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0",
+				"debug": "^4.3.1"
 			}
 		},
 		"@babel/types": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-			"integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-string-parser": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"to-fast-properties": "^2.0.0"
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
 			}
 		},
 		"@bcoe/v8-coverage": {
@@ -10489,6 +11366,37 @@
 						"p-limit": "^3.0.2"
 					}
 				}
+			}
+		},
+		"@emnapi/core": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"@emnapi/runtime": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"@eslint-community/eslint-utils": {
@@ -10588,6 +11496,71 @@
 			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"dev": true
 		},
+		"@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "6.2.2",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+					"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "6.2.3",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+					"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "9.2.2",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+					"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+					"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+					"dev": true,
+					"requires": {
+						"eastasianwidth": "^0.2.0",
+						"emoji-regex": "^9.2.2",
+						"strip-ansi": "^7.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+					"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^6.2.2"
+					}
+				},
+				"wrap-ansi": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+					"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^6.1.0",
+						"string-width": "^5.0.1",
+						"strip-ansi": "^7.0.1"
+					}
+				}
+			}
+		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -10616,270 +11589,353 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
-			"integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
+			"integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.6.3",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"chalk": "^4.1.2",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
 				"slash": "^3.0.0"
 			}
 		},
 		"@jest/core": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
+			"integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^29.7.0",
-				"@jest/reporters": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/console": "30.3.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/reporters": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-changed-files": "^29.7.0",
-				"jest-config": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-resolve-dependencies": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-changed-files": "30.3.0",
+				"jest-config": "30.3.0",
+				"jest-haste-map": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.3.0",
+				"jest-resolve-dependencies": "30.3.0",
+				"jest-runner": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"jest-watcher": "30.3.0",
+				"pretty-format": "30.3.0",
+				"slash": "^3.0.0"
+			},
+			"dependencies": {
+				"ci-info": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+					"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+					"dev": true
+				}
 			}
 		},
+		"@jest/diff-sequences": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
+			"integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+			"dev": true
+		},
 		"@jest/environment": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+			"integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-mock": "^29.7.0"
+				"jest-mock": "30.3.0"
 			}
 		},
 		"@jest/expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
+			"integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
 			"dev": true,
 			"requires": {
-				"expect": "^29.7.0",
-				"jest-snapshot": "^29.7.0"
+				"expect": "30.3.0",
+				"jest-snapshot": "30.3.0"
 			}
 		},
 		"@jest/expect-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
+			"integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
 			"dev": true,
 			"requires": {
-				"jest-get-type": "^29.6.3"
+				"@jest/get-type": "30.1.0"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+			"integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.6.3",
-				"@sinonjs/fake-timers": "^10.0.2",
+				"@jest/types": "30.3.0",
+				"@sinonjs/fake-timers": "^15.0.0",
 				"@types/node": "*",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
 			}
 		},
+		"@jest/get-type": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+			"integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+			"dev": true
+		},
 		"@jest/globals": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
+			"integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
+				"@jest/environment": "30.3.0",
+				"@jest/expect": "30.3.0",
+				"@jest/types": "30.3.0",
+				"jest-mock": "30.3.0"
+			}
+		},
+		"@jest/pattern": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+			"integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"jest-regex-util": "30.0.1"
 			}
 		},
 		"@jest/reporters": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
+			"integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
+				"@jest/console": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
+				"chalk": "^4.1.2",
+				"collect-v8-coverage": "^1.0.2",
+				"exit-x": "^0.2.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
 				"istanbul-lib-coverage": "^3.0.0",
 				"istanbul-lib-instrument": "^6.0.0",
 				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-lib-source-maps": "^5.0.0",
 				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-worker": "30.3.0",
 				"slash": "^3.0.0",
-				"string-length": "^4.0.1",
-				"strip-ansi": "^6.0.0",
+				"string-length": "^4.0.2",
 				"v8-to-istanbul": "^9.0.1"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+					"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "10.5.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+					"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+					"dev": true,
+					"requires": {
+						"foreground-child": "^3.1.0",
+						"jackspeak": "^3.1.2",
+						"minimatch": "^9.0.4",
+						"minipass": "^7.1.2",
+						"package-json-from-dist": "^1.0.0",
+						"path-scurry": "^1.11.1"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.9",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+					"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.2"
+					}
+				}
 			}
 		},
 		"@jest/schemas": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+			"version": "30.0.5",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+			"integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
 			"dev": true,
 			"requires": {
-				"@sinclair/typebox": "^0.27.8"
+				"@sinclair/typebox": "^0.34.0"
+			}
+		},
+		"@jest/snapshot-utils": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
+			"integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "30.3.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"natural-compare": "^1.4.0"
 			}
 		},
 		"@jest/source-map": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+			"integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.9"
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"callsites": "^3.1.0",
+				"graceful-fs": "^4.2.11"
 			}
 		},
 		"@jest/test-result": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
-			"integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
+			"integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"collect-v8-coverage": "^1.0.0"
+				"@jest/console": "30.3.0",
+				"@jest/types": "30.3.0",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"collect-v8-coverage": "^1.0.2"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
+			"integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
+				"@jest/test-result": "30.3.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
 				"slash": "^3.0.0"
 			}
 		},
 		"@jest/transform": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
+			"integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.11.6",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"babel-plugin-istanbul": "^6.1.1",
-				"chalk": "^4.0.0",
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.3.0",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.1",
+				"chalk": "^4.1.2",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pirates": "^4.0.4",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.3.0",
+				"pirates": "^4.0.7",
 				"slash": "^3.0.0",
-				"write-file-atomic": "^4.0.2"
+				"write-file-atomic": "^5.0.1"
 			},
 			"dependencies": {
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				},
 				"write-file-atomic": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-					"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+					"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
 					"dev": true,
 					"requires": {
 						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.7"
+						"signal-exit": "^4.0.1"
 					}
 				}
 			}
 		},
 		"@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
 			"dev": true,
 			"requires": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/schemas": "30.0.5",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
 				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
 			}
 		},
 		"@jridgewell/gen-mapping": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"@jridgewell/resolve-uri": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-			"dev": true
-		},
-		"@jridgewell/set-array": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
 			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.15",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.19",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -10891,6 +11947,18 @@
 			"resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.9.tgz",
 			"integrity": "sha512-yN599ZBuMPPK4tdoToLlvgJB4CLK8fGl7ntfy0Wn7U6ttNvHYurd81bfUiK/6sMkiIwm65R6ck4L6+Y3DfVbNQ==",
 			"dev": true
+		},
+		"@napi-rs/wasm-runtime": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@emnapi/core": "^1.4.3",
+				"@emnapi/runtime": "^1.4.3",
+				"@tybys/wasm-util": "^0.10.0"
+			}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -10917,6 +11985,13 @@
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
+		},
+		"@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"optional": true
 		},
 		"@pkgr/core": {
 			"version": "0.2.9",
@@ -10976,9 +12051,9 @@
 			}
 		},
 		"@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
 			"dev": true
 		},
 		"@sindresorhus/is": {
@@ -10988,21 +12063,21 @@
 			"dev": true
 		},
 		"@sinonjs/commons": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-			"integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
 			"dev": true,
 			"requires": {
 				"type-detect": "4.0.8"
 			}
 		},
 		"@sinonjs/fake-timers": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+			"version": "15.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.0.tgz",
+			"integrity": "sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "^3.0.0"
+				"@sinonjs/commons": "^3.0.1"
 			}
 		},
 		"@szmarczak/http-timer": {
@@ -11014,10 +12089,20 @@
 				"defer-to-connect": "^2.0.0"
 			}
 		},
+		"@tybys/wasm-util": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"@types/babel__core": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.2.tgz",
-			"integrity": "sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==",
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.20.7",
@@ -11028,18 +12113,18 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.5",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.5.tgz",
-			"integrity": "sha512-h9yIuWbJKdOPLJTbmSpPzkF67e659PbQDba7ifWm5BJ8xTv+sDmS7rFmywkWOvXedGTivCdeGSIIX8WLcRTz8w==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
 		},
 		"@types/babel__template": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.2.tgz",
-			"integrity": "sha512-/AVzPICMhMOMYoSx9MoKpGDKdBRsIXMNByh1PXSZoa+v6ZoLa8xxtsT/uLQ/NJm0XVAWl/BvId4MlDeXJaeIZQ==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -11047,12 +12132,12 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.2.tgz",
-			"integrity": "sha512-ojlGK1Hsfce93J0+kn3H5R73elidKUaZonirN33GSmgTUMpzI/MIFfSpF3haANe3G1bEBS9/9/QEqwTzwqFsKw==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.20.7"
+				"@babel/types": "^7.28.2"
 			}
 		},
 		"@types/cacheable-request": {
@@ -11067,15 +12152,6 @@
 				"@types/responselike": "^1.0.0"
 			}
 		},
-		"@types/graceful-fs": {
-			"version": "4.1.7",
-			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
-			"integrity": "sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/http-cache-semantics": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
@@ -11083,24 +12159,24 @@
 			"dev": true
 		},
 		"@types/istanbul-lib-coverage": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-			"integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
 			"dev": true
 		},
 		"@types/istanbul-lib-report": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-			"integrity": "sha512-gPQuzaPR5h/djlAv2apEG1HVOyj1IUs7GpfMZixU0/0KXT3pm64ylHuMUI1/Akh+sq/iikxg6Z2j+fcMDXaaTQ==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "*"
 			}
 		},
 		"@types/istanbul-reports": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-			"integrity": "sha512-kv43F9eb3Lhj+lr/Hn6OcLCs/sSM8bt+fIaP11rCYngfV6NVjzWXJ17owQtDQTL9tQ8WSLUrGsSJ6rJz0F1w1A==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-report": "*"
@@ -11143,31 +12219,167 @@
 			}
 		},
 		"@types/stack-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-			"integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
 			"dev": true
 		},
 		"@types/yargs": {
-			"version": "17.0.25",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.25.tgz",
-			"integrity": "sha512-gy7iPgwnzNvxgAEi2bXOHWCVOG6f7xsprVJH4MjlAWeBmJ7vh/Y1kwMtUrs64ztf24zVIRCpr3n/z6gm9QIkgg==",
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
 		},
 		"@types/yargs-parser": {
-			"version": "21.0.1",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
-			"integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
 			"dev": true
 		},
 		"@ungap/structured-clone": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true
+		},
+		"@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-android-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+			"integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-darwin-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@napi-rs/wasm-runtime": "^0.2.11"
+			}
+		},
+		"@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+			"dev": true,
+			"optional": true
+		},
+		"@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+			"dev": true,
+			"optional": true
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -11439,9 +12651,9 @@
 			}
 		},
 		"anymatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-			"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
 			"dev": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
@@ -11492,88 +12704,73 @@
 			}
 		},
 		"babel-jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
+			"integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^29.7.0",
-				"@types/babel__core": "^7.1.14",
-				"babel-plugin-istanbul": "^6.1.1",
-				"babel-preset-jest": "^29.6.3",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
+				"@jest/transform": "30.3.0",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.1",
+				"babel-preset-jest": "30.3.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
 				"slash": "^3.0.0"
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-instrument": "^5.0.4",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
 				"test-exclude": "^6.0.0"
-			},
-			"dependencies": {
-				"istanbul-lib-instrument": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-					"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-					"dev": true,
-					"requires": {
-						"@babel/core": "^7.12.3",
-						"@babel/parser": "^7.14.7",
-						"@istanbuljs/schema": "^0.1.2",
-						"istanbul-lib-coverage": "^3.2.0",
-						"semver": "^6.3.0"
-					}
-				}
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
+			"integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.3.3",
-				"@babel/types": "^7.3.3",
-				"@types/babel__core": "^7.1.14",
-				"@types/babel__traverse": "^7.0.6"
+				"@types/babel__core": "^7.20.5"
 			}
 		},
 		"babel-preset-current-node-syntax": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-			"integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
 			"dev": true,
 			"requires": {
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-bigint": "^7.8.3",
-				"@babel/plugin-syntax-class-properties": "^7.8.3",
-				"@babel/plugin-syntax-import-meta": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5",
+				"@babel/plugin-syntax-import-attributes": "^7.24.7",
+				"@babel/plugin-syntax-import-meta": "^7.10.4",
 				"@babel/plugin-syntax-json-strings": "^7.8.3",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
 				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-				"@babel/plugin-syntax-top-level-await": "^7.8.3"
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+				"@babel/plugin-syntax-top-level-await": "^7.14.5"
 			}
 		},
 		"babel-preset-jest": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
+			"integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0"
+				"babel-plugin-jest-hoist": "30.3.0",
+				"babel-preset-current-node-syntax": "^1.2.0"
 			}
 		},
 		"balanced-match": {
@@ -11586,6 +12783,12 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true
+		},
+		"baseline-browser-mapping": {
+			"version": "2.10.16",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
+			"integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
 			"dev": true
 		},
 		"big-integer": {
@@ -11725,15 +12928,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.0.tgz",
-			"integrity": "sha512-v+Jcv64L2LbfTC6OnRcaxtqJNJuQAVhZKSJfR/6hn7lhnChUXl4amwVviqN1k411BB+3rRoKMitELRn1CojeRA==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001539",
-				"electron-to-chromium": "^1.4.530",
-				"node-releases": "^2.0.13",
-				"update-browserslist-db": "^1.0.13"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			}
 		},
 		"bser": {
@@ -11827,15 +13031,15 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001541",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
-			"integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
+			"version": "1.0.30001787",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+			"integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
 			"dev": true
 		},
 		"chalk": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"requires": {
 				"ansi-styles": "^4.1.0",
@@ -11918,9 +13122,9 @@
 			"dev": true
 		},
 		"cjs-module-lexer": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"dev": true
 		},
 		"clean-stack": {
@@ -12053,9 +13257,9 @@
 			"dev": true
 		},
 		"collect-v8-coverage": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-			"integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+			"integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
 			"dev": true
 		},
 		"color-convert": {
@@ -12170,21 +13374,6 @@
 				}
 			}
 		},
-		"create-jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
-			"integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-			"dev": true,
-			"requires": {
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-config": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"prompts": "^2.0.1"
-			}
-		},
 		"cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -12270,9 +13459,9 @@
 			}
 		},
 		"dedent": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
-			"integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -12440,12 +13629,6 @@
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
 		},
-		"diff-sequences": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-			"dev": true
-		},
 		"dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -12488,9 +13671,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.4.534",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.534.tgz",
-			"integrity": "sha512-ikY7wAMtMt3jTnHsHG0YLl4MKJiKz2tgidenGSNgwUX2StBLNZ8VCxflD9tZK/ceTs4j8gDC9+6LQQ6iGkK04g==",
+			"version": "1.5.334",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
+			"integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -12540,9 +13723,9 @@
 			}
 		},
 		"escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true
 		},
 		"escape-goat": {
@@ -12861,29 +14044,30 @@
 				"strip-final-newline": "^2.0.0"
 			}
 		},
-		"exit": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-			"dev": true
-		},
 		"exit-hook": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-3.2.0.tgz",
 			"integrity": "sha512-aIQN7Q04HGAV/I5BszisuHTZHXNoC23WtLkxdCLuYZMdWviRD0TMIt2bnUBi9MrHaF/hH8b3gwG9iaAUHKnJGA==",
 			"dev": true
 		},
+		"exit-x": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+			"integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+			"dev": true
+		},
 		"expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
+			"integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
 			"dev": true,
 			"requires": {
-				"@jest/expect-utils": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"@jest/expect-utils": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
 			}
 		},
 		"external-editor": {
@@ -13005,6 +14189,24 @@
 			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true
 		},
+		"foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"dependencies": {
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				}
+			}
+		},
 		"form-data-encoder": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
@@ -13018,9 +14220,9 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"dev": true,
 			"optional": true
 		},
@@ -13108,12 +14310,6 @@
 					"dev": true
 				}
 			}
-		},
-		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
 		},
 		"globby": {
 			"version": "13.2.2",
@@ -13374,9 +14570,9 @@
 			"dev": true
 		},
 		"import-local": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
-			"integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+			"integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
 			"dev": true,
 			"requires": {
 				"pkg-dir": "^4.2.0",
@@ -13918,32 +15114,29 @@
 			"dev": true
 		},
 		"istanbul-lib-coverage": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
-			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
 			"dev": true
 		},
 		"istanbul-lib-instrument": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
-			"integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.12.3",
-				"@babel/parser": "^7.14.7",
-				"@istanbuljs/schema": "^0.1.2",
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
 				"istanbul-lib-coverage": "^3.2.0",
 				"semver": "^7.5.4"
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+					"dev": true
 				}
 			}
 		},
@@ -13976,46 +15169,56 @@
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
 			"dev": true,
 			"requires": {
+				"@jridgewell/trace-mapping": "^0.3.23",
 				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0",
-				"source-map": "^0.6.1"
+				"istanbul-lib-coverage": "^3.0.0"
 			}
 		},
 		"istanbul-reports": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
-			"integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
 			"dev": true,
 			"requires": {
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
 			}
 		},
-		"jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+		"jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"import-local": "^3.0.2",
-				"jest-cli": "^29.7.0"
+				"@isaacs/cliui": "^8.0.2",
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"jest": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
+			"integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+			"dev": true,
+			"requires": {
+				"@jest/core": "30.3.0",
+				"@jest/types": "30.3.0",
+				"import-local": "^3.2.0",
+				"jest-cli": "30.3.0"
 			}
 		},
 		"jest-changed-files": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
-			"integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
+			"integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
 			"dev": true,
 			"requires": {
-				"execa": "^5.0.0",
-				"jest-util": "^29.7.0",
+				"execa": "^5.1.1",
+				"jest-util": "30.3.0",
 				"p-limit": "^3.1.0"
 			},
 			"dependencies": {
@@ -14031,31 +15234,31 @@
 			}
 		},
 		"jest-circus": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
-			"integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
+			"integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.3.0",
+				"@jest/expect": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
+				"chalk": "^4.1.2",
 				"co": "^4.6.0",
-				"dedent": "^1.0.0",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^29.7.0",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"dedent": "^1.6.0",
+				"is-generator-fn": "^2.1.0",
+				"jest-each": "30.3.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
 				"p-limit": "^3.1.0",
-				"pretty-format": "^29.7.0",
-				"pure-rand": "^6.0.0",
+				"pretty-format": "30.3.0",
+				"pure-rand": "^7.0.0",
 				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
+				"stack-utils": "^2.0.6"
 			},
 			"dependencies": {
 				"p-limit": {
@@ -14070,176 +15273,226 @@
 			}
 		},
 		"jest-cli": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
-			"integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
+			"integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"create-jest": "^29.7.0",
-				"exit": "^0.1.2",
-				"import-local": "^3.0.2",
-				"jest-config": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"yargs": "^17.3.1"
+				"@jest/core": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
+				"chalk": "^4.1.2",
+				"exit-x": "^0.2.2",
+				"import-local": "^3.2.0",
+				"jest-config": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"yargs": "^17.7.2"
 			}
 		},
 		"jest-config": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
+			"integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.11.6",
-				"@jest/test-sequencer": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-jest": "^29.7.0",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"deepmerge": "^4.2.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-circus": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"micromatch": "^4.0.4",
+				"@babel/core": "^7.27.4",
+				"@jest/get-type": "30.1.0",
+				"@jest/pattern": "30.0.1",
+				"@jest/test-sequencer": "30.3.0",
+				"@jest/types": "30.3.0",
+				"babel-jest": "30.3.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"deepmerge": "^4.3.1",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-circus": "30.3.0",
+				"jest-docblock": "30.2.0",
+				"jest-environment-node": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.3.0",
+				"jest-runner": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
 				"parse-json": "^5.2.0",
-				"pretty-format": "^29.7.0",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+					"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"ci-info": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+					"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+					"dev": true
+				},
+				"glob": {
+					"version": "10.5.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+					"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+					"dev": true,
+					"requires": {
+						"foreground-child": "^3.1.0",
+						"jackspeak": "^3.1.2",
+						"minimatch": "^9.0.4",
+						"minipass": "^7.1.2",
+						"package-json-from-dist": "^1.0.0",
+						"path-scurry": "^1.11.1"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.9",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+					"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.2"
+					}
+				}
 			}
 		},
 		"jest-diff": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
+			"integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "^4.0.0",
-				"diff-sequences": "^29.6.3",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
+				"@jest/diff-sequences": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.3.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+			"version": "30.2.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
+			"integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^3.0.0"
+				"detect-newline": "^3.1.0"
 			}
 		},
 		"jest-each": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
-			"integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
+			"integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"pretty-format": "^29.7.0"
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.3.0",
+				"chalk": "^4.1.2",
+				"jest-util": "30.3.0",
+				"pretty-format": "30.3.0"
 			}
 		},
 		"jest-environment-node": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
+			"integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0"
 			}
 		},
-		"jest-get-type": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-			"dev": true
-		},
 		"jest-haste-map": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
+			"integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.6.3",
-				"@types/graceful-fs": "^4.1.3",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"anymatch": "^3.0.3",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.3.2",
-				"graceful-fs": "^4.2.9",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"micromatch": "^4.0.4",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"fsevents": "^2.3.3",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.0.1",
+				"jest-util": "30.3.0",
+				"jest-worker": "30.3.0",
+				"picomatch": "^4.0.3",
 				"walker": "^1.0.8"
+			},
+			"dependencies": {
+				"picomatch": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+					"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+					"dev": true
+				}
 			}
 		},
 		"jest-leak-detector": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
+			"integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
 			"dev": true,
 			"requires": {
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
+				"@jest/get-type": "30.1.0",
+				"pretty-format": "30.3.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
+			"integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^4.0.0",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.3.0",
+				"pretty-format": "30.3.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.3.0",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
+				"stack-utils": "^2.0.6"
+			},
+			"dependencies": {
+				"picomatch": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+					"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+					"dev": true
+				}
 			}
 		},
 		"jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.6.3",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-util": "^29.7.0"
+				"jest-util": "30.3.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -14250,63 +15503,63 @@
 			"requires": {}
 		},
 		"jest-regex-util": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+			"integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
+			"integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
 			"dev": true,
 			"requires": {
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"resolve": "^1.20.0",
-				"resolve.exports": "^2.0.0",
-				"slash": "^3.0.0"
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"jest-pnp-resolver": "^1.2.3",
+				"jest-util": "30.3.0",
+				"jest-validate": "30.3.0",
+				"slash": "^3.0.0",
+				"unrs-resolver": "^1.7.11"
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
+			"integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "^29.6.3",
-				"jest-snapshot": "^29.7.0"
+				"jest-regex-util": "30.0.1",
+				"jest-snapshot": "30.3.0"
 			}
 		},
 		"jest-runner": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
+			"integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^29.7.0",
-				"@jest/environment": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/console": "30.3.0",
+				"@jest/environment": "30.3.0",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
+				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"graceful-fs": "^4.2.9",
-				"jest-docblock": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-leak-detector": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-resolve": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"jest-worker": "^29.7.0",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-docblock": "30.2.0",
+				"jest-environment-node": "30.3.0",
+				"jest-haste-map": "30.3.0",
+				"jest-leak-detector": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-resolve": "30.3.0",
+				"jest-runtime": "30.3.0",
+				"jest-util": "30.3.0",
+				"jest-watcher": "30.3.0",
+				"jest-worker": "30.3.0",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			},
@@ -14323,100 +15576,146 @@
 			}
 		},
 		"jest-runtime": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
+			"integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/globals": "^29.7.0",
-				"@jest/source-map": "^29.6.3",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/globals": "30.3.0",
+				"@jest/source-map": "30.0.1",
+				"@jest/test-result": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"cjs-module-lexer": "^1.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"chalk": "^4.1.2",
+				"cjs-module-lexer": "^2.1.0",
+				"collect-v8-coverage": "^1.0.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-regex-util": "30.0.1",
+				"jest-resolve": "30.3.0",
+				"jest-snapshot": "30.3.0",
+				"jest-util": "30.3.0",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
-			}
-		},
-		"jest-snapshot": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
 			},
 			"dependencies": {
-				"semver": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+				"brace-expansion": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+					"integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
 					"dev": true,
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "10.5.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+					"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+					"dev": true,
+					"requires": {
+						"foreground-child": "^3.1.0",
+						"jackspeak": "^3.1.2",
+						"minimatch": "^9.0.4",
+						"minipass": "^7.1.2",
+						"package-json-from-dist": "^1.0.0",
+						"path-scurry": "^1.11.1"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.9",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+					"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.2"
 					}
 				}
 			}
 		},
-		"jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+		"jest-snapshot": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
+			"integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.6.3",
+				"@babel/core": "^7.27.4",
+				"@babel/generator": "^7.27.5",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-syntax-typescript": "^7.27.1",
+				"@babel/types": "^7.27.3",
+				"@jest/expect-utils": "30.3.0",
+				"@jest/get-type": "30.1.0",
+				"@jest/snapshot-utils": "30.3.0",
+				"@jest/transform": "30.3.0",
+				"@jest/types": "30.3.0",
+				"babel-preset-current-node-syntax": "^1.2.0",
+				"chalk": "^4.1.2",
+				"expect": "30.3.0",
+				"graceful-fs": "^4.2.11",
+				"jest-diff": "30.3.0",
+				"jest-matcher-utils": "30.3.0",
+				"jest-message-util": "30.3.0",
+				"jest-util": "30.3.0",
+				"pretty-format": "30.3.0",
+				"semver": "^7.7.2",
+				"synckit": "^0.11.8"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+					"dev": true
+				}
+			}
+		},
+		"jest-util": {
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+			"dev": true,
+			"requires": {
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"dependencies": {
+				"ci-info": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+					"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+					"dev": true
+				},
+				"picomatch": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+					"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+					"dev": true
+				}
 			}
 		},
 		"jest-validate": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
+			"integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^29.6.3",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.3.0",
+				"camelcase": "^6.3.0",
+				"chalk": "^4.1.2",
 				"leven": "^3.1.0",
-				"pretty-format": "^29.7.0"
+				"pretty-format": "30.3.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -14428,31 +15727,32 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
+			"integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/test-result": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"jest-util": "^29.7.0",
-				"string-length": "^4.0.1"
+				"jest-util": "30.3.0",
+				"string-length": "^4.0.2"
 			}
 		},
 		"jest-worker": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
+			"integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
-				"jest-util": "^29.7.0",
+				"@ungap/structured-clone": "^1.3.0",
+				"jest-util": "30.3.0",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
+				"supports-color": "^8.1.1"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -14489,9 +15789,9 @@
 			}
 		},
 		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
 			"dev": true
 		},
 		"json-buffer": {
@@ -14537,12 +15837,6 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true
-		},
-		"kleur": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
 			"dev": true
 		},
 		"latest-version": {
@@ -14999,13 +16293,10 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+					"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+					"dev": true
 				}
 			}
 		},
@@ -15096,6 +16387,12 @@
 				"kind-of": "^6.0.3"
 			}
 		},
+		"minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true
+		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -15106,6 +16403,12 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+			"dev": true
+		},
+		"napi-postinstall": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -15177,9 +16480,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+			"version": "2.0.37",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+			"integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
 			"dev": true
 		},
 		"nodemon": {
@@ -15865,6 +17168,12 @@
 				}
 			}
 		},
+		"package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true
+		},
 		"package-name-conflict": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/package-name-conflict/-/package-name-conflict-1.0.3.tgz",
@@ -15925,11 +17234,23 @@
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true
 		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
+		"path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "10.4.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+					"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+					"dev": true
+				}
+			}
 		},
 		"path-type": {
 			"version": "4.0.0",
@@ -15944,9 +17265,9 @@
 			"dev": true
 		},
 		"picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
 			"dev": true
 		},
 		"picomatch": {
@@ -15956,9 +17277,9 @@
 			"dev": true
 		},
 		"pirates": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-			"integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
 			"dev": true
 		},
 		"pkg-dir": {
@@ -15992,14 +17313,14 @@
 			}
 		},
 		"pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
 			"dev": true,
 			"requires": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
+				"@jest/schemas": "30.0.5",
+				"ansi-styles": "^5.2.0",
+				"react-is": "^18.3.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -16015,16 +17336,6 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
-		},
-		"prompts": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-			"integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-			"dev": true,
-			"requires": {
-				"kleur": "^3.0.3",
-				"sisteransi": "^1.0.5"
-			}
 		},
 		"proto-list": {
 			"version": "1.2.4",
@@ -16064,9 +17375,9 @@
 			}
 		},
 		"pure-rand": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
-			"integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
 			"dev": true
 		},
 		"queue-microtask": {
@@ -16108,9 +17419,9 @@
 			}
 		},
 		"react-is": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
 			"dev": true
 		},
 		"read-file-safe": {
@@ -16269,19 +17580,8 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"dev": true
-		},
-		"resolve": {
-			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-			"dev": true,
-			"requires": {
-				"is-core-module": "^2.13.0",
-				"path-parse": "^1.0.7",
-				"supports-preserve-symlinks-flag": "^1.0.0"
-			}
 		},
 		"resolve-alpn": {
 			"version": "1.2.1",
@@ -16316,12 +17616,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
 			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-			"dev": true
-		},
-		"resolve.exports": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
-			"integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
 			"dev": true
 		},
 		"responselike": {
@@ -16476,12 +17770,6 @@
 				}
 			}
 		},
-		"sisteransi": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-			"dev": true
-		},
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -16595,8 +17883,28 @@
 				"strip-ansi": "^6.0.1"
 			}
 		},
+		"string-width-cjs": {
+			"version": "npm:string-width@4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			}
+		},
 		"strip-ansi": {
 			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.1"
+			}
+		},
+		"strip-ansi-cjs": {
+			"version": "npm:strip-ansi@6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
@@ -16657,12 +17965,6 @@
 					}
 				}
 			}
-		},
-		"supports-preserve-symlinks-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true
 		},
 		"symbol-observable": {
 			"version": "4.0.0",
@@ -16727,12 +18029,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
 			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-			"dev": true
-		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"dev": true
 		},
 		"to-regex-range": {
@@ -16860,6 +18156,34 @@
 				"crypto-random-string": "^4.0.0"
 			}
 		},
+		"unrs-resolver": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+			"integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+			"dev": true,
+			"requires": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+				"@unrs/resolver-binding-android-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-arm64": "1.11.1",
+				"@unrs/resolver-binding-darwin-x64": "1.11.1",
+				"@unrs/resolver-binding-freebsd-x64": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+				"@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+				"@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1",
+				"napi-postinstall": "^0.3.0"
+			}
+		},
 		"untildify": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -16867,13 +18191,13 @@
 			"dev": true
 		},
 		"update-browserslist-db": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"requires": {
-				"escalade": "^3.1.1",
-				"picocolors": "^1.0.0"
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
 			}
 		},
 		"update-notifier": {
@@ -16928,22 +18252,14 @@
 			"dev": true
 		},
 		"v8-to-istanbul": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-			"integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.12",
 				"@types/istanbul-lib-coverage": "^2.0.1",
-				"convert-source-map": "^1.6.0"
-			},
-			"dependencies": {
-				"convert-source-map": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-					"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-					"dev": true
-				}
+				"convert-source-map": "^2.0.0"
 			}
 		},
 		"vali-date": {
@@ -17049,6 +18365,43 @@
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				}
+			}
+		},
+		"wrap-ansi-cjs": {
+			"version": "npm:wrap-ansi@7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
 			"dev": true,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"eslint-plugin-n": "17.24.0",
 		"eslint-plugin-prettier": "5.5.5",
 		"get-stream": "6.0.1",
-		"jest": "29.7.0",
+		"jest": "30.3.0",
 		"nodemon": "3.1.14",
 		"np": "8.0.4",
 		"prettier": "3.8.1",

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ import { DOMParser } from '@xmldom/xmldom'
 	```javascript
 	serializeToString(node)
 	```
-### DOM level2 method and attribute:
+### DOM level 2 method and attribute:
 
 * [Node](http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247)
 
@@ -293,8 +293,17 @@ import { DOMParser } from '@xmldom/xmldom'
 
 * [ParentNode](https://dom.spec.whatwg.org/#interface-parentnode) mixin (on `Document`, `DocumentFragment`, `Element`)
 
-  readonly attribute:
+  readonly attributes:
   - `children`
+  - `firstElementChild`
+  - `lastElementChild`
+  - `childElementCount`
+
+* Element (from [NonDocumentTypeChildNode](https://dom.spec.whatwg.org/#nondocumenttypechildnode) mixin)
+
+  readonly attributes:
+  - `previousElementSibling`
+  - `nextElementSibling`
 
 ### DOM extension by xmldom
 

--- a/test/__snapshots__/entities.test.js.snap
+++ b/test/__snapshots__/entities.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`entity replacement ignores js prototype chain should not pick up 'entities' from the prototype chain 1`] = `
 {

--- a/test/conventions/__snapshots__/html.test.js.snap
+++ b/test/conventions/__snapshots__/html.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HTML_BOOLEAN_ATTRIBUTES should contain immutable allowfullscreen with value 'true' 1`] = `
 [

--- a/test/conventions/__snapshots__/mime-type.test.js.snap
+++ b/test/conventions/__snapshots__/mime-type.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`MIME_TYPE should contain immutable HTML with correct value 1`] = `
 [

--- a/test/conventions/__snapshots__/namespace.test.js.snap
+++ b/test/conventions/__snapshots__/namespace.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NAMESPACE should contain immutable HTML with correct value 1`] = `
 [

--- a/test/dom-parser.test.js
+++ b/test/dom-parser.test.js
@@ -187,15 +187,15 @@ describe('DOMParser', () => {
 
 				// warning
 				expect(() => parser.parseFromString('<xml attr />', MIME_TYPE.XML_TEXT)).not.toThrow(ParseError);
-				expect(onError).toBeCalledTimes(1);
+				expect(onError).toHaveBeenCalledTimes(1);
 				expect(onError).toHaveBeenCalledWith('warning', expect.anything(), expect.anything());
 				// error
 				expect(() => parser.parseFromString('<xml>&e;</xml>', MIME_TYPE.XML_TEXT)).toThrow(ParseError);
-				expect(onError).toBeCalledTimes(2);
+				expect(onError).toHaveBeenCalledTimes(2);
 				expect(onError).toHaveBeenCalledWith('error', expect.anything(), expect.anything());
 				// fatalError
 				expect(() => parser.parseFromString('', MIME_TYPE.XML_TEXT)).toThrow(ParseError);
-				expect(onError).toBeCalledTimes(3);
+				expect(onError).toHaveBeenCalledTimes(3);
 				expect(onError).toHaveBeenCalledWith('fatalError', expect.anything(), expect.anything());
 			});
 			test('should throw for level error when using onWarningStopParsing', () => {
@@ -204,15 +204,15 @@ describe('DOMParser', () => {
 
 				// warning
 				expect(() => parser.parseFromString('<xml attr />', MIME_TYPE.XML_TEXT)).toThrow(ParseError);
-				expect(onError).toBeCalledTimes(1);
+				expect(onError).toHaveBeenCalledTimes(1);
 				expect(onError).toHaveBeenCalledWith('warning', expect.anything(), expect.anything());
 				// error
 				expect(() => parser.parseFromString('<xml>&e;</xml>', MIME_TYPE.XML_TEXT)).toThrow(ParseError);
-				expect(onError).toBeCalledTimes(2);
+				expect(onError).toHaveBeenCalledTimes(2);
 				expect(onError).toHaveBeenCalledWith('error', expect.anything(), expect.anything());
 				// fatalError
 				expect(() => parser.parseFromString('', MIME_TYPE.XML_TEXT)).toThrow(ParseError);
-				expect(onError).toBeCalledTimes(3);
+				expect(onError).toHaveBeenCalledTimes(3);
 				expect(onError).toHaveBeenCalledWith('fatalError', expect.anything(), expect.anything());
 			});
 			test('should throw when errorHandler is not a function', () => {
@@ -222,7 +222,7 @@ describe('DOMParser', () => {
 				var errorHandler = jest.fn();
 				new DOMParser({ errorHandler });
 
-				expect(errorHandler).toBeCalledWith('warning', expect.stringContaining('onError'), expect.anything());
+				expect(errorHandler).toHaveBeenCalledWith('warning', expect.stringContaining('onError'), expect.anything());
 			});
 		});
 	});

--- a/test/dom/dom-implementation.test.js
+++ b/test/dom/dom-implementation.test.js
@@ -62,6 +62,9 @@ describe('DOMImplementation', () => {
 			expect(root.prefix).toBe(null);
 			expect(root.localName).toBe(NAME);
 			expect(doc.documentElement).toBe(root);
+			expect(doc.childElementCount).toBe(1);
+			expect(doc.firstElementChild).toBe(root);
+			expect(doc.lastElementChild).toBe(root);
 			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION);
 			expect(doc.type).toBe('xml');
 		});
@@ -80,6 +83,9 @@ describe('DOMImplementation', () => {
 			expect(root.tagName).toBe(NAME);
 
 			expect(doc.documentElement).toBe(root);
+			expect(doc.childElementCount).toBe(1);
+			expect(doc.firstElementChild).toBe(root);
+			expect(doc.lastElementChild).toBe(root);
 			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION);
 			expect(doc.type).toBe('xml');
 		});
@@ -99,25 +105,9 @@ describe('DOMImplementation', () => {
 			expect(root.tagName).toBe(qualifiedName);
 
 			expect(doc.documentElement).toBe(root);
-			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION);
-			expect(doc.type).toBe('xml');
-		});
-
-		test('should create a Document with root element in a named namespace', () => {
-			const impl = new DOMImplementation();
-			const qualifiedName = `${PREFIX}:${NAME}`;
-			const doc = impl.createDocument(NS, qualifiedName);
-
-			const root = doc.childNodes.item(0);
-			expect(root).toBeInstanceOf(Element);
-			expect(root.ownerDocument).toBe(doc);
-			expect(root.namespaceURI).toBe(NS);
-			expect(root.prefix).toBe(PREFIX);
-			expect(root.localName).toBe(NAME);
-			expect(root.nodeName).toBe(qualifiedName);
-			expect(root.tagName).toBe(qualifiedName);
-
-			expect(doc.documentElement).toBe(root);
+			expect(doc.childElementCount).toBe(1);
+			expect(doc.firstElementChild).toBe(root);
+			expect(doc.lastElementChild).toBe(root);
 			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION);
 			expect(doc.type).toBe('xml');
 		});
@@ -142,6 +132,9 @@ describe('DOMImplementation', () => {
 			expect(root.tagName).toBe(qualifiedName);
 
 			expect(doc.documentElement).toBe(root);
+			expect(doc.childElementCount).toBe(1);
+			expect(doc.firstElementChild).toBe(root);
+			expect(doc.lastElementChild).toBe(root);
 			expect(doc.contentType).toBe(MIME_TYPE.XML_APPLICATION);
 			expect(doc.type).toBe('xml');
 		});
@@ -210,6 +203,9 @@ describe('DOMImplementation', () => {
 			expect(doc.doctype.ownerDocument).toBe(doc);
 			expect(doc.childNodes.item(0)).toBe(doc.doctype);
 			expect(doc.firstChild).toBe(doc.doctype);
+			expect(doc.childElementCount).toBe(1);
+			expect(doc.firstElementChild).toBe(doc.documentElement);
+			expect(doc.lastElementChild).toBe(doc.documentElement);
 
 			expect(doc.documentElement).not.toBeNull();
 			expect(doc.documentElement.localName).toBe('html');
@@ -219,10 +215,14 @@ describe('DOMImplementation', () => {
 			expect(htmlNode.firstChild).not.toBeNull();
 			expect(htmlNode.firstChild.nodeName).toBe('head');
 			expect(htmlNode.firstChild.childNodes).toHaveLength(0);
+			expect(htmlNode.firstElementChild).toBe(htmlNode.firstChild);
+			expect(htmlNode.firstElementChild.nextElementSibling).toBe(htmlNode.lastChild);
 
 			expect(htmlNode.lastChild).not.toBeNull();
 			expect(htmlNode.lastChild.nodeName).toBe('body');
 			expect(htmlNode.lastChild.childNodes).toHaveLength(0);
+			expect(htmlNode.lastElementChild).toBe(htmlNode.lastChild);
+			expect(htmlNode.lastElementChild.previousElementSibling).toBe(htmlNode.firstChild);
 		});
 		test('should create an HTML document with specified elements including an empty title', () => {
 			const impl = new DOMImplementation();

--- a/test/errors/__snapshots__/dom-exception.test.js.snap
+++ b/test/errors/__snapshots__/dom-exception.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DOMException should have correct name from code 1 1`] = `"IndexSizeError"`;
 

--- a/test/errors/__snapshots__/reported-levels.test.js.snap
+++ b/test/errors/__snapshots__/reported-levels.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Encoding_ReplacementCharacter with mimeType text/html should be reported 1`] = `
 [

--- a/test/errors/__snapshots__/xml-error.test.js.snap
+++ b/test/errors/__snapshots__/xml-error.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`html without reported errors html attribute (missing quote) 1`] = `
 {

--- a/test/grammar/__snapshots__/externalid.test.js.snap
+++ b/test/grammar/__snapshots__/externalid.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ExternalID PUBLIC should match ""PUBLIC " a-zA-Z0-9-()+,./:=?;!*#@$_%" '"'"" 1`] = `
 {

--- a/test/grammar/__snapshots__/name.test.js.snap
+++ b/test/grammar/__snapshots__/name.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`QName should match a single NCNameStartChar NCNameChar(s) ':' NCNameStartChar NCNameChar(s) "_-:_-" (\\u005F\\u002D\\u003A\\u005F\\u002D) 1`] = `
 [

--- a/test/grammar/__snapshots__/pi.test.js.snap
+++ b/test/grammar/__snapshots__/pi.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`PI should not be greedy 1`] = `
 [

--- a/test/grammar/__snapshots__/regexp.test.js.snap
+++ b/test/grammar/__snapshots__/regexp.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`all grammar regular expressions should have the expected keys 1`] = `
 [

--- a/test/html/__snapshots__/normalize.test.js.snap
+++ b/test/html/__snapshots__/normalize.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`html normalizer <Label onClick=doClick..">Hello, World</Label> 1`] = `
 {

--- a/test/parse/__snapshots__/locator.test.js.snap
+++ b/test/parse/__snapshots__/locator.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`DOMLocator attribute position 1`] = `
 {

--- a/test/parse/__snapshots__/parse-element.test.js.snap
+++ b/test/parse/__snapshots__/parse-element.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`XML Node Parse closing tag with unquoted value ending with // 1`] = `
 [

--- a/test/parse/__snapshots__/simple.test.js.snap
+++ b/test/parse/__snapshots__/simple.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`parse simple 1`] = `
 {

--- a/test/parse/__snapshots__/test-doc-whitespace.test.js.snap
+++ b/test/parse/__snapshots__/test-doc-whitespace.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`errorHandle document source 1`] = `
 {

--- a/test/parse/node.test.js
+++ b/test/parse/node.test.js
@@ -141,7 +141,12 @@ describe('XML Node Parse', () => {
 
 			expectNeighbours(first, last);
 			expect(fragment.firstChild).toStrictEqual(first);
+			expect(fragment.firstElementChild).toStrictEqual(first);
+			expect(fragment.firstElementChild.nextElementSibling).toStrictEqual(last);
 			expect(fragment.lastChild).toStrictEqual(last);
+			expect(fragment.lastElementChild).toStrictEqual(last);
+			expect(fragment.lastElementChild.previousElementSibling).toStrictEqual(first);
+			expect(fragment.childElementCount).toBe(2);
 		});
 	});
 
@@ -163,10 +168,20 @@ describe('XML Node Parse', () => {
 			const first = fragment.appendChild(dom.createElement('first'));
 			const second = fragment.appendChild(dom.createElement('second'));
 
-			child.parentNode.insertBefore(fragment, child);
+			const parent = child.parentNode;
+			parent.insertBefore(fragment, child);
 
 			expectNeighbours(first, second, child);
-			expect(child.parentNode.firstChild).toStrictEqual(first);
+			expect(parent.firstChild).toStrictEqual(first);
+			expect(parent.childElementCount).toStrictEqual(3);
+			expect(parent.firstElementChild).toStrictEqual(first);
+			expect(parent.lastElementChild).toStrictEqual(child);
+			expect(first.previousElementSibling).toBeNull();
+			expect(first.nextElementSibling).toStrictEqual(second);
+			expect(second.previousElementSibling).toStrictEqual(first);
+			expect(second.nextElementSibling).toStrictEqual(child);
+			expect(child.previousElementSibling).toStrictEqual(second);
+			expect(child.nextElementSibling).toBeNull();
 		});
 	});
 

--- a/test/xmltest/__snapshots__/not-wf.test.js.snap
+++ b/test/xmltest/__snapshots__/not-wf.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`xmltest/not-wellformed standalone should match 001.xml with snapshot: caught 1`] = `"Opening and ending tag mismatch: "doc" != "a""`;
 

--- a/test/xmltest/__snapshots__/valid.test.js.snap
+++ b/test/xmltest/__snapshots__/valid.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`xmltest/valid standalone should match 001.xml with snapshot 1`] = `
 {


### PR DESCRIPTION
Hey!

Since https://github.com/xmldom/xmldom/pull/398 seems to be stale and apparently no longer being worked on by the original author, I figured I'd make another attempt.

This PR adds the following properties to `Element` nodes:
- `childElementCount`
- `firstElementChild`
- `lastElementChild`
- `nextElementSibling`
- `previousElementSibling`

These properties correspond to the attributes defined in the [`ParentNode`](https://dom.spec.whatwg.org/#interface-parentnode) and [`NonDocumentTypeChildNode`](https://dom.spec.whatwg.org/#interface-nondocumenttypechildnode) mixins in the DOM Living Standard.

The first three of these properties are also added to `Document` and `DocumentFragment`.