### PR TITLE
refactor: merge redundant ']' condition at start of while loop

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -689,8 +689,13 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 	if (p.char() === '[') {
 		p.skip(1);
 		var intSubsetStart = p.getIndex();
-		p.skipBlanks();
 		while (p.getIndex() < source.length) {
+			p.skipBlanks();
+			if (p.char() === ']') {
+				var internalSubset = source.substring(intSubsetStart, p.getIndex());
+				p.skip(1);
+				return internalSubset;
+			}
 			var current = null;
 			// Only in external subset
 			// if (char() === '<' && char(1) === '!' && char(2) === '[') {
@@ -698,20 +703,20 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 			// } else
 			if (p.char() === '<' && p.char(1) === '!') {
 				switch (p.char(2)) {
-					case 'E':
+					case 'E': // ELEMENT | ENTITY
 						if (p.char(3) === 'L') {
 							current = p.getMatch(g.elementdecl);
 						} else if (p.char(3) === 'N') {
 							current = p.getMatch(g.EntityDecl);
 						}
 						break;
-					case 'A':
+					case 'A': // ATTRIBUTE
 						current = p.getMatch(g.AttlistDecl);
 						break;
-					case 'N':
+					case 'N': // NOTATION
 						current = p.getMatch(g.NotationDecl);
 						break;
-					case '-':
+					case '-': // COMMENT
 						current = p.getMatch(g.Comment);
 						break;
 				}
@@ -719,23 +724,12 @@ function parseDoctypeInternalSubset(p, errorHandler) {
 				current = parsePI(p, errorHandler);
 			} else if (p.char() === '%') {
 				current = p.getMatch(g.PEReference);
-			} else if (p.char() === ']') {
-				var internalSubset = source.substring(intSubsetStart, p.getIndex());
-				p.skip(1);
-				return internalSubset;
 			} else {
 				return errorHandler.fatalError('Error detected in Markup declaration');
 			}
 			if (!current) {
 				return errorHandler.fatalError('Error in internal subset at position ' + p.getIndex());
 			}
-			p.skipBlanks();
-			if (p.char() === ']') {
-				var internalSubset = source.substring(intSubsetStart, p.getIndex());
-				p.skip(1);
-				return internalSubset;
-			}
-			p.skipBlanks();
 		}
 		return errorHandler.fatalError('doctype internal subset is not well-formed, missing ]');
 	}

--- a/test/sax/parseDoctypeInternalSubset.test.js
+++ b/test/sax/parseDoctypeInternalSubset.test.js
@@ -108,7 +108,7 @@ describe('parseDoctypeCommentOrCData', () => {
 	});
 	test('should call domHandler method with correct values when everything is well-formed', () => {
 		const start = 0;
-		const pi = '<?pi simple ?>';
+		const pi = '<?pi simple ?> ';
 		const Name = 'Name';
 		var source = g.DOCTYPE_DECL_START + ' ' + Name + ' PUBLIC "pubId" "sysId" [' + pi + ']>';
 		const errorHandler = { fatalError: jest.fn() };
@@ -149,6 +149,22 @@ describe('parseDoctypeCommentOrCData', () => {
 		expect(errorHandler.fatalError).not.toHaveBeenCalled();
 		expect(returned).toBe(source.length);
 		expect(domBuilder.startDTD).toHaveBeenCalledWith(Name, '"pubId"', '"sysId"', ' ');
+		expect(domBuilder.endDTD).toHaveBeenCalled();
+	});
+
+	test('should call domHandler method with correct values when everything is well-formed and empty with comment', () => {
+		const start = 0;
+		const Name = 'Name';
+		const internalSubset = ' <!-- comment --> ';
+		var source = g.DOCTYPE_DECL_START + ' ' + Name + ' PUBLIC "pubId" "sysId" [' + internalSubset + ']>';
+		const errorHandler = { fatalError: jest.fn() };
+		const domBuilder = { startDTD: jest.fn(), endDTD: jest.fn() };
+
+		const returned = parseDoctypeCommentOrCData(source, start, domBuilder, errorHandler);
+
+		expect(errorHandler.fatalError).not.toHaveBeenCalled();
+		expect(returned).toBe(source.length);
+		expect(domBuilder.startDTD).toHaveBeenCalledWith(Name, '"pubId"', '"sysId"', internalSubset);
 		expect(domBuilder.endDTD).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
with the fix added in #692 `parseDoctypeInternalSubset` has two places that check for the ending symbol and returned the `internalSubSet` as a string. By moving it to the beginning of the while loop, we only need to check the condition once.

I also added tests for more cases ending with a space before the closing square bracket.