### PR TITLE
chore: minimum tested node version is 14

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,6 +22,7 @@ jobs:
         - 16
         - 18
         - 20
+        - 22
 
     steps:
     - name: Harden Runner
@@ -54,6 +55,7 @@ jobs:
         - 16
         - 18
         - 20
+        - 22
 
     steps:
     - name: Harden Runner

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -18,8 +18,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-        - 10
-        - 12
         - 14
         - 16
         - 18
@@ -50,43 +48,7 @@ jobs:
         - 3
         - 4
         - "5.0" # requires node version 12.20
-        # starting with typescript 5.1 the minimum required node version is 14.17
-        # so current versions have a separate job without node v12
-        node-version:
-        - 12
-        - 14
-        - 16
-        - 18
-        - 20
-
-    steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
-      with:
-        egress-policy: audit
-
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: ./pretest.sh ${{ matrix.ts-version }}
-      working-directory: examples/typescript-node-es6
-    - run: node --experimental-modules dist/index.js
-      if: ${{ matrix.node-version == 12 }}
-      working-directory: examples/typescript-node-es6
-    - run: node dist/index.js
-      if: ${{ matrix.node-version > 12 }}
-      working-directory: examples/typescript-node-es6
-  typescript51-node-es6:
-    # starting with typescript 5.1 the minimum required node version is 14.17
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        ts-version:
-        - 5
+        - 5 # typescript >=5.1 requires node version >=14.17
         node-version:
         - 14
         - 16

--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -24,6 +24,7 @@ jobs:
         - 16
         - 18
         - 20
+        - 22
 
     steps:
     - name: Harden Runner

--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -38,12 +38,12 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci --no-audit
     - run: npm run test
-      if: matrix.node-version != 16
+      if: matrix.node-version != 18
     - run: npm run test -- --coverage
-      if: matrix.node-version == 16
+      if: matrix.node-version == 18
     - run: npm run fuzz
-      if: matrix.node-version == 16
-    - if: matrix.node-version == 16
+      if: matrix.node-version == 18
+    - if: matrix.node-version == 18
       uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"release": "np --no-yarn --test-script testrelease"
 	},
 	"engines": {
-		"node": ">=10.0.0"
+		"node": ">=14.0.0"
 	},
 	"devDependencies": {
 		"@homer0/prettier-plugin-jsdoc": "9.0.2",


### PR DESCRIPTION
- drops node versions 10 and 12 from github actions, and add v22
- bumps `engines.node` to >=14

https://github.com/xmldom/xmldom/discussions/495