### PR TITLE
fix: replace \u2029 as part of normalizeLineEndings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1527,12 +1527,15 @@ declare module '@xmldom/xmldom' {
 		readonly locator?: boolean;
 
 		/**
-		 * used to replace line endings before parsing, defaults to `normalizeLineEndings`,
-		 * which normalizes line endings according to <https://www.w3.org/TR/xml11/#sec-line-ends>.
+		 * used to replace line endings before parsing, defaults to exported `normalizeLineEndings`,
+		 * which normalizes line endings according to <https://www.w3.org/TR/xml11/#sec-line-ends>,
+		 * including some Unicode "newline" characters.
+		 *
+		 * @see {@link normalizeLineEndings}
 		 */
 		readonly normalizeLineEndings?: (source: string) => string;
 		/**
-		 * A function that is invoked for every error that occurs during parsing.
+		 * A function invoked for every error that occurs during parsing.
 		 *
 		 * If it is not provided, all errors are reported to `console.error`
 		 * and only `fatalError`s are thrown as a `ParseError`,
@@ -1572,6 +1575,29 @@ declare module '@xmldom/xmldom' {
 		): void;
 	}
 
+	/**
+	 * Normalizes line ending according to <https://www.w3.org/TR/xml11/#sec-line-ends>,
+	 * including some Unicode "newline" characters:
+	 *
+	 * > XML parsed entities are often stored in computer files which,
+	 * > for editing convenience, are organized into lines.
+	 * > These lines are typically separated by some combination
+	 * > of the characters CARRIAGE RETURN (#xD) and LINE FEED (#xA).
+	 * >
+	 * > To simplify the tasks of applications, the XML processor must behave
+	 * > as if it normalized all line breaks in external parsed entities (including the document entity)
+	 * > on input, before parsing, by translating the following to a single #xA character:
+	 * >
+	 * > 1. the two-character sequence #xD #xA,
+	 * > 2. the two-character sequence #xD #x85,
+	 * > 3. the single character #x85,
+	 * > 4. the single character #x2028,
+	 * > 5. the single character #x2029,
+	 * > 6. any #xD character that is not immediately followed by #xA or #x85.
+	 *
+	 * @prettierignore
+	 */
+	function normalizeLineEndings(input: string): string;
 	/**
 	 * A method that prevents any further parsing when an `error`
 	 * with level `error` is reported during parsing.

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -40,7 +40,7 @@ var XMLReader = sax.XMLReader;
  * @prettierignore
  */
 function normalizeLineEndings(input) {
-	return input.replace(/\r[\n\u0085]/g, '\n').replace(/[\r\u0085\u2028]/g, '\n');
+	return input.replace(/\r[\n\u0085]/g, '\n').replace(/[\r\u0085\u2028\u2029]/g, '\n');
 }
 
 /**

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -18,7 +18,8 @@ var ParseError = errors.ParseError;
 var XMLReader = sax.XMLReader;
 
 /**
- * Normalizes line ending according to <https://www.w3.org/TR/xml11/#sec-line-ends>:
+ * Normalizes line ending according to <https://www.w3.org/TR/xml11/#sec-line-ends>,
+ * including some Unicode "newline" characters:
  *
  * > XML parsed entities are often stored in computer files which,
  * > for editing convenience, are organized into lines.
@@ -27,7 +28,7 @@ var XMLReader = sax.XMLReader;
  * >
  * > To simplify the tasks of applications, the XML processor must behave
  * > as if it normalized all line breaks in external parsed entities (including the document entity)
- * > on input, before parsing, by translating all of the following to a single #xA character:
+ * > on input, before parsing, by translating the following to a single #xA character:
  * >
  * > 1. the two-character sequence #xD #xA,
  * > 2. the two-character sequence #xD #x85,
@@ -64,7 +65,7 @@ function normalizeLineEndings(input) {
  * DEPRECATED! use `onError` instead.
  * @property {function(level:ErrorLevel, message:string, context: DOMHandler):void}
  * [onError]
- * A function that is invoked for every error that occurs during parsing.
+ * A function invoked for every error that occurs during parsing.
  *
  * If it is not provided, all errors are reported to `console.error`
  * and only `fatalError`s are thrown as a `ParseError`,
@@ -79,7 +80,9 @@ function normalizeLineEndings(input) {
  * attribute describing their location in the XML string.
  * Default is true.
  * @property {(string) => string} [normalizeLineEndings]
- * used to replace line endings before parsing, defaults to `normalizeLineEndings`
+ * used to replace line endings before parsing, defaults to exported `normalizeLineEndings`,
+ * which normalizes line endings according to <https://www.w3.org/TR/xml11/#sec-line-ends>,
+ * including some Unicode "newline" characters.
  * @property {Object} [xmlns]
  * The XML namespaces that should be assumed when parsing.
  * The default namespace can be provided by the key that is the empty string.

--- a/lib/dom-parser.js
+++ b/lib/dom-parser.js
@@ -33,7 +33,8 @@ var XMLReader = sax.XMLReader;
  * > 2. the two-character sequence #xD #x85,
  * > 3. the single character #x85,
  * > 4. the single character #x2028,
- * > 5. any #xD character that is not immediately followed by #xA or #x85.
+ * > 5. the single character #x2029,
+ * > 6. any #xD character that is not immediately followed by #xA or #x85.
  *
  * @param {string} input
  * @returns {string}

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,5 +36,6 @@ exports.XMLSerializer = dom.XMLSerializer;
 
 var domParser = require('./dom-parser');
 exports.DOMParser = domParser.DOMParser;
+exports.normalizeLineEndings = domParser.normalizeLineEndings;
 exports.onErrorStopParsing = domParser.onErrorStopParsing;
 exports.onWarningStopParsing = domParser.onWarningStopParsing;

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -109,7 +109,7 @@ function parse(source, defaultNSMapCopy, entityMap, domBuilder, errorHandler) {
 
 	var lineStart = 0;
 	var lineEnd = 0;
-	var linePattern = /.*(?:\r\n?|\n)|.*$/g;
+	var linePattern = /.*(?:\r\n?|[\n\u2028\u2029])|.*$/g;
 	var locator = domBuilder.locator;
 
 	var parseStack = [{ currentNSMap: defaultNSMapCopy }];

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -109,7 +109,7 @@ function parse(source, defaultNSMapCopy, entityMap, domBuilder, errorHandler) {
 
 	var lineStart = 0;
 	var lineEnd = 0;
-	var linePattern = /.*(?:\r\n?|[\n\u2028\u2029])|.*$/g;
+	var linePattern = /.*(?:\r\n?|\n)|.*$/g;
 	var locator = domBuilder.locator;
 
 	var parseStack = [{ currentNSMap: defaultNSMapCopy }];

--- a/test/dom-parser.test.js
+++ b/test/dom-parser.test.js
@@ -327,7 +327,7 @@ describe('DOMParser', () => {
 			// issue: https://github.com/xmldom/xmldom/issues/838
 			const onError = jest.fn();
 			const { parser } = getTestParser({ onError });
-			const source = `<root>${"A".repeat(50_000)}\u2029${"A".repeat(50_000)}\u0085${"A".repeat(50_000)}\u2028${"A".repeat(50_000)}\u2029</root>`;
+			const source = `<root>${'A'.repeat(50000)}\u2029${'A'.repeat(50000)}\u0085${'A'.repeat(50000)}\u2028${'A'.repeat(50000)}\u2029</root>`;
 			const doc = parser.parseFromString(source, MIME_TYPE.XML_TEXT);
 			expect(new XMLSerializer().serializeToString(doc)).toEqual(source.replace(/[\u0085\u2028\u2029]/g, '\n'));
 		}, 500);

--- a/test/dom-parser.test.js
+++ b/test/dom-parser.test.js
@@ -323,6 +323,14 @@ describe('DOMParser', () => {
 			const doc = parser.parseFromString(source, MIME_TYPE.XML_TEXT);
 			expect(new XMLSerializer().serializeToString(doc)).toEqual(source);
 		});
+		test('should be able to open documents with alternative whitespace without creating a bottleneck and replacing them with \\n', () => {
+			// issue: https://github.com/xmldom/xmldom/issues/838
+			const onError = jest.fn();
+			const { parser } = getTestParser({ onError });
+			const source = `<root>${"A".repeat(50_000)}\u2029${"A".repeat(50_000)}\u0085${"A".repeat(50_000)}\u2028${"A".repeat(50_000)}\u2029</root>`;
+			const doc = parser.parseFromString(source, MIME_TYPE.XML_TEXT);
+			expect(new XMLSerializer().serializeToString(doc)).toEqual(source.replace(/[\u0085\u2028\u2029]/g, '\n'));
+		}, 500);
 	});
 });
 

--- a/test/parse/normalize-line-endings.test.js
+++ b/test/parse/normalize-line-endings.test.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const { describe, expect, test } = require('@jest/globals');
 const { DOMParser, normalizeLineEndings } = require('../../lib/dom-parser');
 const { MIME_TYPE } = require('../../lib/conventions');
+
 const whitespaceToHex = (str) => str.replace(/\s/g, (c) => `#x${c.charCodeAt(0).toString(16)}`);
 
 describe('DOMParser constructor option normalizeLineEndings', () => {
@@ -39,6 +41,10 @@ describe('normalizeLineEndings', () => {
 
 	test('should normalize the single character #x2028', () => {
 		expect(whitespaceToHex(normalizeLineEndings('\u2028'))).toBe('#xa');
+	});
+
+	test('should normalize the single character #x2029', () => {
+		expect(whitespaceToHex(normalizeLineEndings('\u2029'))).toBe('#xa');
 	});
 
 	test('should normalize any #xD character that is not immediately followed by #xA or #x85', () => {

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { describe, expect, test } = require('@jest/globals');
 const { getTestParser } = require('../get-test-parser');
 const { DOMParser } = require('../../lib');
 const { MIME_TYPE } = require('../../lib/conventions');


### PR DESCRIPTION
Fixes #838, when the default `normalizeLineEndings` implementation is being used