### PR TITLE
fix(types): correct error handler level to `warning`

### DIFF
--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -164,6 +164,16 @@ const doc = new DOMParser({
 	onError: onWarningStopParsing,
 }).parseFromString(source, MIME_TYPE.XML_TEXT);
 assert(new XMLSerializer().serializeToString(doc), source);
+new DOMParser({
+	onError: (level, msg) => {
+		switch (level) {
+			case 'error':
+			case 'fatalError':
+			case 'warning':
+				assert(typeof msg, 'string');
+		}
+	},
+});
 
 if (failedAssertions.length > 0) {
 	failedAssertions.forEach((error) => console.error(error));

--- a/index.d.ts
+++ b/index.d.ts
@@ -1565,7 +1565,11 @@ declare module '@xmldom/xmldom' {
 	}
 
 	interface ErrorHandlerFunction {
-		(level: 'warn' | 'error' | 'fatalError', msg: string, context: any): void;
+		(
+			level: 'warning' | 'error' | 'fatalError',
+			msg: string,
+			context: any
+		): void;
 	}
 
 	/**

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -2,7 +2,7 @@
 const { DOMParser } = require('../lib/dom-parser');
 
 /**
- * {'warn' | 'error' | 'fatalError'}
+ * {'warning' | 'error' | 'fatalError'}
  *
  * @typedef ErrorLevel
  */


### PR DESCRIPTION
fixes #754