### PR TITLE
fix(types): DOMParser.parseFromString requires mimeType as second argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -284,7 +284,7 @@ declare module '@xmldom/xmldom' {
 		 */
 		parseFromString(
 			source: string,
-			mimeType: MIME_TYPE = MIME_TYPE.XML_TEXT
+			mimeType: MIME_TYPE
 		): Document;
 	}
 


### PR DESCRIPTION
Based on the spec and the current implementation the second argument of DOMParser.parseFromString is not optional and doesn't have a default value.

https://github.com/xmldom/xmldom/blob/9f9a74850a7c929dfd82462e9720a12097bbf426/lib/dom-parser.js#L215

https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
https://html.spec.whatwg.org/#dom-domparser-parsefromstring-dev

This fixes types for changes made in https://github.com/xmldom/xmldom/releases/tag/0.9.0

Previous release https://github.com/xmldom/xmldom/releases/tag/0.8.10 allowed `mimeType` as optional.