### PR TITLE
fix: restore more Node and ProcessingInstruction types

### DIFF
--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -24,6 +24,7 @@ import {
 	Text,
 	XMLSerializer,
 	Element,
+	ProcessingInstruction,
 } from '@xmldom/xmldom';
 
 const failedAssertions: Error[] = [];
@@ -113,6 +114,8 @@ const pi = doc1.createProcessingInstruction('target', 'data');
 assert(pi.nodeType, Node.PROCESSING_INSTRUCTION_NODE);
 assert(pi.target, pi.nodeName);
 assert(pi.data, pi.nodeValue);
+assert(pi instanceof ProcessingInstruction, true);
+assert(pi instanceof CharacterData, true);
 
 const cdata = doc1.createCDATASection('< &');
 assert(cdata instanceof CharacterData, true);

--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -75,6 +75,14 @@ new ParseError('message', {}, domException);
 assert(Node.ATTRIBUTE_NODE, 2);
 assert(Node.DOCUMENT_POSITION_CONTAINS, 8);
 
+// there are no real Node instances,
+// but we want to check that the Node type provides these props
+const fakeNode = {} as unknown as Node;
+fakeNode.nodeType;
+fakeNode.lineNumber;
+fakeNode.columnNumber;
+fakeNode.textContent;
+
 assert(new NodeList().length, 0);
 
 const impl = new DOMImplementation();
@@ -100,6 +108,11 @@ const element = doc1.createElement('a');
 assert(element.nodeType, Node.ELEMENT_NODE);
 assert(element.ownerDocument, doc1);
 assert(element.attributes instanceof NamedNodeMap, true);
+
+const pi = doc1.createProcessingInstruction('target', 'data')
+assert(pi.nodeType, Node.PROCESSING_INSTRUCTION_NODE);
+assert(pi.target, pi.nodeName);
+assert(pi.data, pi.nodeValue);
 
 const cdata = doc1.createCDATASection('< &');
 assert(cdata instanceof CharacterData, true);

--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -112,6 +112,8 @@ assert(element.attributes instanceof NamedNodeMap, true);
 
 const pi = doc1.createProcessingInstruction('target', 'data');
 assert(pi.nodeType, Node.PROCESSING_INSTRUCTION_NODE);
+assert(pi.target, 'target');
+assert(pi.data, 'data');
 assert(pi.target, pi.nodeName);
 assert(pi.data, pi.nodeValue);
 assert(pi instanceof ProcessingInstruction, true);

--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -78,10 +78,10 @@ assert(Node.DOCUMENT_POSITION_CONTAINS, 8);
 // there are no real Node instances,
 // but we want to check that the Node type provides these props
 const fakeNode = {} as unknown as Node;
-fakeNode.nodeType;
-fakeNode.lineNumber;
-fakeNode.columnNumber;
-fakeNode.textContent;
+assert(fakeNode.nodeType, undefined);
+assert(fakeNode.lineNumber, undefined);
+assert(fakeNode.columnNumber, undefined);
+assert(fakeNode.textContent, undefined);
 
 assert(new NodeList().length, 0);
 
@@ -109,7 +109,7 @@ assert(element.nodeType, Node.ELEMENT_NODE);
 assert(element.ownerDocument, doc1);
 assert(element.attributes instanceof NamedNodeMap, true);
 
-const pi = doc1.createProcessingInstruction('target', 'data')
+const pi = doc1.createProcessingInstruction('target', 'data');
 assert(pi.nodeType, Node.PROCESSING_INSTRUCTION_NODE);
 assert(pi.target, pi.nodeName);
 assert(pi.data, pi.nodeValue);

--- a/index.d.ts
+++ b/index.d.ts
@@ -975,12 +975,7 @@ declare module '@xmldom/xmldom' {
 	 *
 	 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CharacterData)
 	 */
-	var CharacterData: {
-		// instanceof pre ts 5.3
-		(val: unknown): val is CharacterData;
-		// instanceof post ts 5.3
-		[Symbol.hasInstance](val: unknown): val is CharacterData;
-	};
+	var CharacterData: InstanceOf<CharacterData>;
 
 	/**
 	 * The textual content of Element or Attr. If an element has no markup within its content, it has
@@ -1081,11 +1076,16 @@ declare module '@xmldom/xmldom' {
 	interface ProcessingInstruction extends Node {
 		nodeType: typeof Node.PROCESSING_INSTRUCTION_NODE;
 		/**
-		 * Everything that goes after the target, excluding `?>`.
+		 * A string representing the textual data contained in this object.
+		 * For `ProcessingInstruction`, that means everything that goes after the `target`, excluding
+		 * `?>`.
+		 *
 		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CharacterData/data)
 		 */
 		data: string;
-		/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/target) */
+		/**
+		 * A string containing the name of the application.
+		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/target) */
 		readonly target: string;
 	}
 	var ProcessingInstruction: InstanceOf<ProcessingInstruction>;
@@ -1394,7 +1394,6 @@ declare module '@xmldom/xmldom' {
 	class XMLSerializer {
 		serializeToString(node: Node, nodeFilter?: (node: Node) => boolean): string;
 	}
-
 	// END ./lib/dom.js
 
 	// START ./lib/dom-parser.js

--- a/index.d.ts
+++ b/index.d.ts
@@ -1073,7 +1073,7 @@ declare module '@xmldom/xmldom' {
 	}
 	var Notation: InstanceOf<Notation>;
 
-	interface ProcessingInstruction extends Node {
+	interface ProcessingInstruction extends CharacterData {
 		nodeType: typeof Node.PROCESSING_INSTRUCTION_NODE;
 		/**
 		 * A string representing the textual data contained in this object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -350,7 +350,7 @@ declare module '@xmldom/xmldom' {
 	 * cannot have children will throw an exception.
 	 *
 	 * **This behavior is slightly different from the in the specs**:
-	 * - undeclared properties: nodeType, baseURI, isConnected, parentElement, textContent
+	 * - undeclared properties: baseURI, isConnected, parentElement
 	 * - missing methods: contains, getRootNode, isEqualNode, isSameNode
 	 *
 	 * @see http://www.w3.org/TR/2000/REC-DOM-Level-2-Core-20001113/core.html#ID-1950641247
@@ -396,6 +396,12 @@ declare module '@xmldom/xmldom' {
 		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/nodeName)
 		 */
 		readonly nodeName: string;
+		/**
+		 * Returns the type of node.
+		 *
+		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/nodeType)
+		 */
+		readonly nodeType: number;
 		/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/nodeValue) */
 		nodeValue: string | null;
 		/**
@@ -420,6 +426,19 @@ declare module '@xmldom/xmldom' {
 		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/previousSibling)
 		 */
 		readonly previousSibling: Node | null;
+		/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
+		textContent: string | null;
+
+		/**
+		 * Zero based line position inside the parsed source,
+		 * if the `locator` was not disabled.
+		 */
+		lineNumber?: number;
+		/**
+		 * One based column position inside the parsed source,
+		 * if the `locator` was not disabled.
+		 */
+		columnNumber?: number;
 
 		/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/appendChild) */
 		appendChild(node: Node): Node;
@@ -1061,6 +1080,13 @@ declare module '@xmldom/xmldom' {
 
 	interface ProcessingInstruction extends Node {
 		nodeType: typeof Node.PROCESSING_INSTRUCTION_NODE;
+		/**
+		 * Everything that goes after the target, excluding `?>`.
+		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CharacterData/data)
+		 */
+		data: string;
+		/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/target) */
+		readonly target: string;
 	}
 	var ProcessingInstruction: InstanceOf<ProcessingInstruction>;
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -979,7 +979,7 @@ DOMImplementation.prototype = {
  * cannot have children will throw an exception.
  *
  * **This behavior is slightly different from the in the specs**:
- * - undeclared properties: nodeType, baseURI, isConnected, parentElement, textContent
+ * - undeclared properties: baseURI, isConnected, parentElement
  * - missing methods: contains, getRootNode, isEqualNode, isSameNode
  *
  * @class

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1587,12 +1587,13 @@ function hasValidParentNodeType(node) {
 function hasInsertableNodeType(node) {
 	return (
 		node &&
-		(isElementNode(node) ||
-			node instanceof CharacterData ||
-			isDocTypeNode(node) ||
-			node.nodeType === Node.DOCUMENT_FRAGMENT_NODE ||
+		(node.nodeType === Node.CDATA_SECTION_NODE ||
 			node.nodeType === Node.COMMENT_NODE ||
-			node.nodeType === Node.PROCESSING_INSTRUCTION_NODE)
+			node.nodeType === Node.DOCUMENT_FRAGMENT_NODE ||
+			node.nodeType === Node.DOCUMENT_TYPE_NODE ||
+			node.nodeType === Node.ELEMENT_NODE ||
+			node.nodeType === Node.PROCESSING_INSTRUCTION_NODE ||
+			node.nodeType === Node.TEXT_NODE)
 	);
 }
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2481,7 +2481,7 @@ function ProcessingInstruction(symbol) {
 	checkSymbol(symbol);
 }
 ProcessingInstruction.prototype.nodeType = PROCESSING_INSTRUCTION_NODE;
-_extends(ProcessingInstruction, Node);
+_extends(ProcessingInstruction, CharacterData);
 function XMLSerializer() {}
 XMLSerializer.prototype.serializeToString = function (node, nodeFilter) {
 	return nodeSerializeToString.call(node, nodeFilter);


### PR DESCRIPTION
- `Node.nodeType`
- `Node.textContent`
- `Node.columnNumber`
- `Node.lineNumber`
- `ProcessingInstruction.data` (inherited from `CharacterData`)
- `ProcessingInstruction.target`

fixes #725