### PR TITLE
fix: locator is now true even when other options are being used for the DOMParser

### DIFF
--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -101,7 +101,10 @@ function normalizeLineEndings(input) {
  * @see https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
  */
 function DOMParser(options) {
-	options = options || { locator: true };
+	options = options || {};
+	if (typeof options.locator === 'undefined') {
+		options.locator = true;
+	}
 
 	/**
 	 * The method to use instead of `conventions.assign`, which is used to copy values from

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -102,7 +102,7 @@ function normalizeLineEndings(input) {
  */
 function DOMParser(options) {
 	options = options || {};
-	if (typeof options.locator === 'undefined') {
+	if (options.locator === undefined) {
 		options.locator = true;
 	}
 

--- a/test/dom-parser.test.js
+++ b/test/dom-parser.test.js
@@ -34,8 +34,22 @@ describe('DOMParser', () => {
 			};
 			expect(doc.documentElement).toMatchObject(expected);
 		});
-		test("should not use locator when it's not set in options", () => {
+		test("should use locator when it's not explicitly set to false in options", () => {
 			const options = {};
+			const it = new DOMParser(options);
+
+			const doc = it.parseFromString('<xml/>', MIME_TYPE.XML_TEXT);
+
+			const expected = {
+				columnNumber: 1,
+				lineNumber: 1,
+			};
+			expect(doc.documentElement).toMatchObject(expected);
+		});
+		test("should not use locator when it's set to false in options", () => {
+			const options = {
+				locator: false,
+			};
 			const it = new DOMParser(options);
 
 			const doc = it.parseFromString('<xml/>', MIME_TYPE.XML_TEXT);


### PR DESCRIPTION
Fixed locator not being true by default when using any other options.
Closes #802 