### PR TITLE
fix: add missing type definitions

### DIFF
--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -23,6 +23,7 @@ import {
 	ParseError,
 	Text,
 	XMLSerializer,
+	Element,
 } from '@xmldom/xmldom';
 
 const failedAssertions: Error[] = [];
@@ -85,6 +86,8 @@ assert(doc1.DOCUMENT_POSITION_CONTAINS, 8);
 assert(doc1 instanceof Node, true);
 assert(doc1 instanceof Document, true);
 assert(doc1.childNodes instanceof NodeList, true);
+assert(doc1.documentElement instanceof Element, true);
+assert(doc1.documentElement?.tagName, 'qualifiedName');
 assert(doc1.getElementsByClassName('hide') instanceof LiveNodeList, true);
 
 const attr = doc1.createAttribute('attr');

--- a/index.d.ts
+++ b/index.d.ts
@@ -771,6 +771,13 @@ declare module '@xmldom/xmldom' {
 		/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/attributes) */
 		readonly attributes: NamedNodeMap;
 		/**
+		 * Returns the HTML-uppercased qualified name.
+		 *
+		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/tagName)
+		 */
+		readonly tagName: string;
+
+		/**
 		 * Returns element's first attribute whose qualified name is qualifiedName, and null if there
 		 * is no such attribute otherwise.
 		 *
@@ -1067,6 +1074,12 @@ declare module '@xmldom/xmldom' {
 		readonly nodeName: '#document';
 		readonly nodeType: typeof Node.DOCUMENT_NODE;
 		readonly doctype: DocumentType | null;
+		/**
+		 * Gets a reference to the root node of the document.
+		 *
+		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/documentElement)
+		 */
+		readonly documentElement: Element | null;
 
 		/**
 		 * Creates an attribute object with a specified name.


### PR DESCRIPTION
Adds types for properties that are exported,
but are missing in index.d.ts:

- `Document.domElement`
- `Element.tagName`

Fixes #720