### PR TITLE
fix: `getElements*` methods return `LiveNodeList<Element>`

### DIFF
--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -98,6 +98,11 @@ assert(doc1.childNodes instanceof NodeList, true);
 assert(doc1.documentElement instanceof Element, true);
 assert(doc1.documentElement?.tagName, 'qualifiedName');
 assert(doc1.getElementsByClassName('hide') instanceof LiveNodeList, true);
+Array.from(doc1.getElementsByTagName('img')).find(
+	// just a type check, since the document doesn't return any img elements,
+	// so this method will never be executed
+	(element) => assert(element instanceof Element, true)
+);
 
 const attr = doc1.createAttribute('attr');
 assert(attr.nodeType, Node.ATTRIBUTE_NODE);

--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -99,8 +99,8 @@ assert(doc1.documentElement instanceof Element, true);
 assert(doc1.documentElement?.tagName, 'qualifiedName');
 assert(doc1.getElementsByClassName('hide') instanceof LiveNodeList, true);
 Array.from(doc1.getElementsByTagName('img')).find(
-	// just a type check, since the document doesn't return any img elements,
-	// so this method will never be executed
+	// just a type check, since the document doesn't contain any img elements,
+	// this method will never be executed, but typescript checks need to pass
 	(element) => assert(element instanceof Element, true)
 );
 

--- a/examples/typescript-node-es6/tsconfig.json
+++ b/examples/typescript-node-es6/tsconfig.json
@@ -11,9 +11,9 @@
 		// "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
 		/* Language and Environment */
-		"target": "es5" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		"target": "es6" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
 		"lib": [
-			"ES5"
+			"ES6"
 		] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
 		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
 		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */

--- a/index.d.ts
+++ b/index.d.ts
@@ -637,23 +637,12 @@ declare module '@xmldom/xmldom' {
 		 * Get an attribute by name. Note: Name is in lower case in case of HTML namespace and
 		 * document.
 		 *
-		 * @param {string} localName
-		 * The local name of the attribute.
-		 * @returns {Attr | null}
-		 * The attribute with the given local name, or null if no such attribute exists.
 		 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
 		 */
 		getNamedItem(qualifiedName: string): Attr | null;
 		/**
 		 * Get an attribute by namespace and local name.
 		 *
-		 * @param {string | null} namespaceURI
-		 * The namespace URI of the attribute.
-		 * @param {string} localName
-		 * The local name of the attribute.
-		 * @returns {Attr | null}
-		 * The attribute with the given namespace URI and local name, or null if no such attribute
-		 * exists.
 		 * @see https://dom.spec.whatwg.org/#concept-element-attributes-get-by-namespace
 		 */
 		getNamedItemNS(namespace: string | null, localName: string): Attr | null;
@@ -663,10 +652,6 @@ declare module '@xmldom/xmldom' {
 		/**
 		 * Removes an attribute specified by the local name.
 		 *
-		 * @param {string} localName
-		 * The local name of the attribute to be removed.
-		 * @returns {Attr}
-		 * The attribute node that was removed.
 		 * @throws {DOMException}
 		 * With code:
 		 * - {@link DOMException.NOT_FOUND_ERR} if no attribute with the given name is found.
@@ -677,12 +662,6 @@ declare module '@xmldom/xmldom' {
 		/**
 		 * Removes an attribute specified by the namespace and local name.
 		 *
-		 * @param {string | null} namespaceURI
-		 * The namespace URI of the attribute to be removed.
-		 * @param {string} localName
-		 * The local name of the attribute to be removed.
-		 * @returns {Attr}
-		 * The attribute node that was removed.
 		 * @throws {DOMException}
 		 * With code:
 		 * - {@link DOMException.NOT_FOUND_ERR} if no attribute with the given namespace URI and
@@ -694,11 +673,6 @@ declare module '@xmldom/xmldom' {
 		/**
 		 * Set an attribute.
 		 *
-		 * @param {Attr} attr
-		 * The attribute to set.
-		 * @returns {Attr | null}
-		 * The old attribute with the same local name and namespace URI as the new one, or null if no
-		 * such attribute exists.
 		 * @throws {DOMException}
 		 * With code:
 		 * - {@link INUSE_ATTRIBUTE_ERR} - If the attribute is already an attribute of another
@@ -710,11 +684,6 @@ declare module '@xmldom/xmldom' {
 		 * Set an attribute, replacing an existing attribute with the same local name and namespace
 		 * URI if one exists.
 		 *
-		 * @param {Attr} attr
-		 * The attribute to set.
-		 * @returns {Attr | null}
-		 * The old attribute with the same local name and namespace URI as the new one, or null if no
-		 * such attribute exists.
 		 * @throws {DOMException}
 		 * Throws a DOMException with the name "InUseAttributeError" if the attribute is already an
 		 * attribute of another element.
@@ -731,7 +700,7 @@ declare module '@xmldom/xmldom' {
 	 *
 	 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/NodeList)
 	 */
-	class NodeList implements Iterable<Node> {
+	class NodeList<T extends Node = Node> implements Iterable<T> {
 		/**
 		 * Returns the number of nodes in the collection.
 		 *
@@ -743,34 +712,40 @@ declare module '@xmldom/xmldom' {
 		 *
 		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/NodeList/item)
 		 */
-		item(index: number): Node | null;
+		item(index: number): T | null;
 		/**
 		 * Returns a string representation of the NodeList.
 		 */
-		toString(nodeFilter: (node: Node) => Node | undefined): string;
+		toString(nodeFilter: (node: T) => T | undefined): string;
 		/**
 		 * Filters the NodeList based on a predicate.
 		 *
 		 * @private
 		 */
-		filter(predicate: (node: Node) => boolean): Node[];
+		filter(predicate: (node: T) => boolean): T[];
 		/**
 		 * Returns the first index at which a given node can be found in the NodeList, or -1 if it is
 		 * not present.
 		 *
 		 * @private
 		 */
-		indexOf(node: Node): number;
-		[index: number]: Node | undefined;
+		indexOf(node: T): number;
 
-		[Symbol.iterator](): Iterator<Node>;
+		/**
+		 * Index based access returns `undefined`, when accessing indexes >= `length`.
+		 * But it would break a lot of code (like `Array.from` usages),
+		 * if it would be typed as `T | undefined`.
+		 */
+		[index: number]: T;
+
+		[Symbol.iterator](): Iterator<T>;
 	}
 
 	/**
 	 * Represents a live collection of nodes that is automatically updated when its associated
 	 * document changes.
 	 */
-	interface LiveNodeList extends NodeList {}
+	interface LiveNodeList<T extends Node = Node> extends NodeList<T> {}
 	/**
 	 * Represents a live collection of nodes that is automatically updated when its associated
 	 * document changes.
@@ -838,7 +813,7 @@ declare module '@xmldom/xmldom' {
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByClassName
 		 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 		 */
-		getElementsByClassName(classNames: string): LiveNodeList;
+		getElementsByClassName(classNames: string): LiveNodeList<Element>;
 
 		/**
 		 * Returns a LiveNodeList of elements with the given qualifiedName.
@@ -862,7 +837,7 @@ declare module '@xmldom/xmldom' {
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByTagName
 		 * @see https://dom.spec.whatwg.org/#concept-getelementsbytagname
 		 */
-		getElementsByTagName(qualifiedName: string): LiveNodeList;
+		getElementsByTagName(qualifiedName: string): LiveNodeList<Element>;
 
 		/**
 		 * Returns a `LiveNodeList` of elements with the given tag name belonging to the given
@@ -874,7 +849,7 @@ declare module '@xmldom/xmldom' {
 		getElementsByTagNameNS(
 			namespaceURI: string | null,
 			localName: string
-		): LiveNodeList;
+		): LiveNodeList<Element>;
 
 		getQualifiedName(): string;
 		/**
@@ -1107,7 +1082,6 @@ declare module '@xmldom/xmldom' {
 		/**
 		 * The implementation that created this document.
 		 *
-		 * @type DOMImplementation
 		 * @readonly
 		 */
 		readonly implementation: DOMImplementation;
@@ -1125,9 +1099,6 @@ declare module '@xmldom/xmldom' {
 		/**
 		 * Creates an attribute object with a specified name.
 		 *
-		 * @param name
-		 * String that sets the attribute object's name.
-		 *
 		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/createAttribute)
 		 */
 		createAttribute(localName: string): Attr;
@@ -1144,9 +1115,6 @@ declare module '@xmldom/xmldom' {
 
 		/**
 		 * Creates a comment object with the specified data.
-		 *
-		 * @param data
-		 * Sets the comment object's data.
 		 *
 		 * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/createComment)
 		 */
@@ -1208,9 +1176,6 @@ declare module '@xmldom/xmldom' {
 
 		/**
 		 * Returns a reference to the first object with the specified value of the ID attribute.
-		 *
-		 * @param elementId
-		 * String that specifies the ID value.
 		 */
 		getElementById(elementId: string): Element | null;
 
@@ -1229,7 +1194,7 @@ declare module '@xmldom/xmldom' {
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByClassName
 		 * @see https://dom.spec.whatwg.org/#concept-getelementsbyclassname
 		 */
-		getElementsByClassName(classNames: string): LiveNodeList;
+		getElementsByClassName(classNames: string): LiveNodeList<Element>;
 
 		/**
 		 * Returns a LiveNodeList of elements with the given qualifiedName.
@@ -1253,7 +1218,7 @@ declare module '@xmldom/xmldom' {
 		 * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/getElementsByTagName
 		 * @see https://dom.spec.whatwg.org/#concept-getelementsbytagname
 		 */
-		getElementsByTagName(qualifiedName: string): LiveNodeList;
+		getElementsByTagName(qualifiedName: string): LiveNodeList<Element>;
 
 		/**
 		 * Returns a `LiveNodeList` of elements with the given tag name belonging to the given
@@ -1268,7 +1233,7 @@ declare module '@xmldom/xmldom' {
 		getElementsByTagNameNS(
 			namespaceURI: string | null,
 			localName: string
-		): LiveNodeList;
+		): LiveNodeList<Element>;
 		/**
 		 * Returns a copy of node. If deep is true, the copy also includes the node's descendants.
 		 *


### PR DESCRIPTION
- NodeList and LiveNodeList are now generic, with a default of `Node` when no type argument is passed.
- `Node.getElements*` and `Document.getElements*` return `LiveNodeList<Element>`
- `NodeList[number]` is now typed as `T` instead of `T | undefined`, which of course only works for indexes < `length`

Fixes #731