### PR TITLE
fix: parse empty/whitspace only doctype internal subset

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -719,6 +719,10 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 				current = parsePI(p, errorHandler);
 			} else if (p.char() === '%') {
 				current = p.getMatch(g.PEReference);
+			} else if (p.char() === ']') {
+				var internalSubset = source.substring(intSubsetStart, p.getIndex());
+				p.skip(1);
+				return internalSubset;
 			} else {
 				return errorHandler.fatalError('Error detected in Markup declaration');
 			}

--- a/test/sax/parseDoctypeInternalSubset.test.js
+++ b/test/sax/parseDoctypeInternalSubset.test.js
@@ -133,7 +133,7 @@ describe('parseDoctypeCommentOrCData', () => {
 
 		expect(errorHandler.fatalError).not.toHaveBeenCalled();
 		expect(returned).toBe(source.length);
-		expect(domBuilder.startDTD).toHaveBeenCalledWith(Name, '"pubId"', '"sysId"', "");
+		expect(domBuilder.startDTD).toHaveBeenCalledWith(Name, '"pubId"', '"sysId"', '');
 		expect(domBuilder.endDTD).toHaveBeenCalled();
 	});
 
@@ -148,7 +148,7 @@ describe('parseDoctypeCommentOrCData', () => {
 
 		expect(errorHandler.fatalError).not.toHaveBeenCalled();
 		expect(returned).toBe(source.length);
-		expect(domBuilder.startDTD).toHaveBeenCalledWith(Name, '"pubId"', '"sysId"', " ");
+		expect(domBuilder.startDTD).toHaveBeenCalledWith(Name, '"pubId"', '"sysId"', ' ');
 		expect(domBuilder.endDTD).toHaveBeenCalled();
 	});
 });

--- a/test/sax/parseDoctypeInternalSubset.test.js
+++ b/test/sax/parseDoctypeInternalSubset.test.js
@@ -125,6 +125,21 @@ describe('parseDoctypeCommentOrCData', () => {
 	test('should call domHandler method with correct values when everything is well-formed and empty', () => {
 		const start = 0;
 		const Name = 'Name';
+		var source = g.DOCTYPE_DECL_START + ' ' + Name + ' PUBLIC "pubId" "sysId" []>';
+		const errorHandler = { fatalError: jest.fn() };
+		const domBuilder = { startDTD: jest.fn(), endDTD: jest.fn() };
+
+		const returned = parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler);
+
+		expect(errorHandler.fatalError).not.toHaveBeenCalled();
+		expect(returned).toBe(source.length);
+		expect(domBuilder.startDTD).toHaveBeenCalledWith(Name, '"pubId"', '"sysId"', "");
+		expect(domBuilder.endDTD).toHaveBeenCalled();
+	});
+
+	test('should call domHandler method with correct values when everything is well-formed and empty with spaces', () => {
+		const start = 0;
+		const Name = 'Name';
 		var source = g.DOCTYPE_DECL_START + ' ' + Name + ' PUBLIC "pubId" "sysId" [ ]>';
 		const errorHandler = { fatalError: jest.fn() };
 		const domBuilder = { startDTD: jest.fn(), endDTD: jest.fn() };

--- a/test/sax/parseDoctypeInternalSubset.test.js
+++ b/test/sax/parseDoctypeInternalSubset.test.js
@@ -124,7 +124,6 @@ describe('parseDoctypeCommentOrCData', () => {
 
 	test('should call domHandler method with correct values when everything is well-formed and empty', () => {
 		const start = 0;
-		const pi = '<?pi simple ?>';
 		const Name = 'Name';
 		var source = g.DOCTYPE_DECL_START + ' ' + Name + ' PUBLIC "pubId" "sysId" [ ]>';
 		const errorHandler = { fatalError: jest.fn() };

--- a/test/sax/parseDoctypeInternalSubset.test.js
+++ b/test/sax/parseDoctypeInternalSubset.test.js
@@ -121,4 +121,20 @@ describe('parseDoctypeCommentOrCData', () => {
 		expect(domBuilder.startDTD).toHaveBeenCalledWith(Name, '"pubId"', '"sysId"', pi);
 		expect(domBuilder.endDTD).toHaveBeenCalled();
 	});
+
+	test('should call domHandler method with correct values when everything is well-formed and empty', () => {
+		const start = 0;
+		const pi = '<?pi simple ?>';
+		const Name = 'Name';
+		var source = g.DOCTYPE_DECL_START + ' ' + Name + ' PUBLIC "pubId" "sysId" [ ]>';
+		const errorHandler = { fatalError: jest.fn() };
+		const domBuilder = { startDTD: jest.fn(), endDTD: jest.fn() };
+
+		const returned = parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler);
+
+		expect(errorHandler.fatalError).not.toHaveBeenCalled();
+		expect(returned).toBe(source.length);
+		expect(domBuilder.startDTD).toHaveBeenCalledWith(Name, '"pubId"', '"sysId"', " ");
+		expect(domBuilder.endDTD).toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
Added a condition to the parser to allow empty doctypes