### PR TITLE
fix: restore performance for large amount of child nodes

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2054,7 +2054,7 @@ function _insertBefore(parent, node, child, _inDocumentAssertion) {
 	do {
 		newFirst.parentNode = parent;
 	} while (newFirst !== newLast && (newFirst = newFirst.nextSibling));
-	_onUpdateChild(parent.ownerDocument || parent, parent);
+	_onUpdateChild(parent.ownerDocument || parent, parent, node);
 	if (node.nodeType == DOCUMENT_FRAGMENT_NODE) {
 		node.firstChild = node.lastChild = null;
 	}

--- a/test/dom/node.test.js
+++ b/test/dom/node.test.js
@@ -6,6 +6,7 @@ const { DOMParser } = require('../../lib/dom-parser');
 const { DOMExceptionName } = require('../../lib/errors');
 const { expectDOMException } = require('../errors/expectDOMException');
 const { MIME_TYPE } = require('../../lib/conventions');
+const { performance } = require('perf_hooks');
 
 describe('Node.prototype', () => {
 	describe('constructor', () => {

--- a/test/dom/node.test.js
+++ b/test/dom/node.test.js
@@ -2,8 +2,10 @@
 
 const { describe, test, expect } = require('@jest/globals');
 const { DOMImplementation, Node } = require('../../lib/dom');
+const { DOMParser } = require('../../lib/dom-parser');
 const { DOMExceptionName } = require('../../lib/errors');
 const { expectDOMException } = require('../errors/expectDOMException');
+const { MIME_TYPE } = require('../../lib/conventions');
 
 describe('Node.prototype', () => {
 	describe('constructor', () => {
@@ -27,6 +29,17 @@ describe('Node.prototype', () => {
 					`Unexpected parent node type ${node.nodeType}`
 				);
 			});
+		});
+		const MANY = 10 * 1000;
+		const huge = `<xml>${[...Array(MANY).keys()].map((i) => `<node index="${i}"/>`).join('\n\t')}</xml>`;
+		test(`should be able to parse and append ${MANY / 1000}k nodes with a good performance`, () => {
+			const start = performance.now();
+			new DOMParser().parseFromString(huge, MIME_TYPE.XML_TEXT);
+			const duration = performance.now() - start;
+			// with the issue the test was introduced for,
+			// it took minutes for such an amount of nodes to be appended
+			// it usually takes < 1sec on my machine, but let's make sure the test is not flaky anywhere
+			expect(duration).toBeLessThanOrEqual(1500);
 		});
 	});
 	describe('isConnected', () => {


### PR DESCRIPTION
as part of https://github.com/xmldom/xmldom/pull/550 ("drop redundant and broken `Element.appendChild` implementation") 
the `_onUpdateChild` was not passed the added child, so the `childNodes` were "re-indexed" from the `firstChild` each time a node was appended. 
This is why the performance degraded significantly, when there are a lot of childNodes to be appended.

fixes https://github.com/xmldom/xmldom/issues/748