### PR TITLE
feat: add Element.getElementsByClassName

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -804,7 +804,22 @@ declare module '@xmldom/xmldom' {
 			namespace: string | null,
 			localName: string
 		): Attr | null;
-		/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/getBoundingClientRect) */
+		/**
+		 * Returns a LiveNodeList of all child elements which have **all** of the given class
+		 * name(s).
+		 *
+		 * Returns an empty list if `classNames` is an empty string or only contains HTML white space
+		 * characters.
+		 *
+		 * Warning: This returns a live LiveNodeList.
+		 * Changes in the DOM will reflect in the array as the changes occur.
+		 * If an element selected by this array no longer qualifies for the selector,
+		 * it will automatically be removed. Be aware of this for iteration purposes.
+		 *
+		 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByClassName
+		 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
+		 */
+		getElementsByClassName(classNames: string): LiveNodeList;
 
 		/**
 		 * Returns a LiveNodeList of elements with the given qualifiedName.
@@ -1118,7 +1133,6 @@ declare module '@xmldom/xmldom' {
 		 */
 		createDocumentFragment(): DocumentFragment;
 
-
 		createElement(tagName: string): Element;
 
 		/**
@@ -1141,10 +1155,7 @@ declare module '@xmldom/xmldom' {
 		 *
 		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/createElementNS)
 		 */
-		createElementNS(
-			namespace: string | null,
-			qualifiedName: string,
-		): Element;
+		createElementNS(namespace: string | null, qualifiedName: string): Element;
 
 		/**
 		 * Returns a ProcessingInstruction node whose target is target and data is data. If target does
@@ -1178,20 +1189,17 @@ declare module '@xmldom/xmldom' {
 		getElementById(elementId: string): Element | null;
 
 		/**
-		 * The `getElementsByClassName` method of `Document` interface returns an array-like object
-		 * of all child elements which have **all** of the given class name(s).
+		 * Returns a LiveNodeList of all child elements which have **all** of the given class
+		 * name(s).
 		 *
-		 * Returns an empty list if `classeNames` is an empty string or only contains HTML white
-		 * space characters.
+		 * Returns an empty list if `classNames` is an empty string or only contains HTML white space
+		 * characters.
 		 *
-		 * Warning: This is a live LiveNodeList.
+		 * Warning: This returns a live LiveNodeList.
 		 * Changes in the DOM will reflect in the array as the changes occur.
 		 * If an element selected by this array no longer qualifies for the selector,
 		 * it will automatically be removed. Be aware of this for iteration purposes.
 		 *
-		 * @param {string} classNames
-		 * Is a string representing the class name(s) to match; multiple class names are separated by
-		 * (ASCII-)whitespace.
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 		 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 		 */

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2004,51 +2004,6 @@ Document.prototype = {
 	},
 
 	/**
-	 * The `getElementsByClassName` method of `Document` interface returns an array-like object of
-	 * all child elements which have **all** of the given class name(s).
-	 *
-	 * Returns an empty list if `classeNames` is an empty string or only contains HTML white space
-	 * characters.
-	 *
-	 * Warning: This is a live LiveNodeList.
-	 * Changes in the DOM will reflect in the array as the changes occur.
-	 * If an element selected by this array no longer qualifies for the selector,
-	 * it will automatically be removed. Be aware of this for iteration purposes.
-	 *
-	 * @param {string} classNames
-	 * Is a string representing the class name(s) to match; multiple class names are separated by
-	 * (ASCII-)whitespace.
-	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
-	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
-	 */
-	getElementsByClassName: function (classNames) {
-		var classNamesSet = toOrderedSet(classNames);
-		return new LiveNodeList(this, function (base) {
-			var ls = [];
-			if (classNamesSet.length > 0) {
-				_visitNode(base.documentElement, function (node) {
-					if (node !== base && node.nodeType === ELEMENT_NODE) {
-						var nodeClassNames = node.getAttribute('class');
-						// can be null if the attribute does not exist
-						if (nodeClassNames) {
-							// before splitting and iterating just compare them for the most common case
-							var matches = classNames === nodeClassNames;
-							if (!matches) {
-								var nodeClassNamesSet = toOrderedSet(nodeClassNames);
-								matches = classNamesSet.every(arrayIncludes(nodeClassNamesSet));
-							}
-							if (matches) {
-								ls.push(node);
-							}
-						}
-					}
-				});
-			}
-			return ls;
-		});
-	},
-
-	/**
 	 * Creates a new `Element` that is owned by this `Document`.
 	 * In HTML Documents `localName` is the lower cased `tagName`,
 	 * otherwise no transformation is being applied.
@@ -2303,6 +2258,51 @@ Element.prototype = {
 	},
 
 	/**
+	 * Returns a LiveNodeList of all child elements which have **all** of the given class name(s).
+	 *
+	 * Returns an empty list if `classNames` is an empty string or only contains HTML white space
+	 * characters.
+	 *
+	 * Warning: This returns a live LiveNodeList.
+	 * Changes in the DOM will reflect in the array as the changes occur.
+	 * If an element selected by this array no longer qualifies for the selector,
+	 * it will automatically be removed. Be aware of this for iteration purposes.
+	 *
+	 * @param {string} classNames
+	 * Is a string representing the class name(s) to match; multiple class names are separated by
+	 * (ASCII-)whitespace.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByClassName
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
+	 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
+	 */
+	getElementsByClassName: function (classNames) {
+		var classNamesSet = toOrderedSet(classNames);
+		return new LiveNodeList(this, function (base) {
+			var ls = [];
+			if (classNamesSet.length > 0) {
+				_visitNode(base, function (node) {
+					if (node !== base && node.nodeType === ELEMENT_NODE) {
+						var nodeClassNames = node.getAttribute('class');
+						// can be null if the attribute does not exist
+						if (nodeClassNames) {
+							// before splitting and iterating just compare them for the most common case
+							var matches = classNames === nodeClassNames;
+							if (!matches) {
+								var nodeClassNamesSet = toOrderedSet(nodeClassNames);
+								matches = classNamesSet.every(arrayIncludes(nodeClassNamesSet));
+							}
+							if (matches) {
+								ls.push(node);
+							}
+						}
+					}
+				});
+			}
+			return ls;
+		});
+	},
+
+	/**
 	 * Returns a LiveNodeList of elements with the given qualifiedName.
 	 * Searching for all descendants can be done by passing `*` as `qualifiedName`.
 	 *
@@ -2365,6 +2365,7 @@ Element.prototype = {
 		});
 	},
 };
+Document.prototype.getElementsByClassName = Element.prototype.getElementsByClassName;
 Document.prototype.getElementsByTagName = Element.prototype.getElementsByTagName;
 Document.prototype.getElementsByTagNameNS = Element.prototype.getElementsByTagNameNS;
 

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -92,7 +92,7 @@ describe('Document.prototype', () => {
 
 			expect(doc.getElementsByClassName(' \f\n\r\t')).toHaveLength(0);
 		});
-		test('should return only the case insensitive matching names', () => {
+		test('should return only the case sensitive matching names', () => {
 			const MIXED_CASES = ['AAA', 'AAa', 'AaA', 'aAA'];
 			const doc = getTestParser().parser.parseFromString(INPUT(...MIXED_CASES), MIME_TYPE.XML_TEXT);
 

--- a/test/dom/element.test.js
+++ b/test/dom/element.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { describe, expect, test } = require('@jest/globals');
+const { getTestParser } = require('../get-test-parser');
 const { DOMParser, DOMImplementation, XMLSerializer } = require('../../lib');
 const { MIME_TYPE, NAMESPACE } = require('../../lib/conventions');
 const { Element, Node } = require('../../lib/dom');
@@ -128,6 +129,29 @@ describe('documentElement', () => {
 	xit('self append failed', () => {});
 });
 
+const INPUT = (first = '', second = '', third = '', fourth = '') => `
+<html >
+	<body id='body'>
+		<p id='p1' class=' quote first   odd ${first} '>Lorem ipsum</p>
+		<p id='p2' class=' quote second  even ${second} '>Lorem ipsum</p>
+		<p id='p3' class=' quote third   odd ${third} '>Lorem ipsum</p>
+		<p id='p4' class=' quote fourth  even ${fourth} '>Lorem ipsum</p>
+	</body>
+</html>
+`;
+
+/**
+ * Whitespace that can be part of classnames.
+ * Some characters (like `\u2028`) will be normalized when parsing,
+ * but they can still be added to the dom after parsing.
+ *
+ * @see https://www.w3.org/TR/html52/infrastructure.html#set-of-space-separated-tokens
+ * @see {@link normalizeLineEndings}
+ * @see https://www.w3.org/TR/xml11/#sec-line-ends
+ */
+const NON_HTML_WHITESPACE =
+	'\v\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000\ufeff';
+
 describe('Element', () => {
 	const ATTR_MIXED_CASE = 'AttR';
 	const ATTR_LOWER_CASE = 'attr';
@@ -140,6 +164,73 @@ describe('Element', () => {
 	describe('getAttribute', () => {
 		const doc = new DOMImplementation().createDocument(null, 'xml');
 		expect(doc.documentElement.getAttribute('no')).toBeNull();
+	});
+	describe('getElementsByClassName', () => {
+		test('should be able to resolve [] as a class name', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT('[]'), MIME_TYPE.XML_TEXT);
+			const body = doc.getElementsByTagName('body')[0];
+			expect(body.getElementsByClassName('[]')).toHaveLength(1);
+		});
+		test('should be able to resolve [ as a class name', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT('['), MIME_TYPE.XML_TEXT);
+			const body = doc.getElementsByTagName('body')[0];
+			expect(body.getElementsByClassName('[')).toHaveLength(1);
+		});
+		test('should be able to resolve multiple class names in a different order', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT(), MIME_TYPE.XML_TEXT);
+			const body = doc.getElementsByTagName('body')[0];
+			expect(body.getElementsByClassName('odd quote')).toHaveLength(2);
+		});
+		test('should be able to resolve non html whitespace as classname', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT(), MIME_TYPE.XML_TEXT);
+			const body = doc.getElementsByTagName('body')[0];
+			const firstP = body.getElementsByTagName('p')[0];
+			expect(firstP).toBeDefined();
+
+			firstP.setAttribute('class', firstP.getAttribute('class') + ' ' + NON_HTML_WHITESPACE);
+
+			expect(body.getElementsByClassName(`quote ${NON_HTML_WHITESPACE}`)).toHaveLength(1);
+		});
+		test('should not allow regular expression in argument', () => {
+			const search = '(((a||||)+)+)+';
+			const matching = 'aaaaa';
+			expect(new RegExp(search).test(matching)).toBe(true);
+
+			const doc = getTestParser().parser.parseFromString(INPUT(search, matching, search), MIME_TYPE.XML_TEXT);
+			const body = doc.getElementsByTagName('body')[0];
+
+			expect(body.getElementsByClassName(search)).toHaveLength(2);
+		});
+		test('should return an empty collection when no class names or are passed', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT(), MIME_TYPE.XML_TEXT);
+			const body = doc.getElementsByTagName('body')[0];
+
+			expect(body.getElementsByClassName('')).toHaveLength(0);
+		});
+		test('should return only children not the element itself', () => {
+			const doc = getTestParser().parser.parseFromString(INPUT(), MIME_TYPE.XML_TEXT);
+			const body = doc.getElementsByTagName('body')[0];
+			body.setAttribute('class', 'quote');
+
+			expect(body.getElementsByClassName('quote')).toHaveLength(4);
+		});
+		test('should return an empty collection when only spaces are passed', () => {
+			const doc = getTestParser().parser.parseFromString(
+				INPUT(' \f\n\r\t', ' \f\n\r\t', ' \f\n\r\t', ' \f\n\r\t'),
+				MIME_TYPE.XML_TEXT
+			);
+			const body = doc.getElementsByTagName('body')[0];
+
+			expect(body.getElementsByClassName(' \f\n\r\t')).toHaveLength(0);
+		});
+		test('should return only the case sensitive matching names', () => {
+			const MIXED_CASES = ['AAA', 'AAa', 'AaA', 'aAA'];
+			const doc = getTestParser().parser.parseFromString(INPUT(...MIXED_CASES), MIME_TYPE.XML_TEXT);
+
+			MIXED_CASES.forEach((className) => {
+				expect(doc.getElementsByClassName(className)).toHaveLength(1);
+			});
+		});
 	});
 	describe('setAttribute', () => {
 		test.each([null, NAMESPACE.HTML])('should set attribute as is in XML document with namespace %s', (ns) => {


### PR DESCRIPTION
the method was previously implemented on the Document interface.

https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByClassName

supersedes #584
fixes #582