### PR TITLE
chore: drop jazzer and rxjs devDependencies

### DIFF
--- a/fuzz/__snapshots__/regression.test.js.snap
+++ b/fuzz/__snapshots__/regression.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`dom-parser.html.target.js crash-doctype-in-element.xml 1`] = `-1`;
+
+exports[`dom-parser.html.target.js crash-proto-prefix.xml 1`] = `-1`;
+
+exports[`dom-parser.xml.target.js crash-doctype-in-element.xml 1`] = `-1`;
+
+exports[`dom-parser.xml.target.js crash-proto-prefix.xml 1`] = `-1`;

--- a/fuzz/regression.test.js
+++ b/fuzz/regression.test.js
@@ -10,14 +10,18 @@ const TARGETS = fs
 	.map((target) => [target, path.join(__dirname, target)]);
 
 TARGETS.forEach(([target, targetPath]) => {
-	describe('', () => {
+	describe(target, () => {
+		const regressionDir = path.join(__filename.replace(/\.js$/, ''), target);
+		const testfiles = fs.readdirSync(regressionDir);
+		const module = require(targetPath);
 		beforeAll(() => {
-			const regressionDir = path.join(__filename.replace(/\.js$/, ''), target);
 			expect(fs.existsSync(regressionDir)).toBe(true);
-			const testfiles = fs.readdirSync(regressionDir);
 			expect(testfiles.length).toBeGreaterThan(0);
 		});
-		const module = require(targetPath);
-		test.fuzz(target, (data) => module.fuzz(data));
+		testfiles.forEach((testfile) => {
+			test(path.basename(testfile), () => {
+				expect(module.fuzz(fs.readFileSync(path.join(regressionDir, testfile)))).toMatchSnapshot();
+			});
+		});
 	});
 });

--- a/jest.fuzz.config.js
+++ b/jest.fuzz.config.js
@@ -150,7 +150,7 @@ module.exports = {
 	// testResultsProcessor: undefined,
 
 	// This option allows use of a custom test runner
-	testRunner: '@jazzer.js/jest-runner',
+	// testRunner: '@jazzer.js/jest-runner',
 
 	// This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
 	// testURL: "http://localhost",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@homer0/prettier-plugin-jsdoc": "9.1.0",
-				"@jazzer.js/core": "2.1.0",
-				"@jazzer.js/jest-runner": "2.1.0",
 				"auto-changelog": "2.5.0",
 				"eslint": "8.57.1",
 				"eslint-config-prettier": "10.0.1",
@@ -24,7 +22,6 @@
 				"nodemon": "3.1.9",
 				"np": "8.0.4",
 				"prettier": "3.5.1",
-				"rxjs": "7.8.1",
 				"xmltest": "2.0.3",
 				"yauzl": "3.2.0"
 			},
@@ -824,135 +821,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@jazzer.js/bug-detectors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/bug-detectors/-/bug-detectors-2.1.0.tgz",
-			"integrity": "sha512-rFERKoSkLNZq52rRCXQKRqLX9Bfkb2+tzMrI/tDQ27//HwfdaJUej4MPKXg3YxFSGAEtshNNSXAn2liJmyLWpQ==",
-			"dev": true,
-			"dependencies": {
-				"@jazzer.js/core": "2.1.0",
-				"@jazzer.js/hooking": "2.1.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0",
-				"npm": ">= 7.0.0"
-			}
-		},
-		"node_modules/@jazzer.js/core": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/core/-/core-2.1.0.tgz",
-			"integrity": "sha512-9uTuKlZ0WyC8evq++46TYg0SFszGx7X4/Y8nVsFmIg9sc0ceO9fmE1qg8KOafkzM9DvSdv+JL2UYWxnmgE1CJQ==",
-			"dev": true,
-			"dependencies": {
-				"@jazzer.js/bug-detectors": "2.1.0",
-				"@jazzer.js/fuzzer": "2.1.0",
-				"@jazzer.js/hooking": "2.1.0",
-				"@jazzer.js/instrumentor": "2.1.0",
-				"istanbul-lib-coverage": "^3.2.0",
-				"istanbul-lib-report": "^3.0.1",
-				"istanbul-reports": "^3.1.6",
-				"tmp": "^0.2.1",
-				"yargs": "^17.7.2"
-			},
-			"bin": {
-				"jazzer": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">= 14.0.0",
-				"npm": ">= 7.0.0"
-			}
-		},
-		"node_modules/@jazzer.js/core/node_modules/tmp": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-			"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-			"dev": true,
-			"dependencies": {
-				"rimraf": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8.17.0"
-			}
-		},
-		"node_modules/@jazzer.js/fuzzer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/fuzzer/-/fuzzer-2.1.0.tgz",
-			"integrity": "sha512-WroUAGH1+AFoI+5kRGOjvh9+1GsYEmCinvEt9yF0E0pBTeadssCG6Y8adeYh6W0rum2LjPsjVfLEWMunRLt/Ew==",
-			"dev": true,
-			"hasInstallScript": true,
-			"dependencies": {
-				"bindings": "^1.5.0",
-				"cmake-js": "^7.2.1",
-				"node-addon-api": "^7.0.0",
-				"prebuild-install": "^7.1.1"
-			},
-			"engines": {
-				"node": ">= 14.0.0",
-				"npm": ">= 7.0.0"
-			}
-		},
-		"node_modules/@jazzer.js/hooking": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/hooking/-/hooking-2.1.0.tgz",
-			"integrity": "sha512-caNQslD27mxkYfi7woVEN98rbPL41Ezn/pGkMB/ghcBWcG0jCJDqacRJX4Gv8ypfIhemDJEocL26Ld2XSx07Pw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.23.2"
-			},
-			"engines": {
-				"node": ">= 14.0.0",
-				"npm": ">= 7.0.0"
-			}
-		},
-		"node_modules/@jazzer.js/instrumentor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/instrumentor/-/instrumentor-2.1.0.tgz",
-			"integrity": "sha512-ewvx2DKczcwusO5XlRYaMO757cFDKY+mEbS2g5k81Razq3AA/uRVU1/Ei/1FZeg9tKCuaTq9Gwl+9bdA9ER8Og==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.23.2",
-				"@babel/generator": "^7.23.0",
-				"@jazzer.js/fuzzer": "2.1.0",
-				"@jazzer.js/hooking": "2.1.0",
-				"istanbul-lib-hook": "^3.0.0",
-				"istanbul-lib-instrument": "^6.0.1",
-				"proper-lockfile": "^4.1.2",
-				"source-map-support": "^0.5.21"
-			},
-			"engines": {
-				"node": ">= 14.0.0",
-				"npm": ">= 7.0.0"
-			}
-		},
-		"node_modules/@jazzer.js/instrumentor/node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dev": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/@jazzer.js/jest-runner": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/jest-runner/-/jest-runner-2.1.0.tgz",
-			"integrity": "sha512-DbBP0YjBuzc/wYpVe3w+lEdR7qb6aXbIMYytBdPU0cWa1n/U3s/st/Adcz+yATEYP/UOlf06gR4qZfPmRZcTwA==",
-			"dev": true,
-			"dependencies": {
-				"@jazzer.js/core": "2.1.0",
-				"cosmiconfig": "^8.3.6",
-				"istanbul-reports": "^3.1.6"
-			},
-			"engines": {
-				"node": ">= 14.0.0",
-				"npm": ">= 7.0.0"
-			},
-			"peerDependencies": {
-				"@types/jest": "29.*",
-				"jest": "29.*"
-			}
-		},
 		"node_modules/@jest/console": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
@@ -1558,17 +1426,6 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
-		"node_modules/@types/jest": {
-			"version": "29.5.6",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.6.tgz",
-			"integrity": "sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"expect": "^29.0.0",
-				"pretty-format": "^29.0.0"
-			}
-		},
 		"node_modules/@types/keyv": {
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -2057,37 +1914,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/append-transform": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-			"integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-			"dev": true,
-			"dependencies": {
-				"default-require-extensions": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/aproba": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-			"dev": true
-		},
-		"node_modules/are-we-there-yet": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-			"dev": true,
-			"dependencies": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^3.6.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
 		"node_modules/argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2105,12 +1931,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"dev": true
 		},
 		"node_modules/auto-changelog": {
 			"version": "2.5.0",
@@ -2151,17 +1971,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/axios": {
-			"version": "1.7.5",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
-			"integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
-			"dev": true,
-			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -2313,15 +2122,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"dependencies": {
-				"file-uri-to-path": "1.0.0"
 			}
 		},
 		"node_modules/bl": {
@@ -2799,15 +2599,6 @@
 				"fsevents": "~2.3.2"
 			}
 		},
-		"node_modules/chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/ci-info": {
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
@@ -2996,48 +2787,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/cmake-js": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-7.2.1.tgz",
-			"integrity": "sha512-AdPSz9cSIJWdKvm0aJgVu3X8i0U3mNTswJkSHzZISqmYVjZk7Td4oDFg0mCBA383wO+9pG5Ix7pEP1CZH9x2BA==",
-			"dev": true,
-			"dependencies": {
-				"axios": "^1.3.2",
-				"debug": "^4",
-				"fs-extra": "^10.1.0",
-				"lodash.isplainobject": "^4.0.6",
-				"memory-stream": "^1.0.0",
-				"node-api-headers": "^0.0.2",
-				"npmlog": "^6.0.2",
-				"rc": "^1.2.7",
-				"semver": "^7.3.8",
-				"tar": "^6.1.11",
-				"url-join": "^4.0.1",
-				"which": "^2.0.2",
-				"yargs": "^17.6.0"
-			},
-			"bin": {
-				"cmake-js": "bin/cmake-js"
-			},
-			"engines": {
-				"node": ">= 14.15.0"
-			}
-		},
-		"node_modules/cmake-js/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3077,27 +2826,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
-		},
-		"node_modules/color-support": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-			"dev": true,
-			"bin": {
-				"color-support": "bin.js"
-			}
-		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/commander": {
 			"version": "6.2.1",
@@ -3176,12 +2904,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-			"dev": true
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -3558,21 +3280,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/default-require-extensions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
-			"integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
-			"dev": true,
-			"dependencies": {
-				"strip-bom": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -3650,30 +3357,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-			"dev": true
-		},
-		"node_modules/detect-libc": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -3783,6 +3466,33 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
+		},
+		"node_modules/encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"iconv-lite": "^0.6.2"
+			}
+		},
+		"node_modules/encoding/node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.4",
@@ -4355,15 +4065,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/expand-template": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/expect": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -4479,12 +4180,6 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"node_modules/file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
-		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4529,40 +4224,6 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
-		"node_modules/follow-redirects": {
-			"version": "1.15.6",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"engines": {
-				"node": ">=4.0"
-			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"dev": true,
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/form-data-encoder": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
@@ -4570,50 +4231,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 14.17"
-			}
-		},
-		"node_modules/fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-			"dev": true
-		},
-		"node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dev": true,
-			"dependencies": {
-				"minipass": "^3.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/fs-minipass/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -4643,25 +4260,6 @@
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/gauge": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-			"dev": true,
-			"dependencies": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.3",
-				"console-control-strings": "^1.1.0",
-				"has-unicode": "^2.0.1",
-				"signal-exit": "^3.0.7",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.5"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/gensync": {
@@ -4714,12 +4312,6 @@
 			"funding": {
 				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
 			}
-		},
-		"node_modules/github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-			"dev": true
 		},
 		"node_modules/github-url-from-git": {
 			"version": "1.5.0",
@@ -4919,12 +4511,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-			"dev": true
 		},
 		"node_modules/has-yarn": {
 			"version": "3.0.0",
@@ -5915,18 +5501,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/istanbul-lib-hook": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-			"integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-			"dev": true,
-			"dependencies": {
-				"append-transform": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/istanbul-lib-instrument": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
@@ -6711,18 +6285,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
 		"node_modules/keyv": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -7137,12 +6699,6 @@
 			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
 			"dev": true
 		},
-		"node_modules/lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7380,15 +6936,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/memory-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-1.0.0.tgz",
-			"integrity": "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww==",
-			"dev": true,
-			"dependencies": {
-				"readable-stream": "^3.4.0"
-			}
-		},
 		"node_modules/meow": {
 			"version": "12.1.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -7427,27 +6974,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dev": true,
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -7490,10 +7016,14 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/minimist-options": {
 			"version": "4.1.0",
@@ -7509,58 +7039,6 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"dev": true,
-			"dependencies": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
-		"node_modules/minizlib/node_modules/minipass": {
-			"version": "3.3.6",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"dev": true,
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/mkdirp-classic": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-			"dev": true
-		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7571,12 +7049,6 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-			"dev": true
-		},
-		"node_modules/napi-build-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
 			"dev": true
 		},
 		"node_modules/natural-compare": {
@@ -7617,45 +7089,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/node-abi": {
-			"version": "3.51.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
-			"integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
-			"dev": true,
-			"dependencies": {
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-abi/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-addon-api": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
-			"integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==",
-			"dev": true
-		},
-		"node_modules/node-api-headers": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-0.0.2.tgz",
-			"integrity": "sha512-YsjmaKGPDkmhoNKIpkChtCsPVaRE0a274IdERKnuc/E8K1UJdBZ4/mvI006OijlQZHCfpRNOH3dfHQs92se8gg==",
-			"dev": true
 		},
 		"node_modules/node-fetch": {
 			"version": "2.6.7",
@@ -8205,21 +7638,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/npmlog": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-			"dev": true,
-			"dependencies": {
-				"are-we-there-yet": "^3.0.0",
-				"console-control-strings": "^1.1.0",
-				"gauge": "^4.0.3",
-				"set-blocking": "^2.0.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/number-is-nan": {
@@ -8876,32 +8294,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/prebuild-install": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-			"dev": true,
-			"dependencies": {
-				"detect-libc": "^2.0.0",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.3",
-				"mkdirp-classic": "^0.5.3",
-				"napi-build-utils": "^1.0.1",
-				"node-abi": "^3.3.0",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^4.0.0",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0"
-			},
-			"bin": {
-				"prebuild-install": "bin.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8986,27 +8378,10 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/proper-lockfile": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-			"dev": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.4",
-				"retry": "^0.12.0",
-				"signal-exit": "^3.0.2"
-			}
-		},
 		"node_modules/proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-			"dev": true
-		},
-		"node_modules/proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
 		"node_modules/pstree.remy": {
@@ -9026,10 +8401,11 @@
 			}
 		},
 		"node_modules/punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -9461,15 +8837,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-			"dev": true,
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -9628,12 +8995,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"dev": true
-		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -9660,51 +9021,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
-		},
-		"node_modules/simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
 		},
 		"node_modules/simple-update-notifier": {
 			"version": "2.0.0",
@@ -10005,57 +9321,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"dev": true,
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-			"dev": true,
-			"dependencies": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			}
-		},
-		"node_modules/tar-fs/node_modules/chownr": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"dev": true
-		},
-		"node_modules/tar-stream": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-			"dev": true,
-			"dependencies": {
-				"bl": "^4.0.3",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -10150,18 +9415,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
-		},
-		"node_modules/tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.0.1"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -10264,15 +9517,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/universalify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-			"dev": true,
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/untildify": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -10373,12 +9617,6 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"node_modules/url-join": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-			"dev": true
-		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10464,15 +9702,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/wide-align": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-			"dev": true,
-			"dependencies": {
-				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
 		"node_modules/widest-line": {
@@ -11307,104 +10536,6 @@
 			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
 			"dev": true
 		},
-		"@jazzer.js/bug-detectors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/bug-detectors/-/bug-detectors-2.1.0.tgz",
-			"integrity": "sha512-rFERKoSkLNZq52rRCXQKRqLX9Bfkb2+tzMrI/tDQ27//HwfdaJUej4MPKXg3YxFSGAEtshNNSXAn2liJmyLWpQ==",
-			"dev": true,
-			"requires": {
-				"@jazzer.js/core": "2.1.0",
-				"@jazzer.js/hooking": "2.1.0"
-			}
-		},
-		"@jazzer.js/core": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/core/-/core-2.1.0.tgz",
-			"integrity": "sha512-9uTuKlZ0WyC8evq++46TYg0SFszGx7X4/Y8nVsFmIg9sc0ceO9fmE1qg8KOafkzM9DvSdv+JL2UYWxnmgE1CJQ==",
-			"dev": true,
-			"requires": {
-				"@jazzer.js/bug-detectors": "2.1.0",
-				"@jazzer.js/fuzzer": "2.1.0",
-				"@jazzer.js/hooking": "2.1.0",
-				"@jazzer.js/instrumentor": "2.1.0",
-				"istanbul-lib-coverage": "^3.2.0",
-				"istanbul-lib-report": "^3.0.1",
-				"istanbul-reports": "^3.1.6",
-				"tmp": "^0.2.1",
-				"yargs": "^17.7.2"
-			},
-			"dependencies": {
-				"tmp": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-					"integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-					"dev": true,
-					"requires": {
-						"rimraf": "^3.0.0"
-					}
-				}
-			}
-		},
-		"@jazzer.js/fuzzer": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/fuzzer/-/fuzzer-2.1.0.tgz",
-			"integrity": "sha512-WroUAGH1+AFoI+5kRGOjvh9+1GsYEmCinvEt9yF0E0pBTeadssCG6Y8adeYh6W0rum2LjPsjVfLEWMunRLt/Ew==",
-			"dev": true,
-			"requires": {
-				"bindings": "^1.5.0",
-				"cmake-js": "^7.2.1",
-				"node-addon-api": "^7.0.0",
-				"prebuild-install": "^7.1.1"
-			}
-		},
-		"@jazzer.js/hooking": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/hooking/-/hooking-2.1.0.tgz",
-			"integrity": "sha512-caNQslD27mxkYfi7woVEN98rbPL41Ezn/pGkMB/ghcBWcG0jCJDqacRJX4Gv8ypfIhemDJEocL26Ld2XSx07Pw==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.23.2"
-			}
-		},
-		"@jazzer.js/instrumentor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/instrumentor/-/instrumentor-2.1.0.tgz",
-			"integrity": "sha512-ewvx2DKczcwusO5XlRYaMO757cFDKY+mEbS2g5k81Razq3AA/uRVU1/Ei/1FZeg9tKCuaTq9Gwl+9bdA9ER8Og==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.23.2",
-				"@babel/generator": "^7.23.0",
-				"@jazzer.js/fuzzer": "2.1.0",
-				"@jazzer.js/hooking": "2.1.0",
-				"istanbul-lib-hook": "^3.0.0",
-				"istanbul-lib-instrument": "^6.0.1",
-				"proper-lockfile": "^4.1.2",
-				"source-map-support": "^0.5.21"
-			},
-			"dependencies": {
-				"source-map-support": {
-					"version": "0.5.21",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-					"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-					"dev": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
-					}
-				}
-			}
-		},
-		"@jazzer.js/jest-runner": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@jazzer.js/jest-runner/-/jest-runner-2.1.0.tgz",
-			"integrity": "sha512-DbBP0YjBuzc/wYpVe3w+lEdR7qb6aXbIMYytBdPU0cWa1n/U3s/st/Adcz+yATEYP/UOlf06gR4qZfPmRZcTwA==",
-			"dev": true,
-			"requires": {
-				"@jazzer.js/core": "2.1.0",
-				"cosmiconfig": "^8.3.6",
-				"istanbul-reports": "^3.1.6"
-			}
-		},
 		"@jest/console": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
@@ -11896,17 +11027,6 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
-		"@types/jest": {
-			"version": "29.5.6",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.6.tgz",
-			"integrity": "sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"expect": "^29.0.0",
-				"pretty-format": "^29.0.0"
-			}
-		},
 		"@types/keyv": {
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -12249,31 +11369,6 @@
 				"picomatch": "^2.0.4"
 			}
 		},
-		"append-transform": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-			"integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-			"dev": true,
-			"requires": {
-				"default-require-extensions": "^3.0.0"
-			}
-		},
-		"aproba": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-			"dev": true
-		},
-		"are-we-there-yet": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
-			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-			"dev": true,
-			"requires": {
-				"delegates": "^1.0.0",
-				"readable-stream": "^3.6.0"
-			}
-		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -12287,12 +11382,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-			"dev": true
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true
 		},
 		"auto-changelog": {
@@ -12321,17 +11410,6 @@
 					"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 					"dev": true
 				}
-			}
-		},
-		"axios": {
-			"version": "1.7.5",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
-			"integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
-			"dev": true,
-			"requires": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
-				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"babel-jest": {
@@ -12442,15 +11520,6 @@
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
 			"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
 			"dev": true
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
 		},
 		"bl": {
 			"version": "4.1.0",
@@ -12763,12 +11832,6 @@
 				"readdirp": "~3.6.0"
 			}
 		},
-		"chownr": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-			"dev": true
-		},
 		"ci-info": {
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
@@ -12898,38 +11961,6 @@
 				"mimic-response": "^1.0.0"
 			}
 		},
-		"cmake-js": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-7.2.1.tgz",
-			"integrity": "sha512-AdPSz9cSIJWdKvm0aJgVu3X8i0U3mNTswJkSHzZISqmYVjZk7Td4oDFg0mCBA383wO+9pG5Ix7pEP1CZH9x2BA==",
-			"dev": true,
-			"requires": {
-				"axios": "^1.3.2",
-				"debug": "^4",
-				"fs-extra": "^10.1.0",
-				"lodash.isplainobject": "^4.0.6",
-				"memory-stream": "^1.0.0",
-				"node-api-headers": "^0.0.2",
-				"npmlog": "^6.0.2",
-				"rc": "^1.2.7",
-				"semver": "^7.3.8",
-				"tar": "^6.1.11",
-				"url-join": "^4.0.1",
-				"which": "^2.0.2",
-				"yargs": "^17.6.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
-			}
-		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -12962,21 +11993,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
-		},
-		"color-support": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-			"dev": true
-		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
 		},
 		"commander": {
 			"version": "6.2.1",
@@ -13039,12 +12055,6 @@
 					}
 				}
 			}
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-			"dev": true
 		},
 		"convert-source-map": {
 			"version": "2.0.0",
@@ -13294,15 +12304,6 @@
 				"untildify": "^4.0.0"
 			}
 		},
-		"default-require-extensions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
-			"integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
-			"dev": true,
-			"requires": {
-				"strip-bom": "^4.0.0"
-			}
-		},
 		"defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -13353,24 +12354,6 @@
 					"dev": true
 				}
 			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"dev": true
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-			"dev": true
-		},
-		"detect-libc": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
-			"dev": true
 		},
 		"detect-newline": {
 			"version": "3.1.0",
@@ -13448,6 +12431,30 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
+		},
+		"encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"requires": {
+				"iconv-lite": "^0.6.2"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+					"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+					"dev": true,
+					"optional": true,
+					"peer": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3.0.0"
+					}
+				}
+			}
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
@@ -13828,12 +12835,6 @@
 			"integrity": "sha512-aIQN7Q04HGAV/I5BszisuHTZHXNoC23WtLkxdCLuYZMdWviRD0TMIt2bnUBi9MrHaF/hH8b3gwG9iaAUHKnJGA==",
 			"dev": true
 		},
-		"expand-template": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-			"dev": true
-		},
 		"expect": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -13931,12 +12932,6 @@
 				"flat-cache": "^3.0.4"
 			}
 		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true
-		},
 		"fill-range": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -13972,65 +12967,11 @@
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
-		"follow-redirects": {
-			"version": "1.15.6",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-			"integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-			"dev": true
-		},
-		"form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"form-data-encoder": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
 			"integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
 			"dev": true
-		},
-		"fs-constants": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-			"dev": true
-		},
-		"fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			}
-		},
-		"fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-			"dev": true,
-			"requires": {
-				"minipass": "^3.0.0"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "3.3.6",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				}
-			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -14050,22 +12991,6 @@
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
 			"dev": true
-		},
-		"gauge": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
-			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-			"dev": true,
-			"requires": {
-				"aproba": "^1.0.3 || ^2.0.0",
-				"color-support": "^1.1.3",
-				"console-control-strings": "^1.1.0",
-				"has-unicode": "^2.0.1",
-				"signal-exit": "^3.0.7",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"wide-align": "^1.1.5"
-			}
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -14099,12 +13024,6 @@
 			"requires": {
 				"resolve-pkg-maps": "^1.0.0"
 			}
-		},
-		"github-from-package": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-			"dev": true
 		},
 		"github-url-from-git": {
 			"version": "1.5.0",
@@ -14250,12 +13169,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
-		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
 			"dev": true
 		},
 		"has-yarn": {
@@ -14966,15 +13879,6 @@
 			"integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
 			"dev": true
 		},
-		"istanbul-lib-hook": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-			"integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-			"dev": true,
-			"requires": {
-				"append-transform": "^2.0.0"
-			}
-		},
 		"istanbul-lib-instrument": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
@@ -15576,16 +14480,6 @@
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true
 		},
-		"jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.6",
-				"universalify": "^2.0.0"
-			}
-		},
 		"keyv": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
@@ -15912,12 +14806,6 @@
 			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
 			"dev": true
 		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-			"dev": true
-		},
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -16092,15 +14980,6 @@
 			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
 			"dev": true
 		},
-		"memory-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-1.0.0.tgz",
-			"integrity": "sha512-Wm13VcsPIMdG96dzILfij09PvuS3APtcKNh7M28FsCA/w6+1mjR7hhPmfFNoilX9xU7wTdhsH5lJAm6XNzdtww==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^3.4.0"
-			}
-		},
 		"meow": {
 			"version": "12.1.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -16127,21 +15006,6 @@
 			"requires": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
-			}
-		},
-		"mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"dev": true
-		},
-		"mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"dev": true,
-			"requires": {
-				"mime-db": "1.52.0"
 			}
 		},
 		"mimic-fn": {
@@ -16172,9 +15036,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"dev": true
 		},
 		"minimist-options": {
@@ -16188,45 +15052,6 @@
 				"kind-of": "^6.0.3"
 			}
 		},
-		"minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true
-		},
-		"minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-			"dev": true,
-			"requires": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
-			},
-			"dependencies": {
-				"minipass": {
-					"version": "3.3.6",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-					"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-					"dev": true,
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				}
-			}
-		},
-		"mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"dev": true
-		},
-		"mkdirp-classic": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-			"dev": true
-		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -16237,12 +15062,6 @@
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-			"dev": true
-		},
-		"napi-build-utils": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -16273,38 +15092,6 @@
 					"dev": true
 				}
 			}
-		},
-		"node-abi": {
-			"version": "3.51.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
-			"integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
-			"dev": true,
-			"requires": {
-				"semver": "^7.3.5"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
-			}
-		},
-		"node-addon-api": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
-			"integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==",
-			"dev": true
-		},
-		"node-api-headers": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-0.0.2.tgz",
-			"integrity": "sha512-YsjmaKGPDkmhoNKIpkChtCsPVaRE0a274IdERKnuc/E8K1UJdBZ4/mvI006OijlQZHCfpRNOH3dfHQs92se8gg==",
-			"dev": true
 		},
 		"node-fetch": {
 			"version": "2.6.7",
@@ -16667,18 +15454,6 @@
 			"dev": true,
 			"requires": {
 				"path-key": "^3.0.0"
-			}
-		},
-		"npmlog": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
-			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-			"dev": true,
-			"requires": {
-				"are-we-there-yet": "^3.0.0",
-				"console-control-strings": "^1.1.0",
-				"gauge": "^4.0.3",
-				"set-blocking": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -17127,26 +15902,6 @@
 				"find-up": "^4.0.0"
 			}
 		},
-		"prebuild-install": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-			"integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-			"dev": true,
-			"requires": {
-				"detect-libc": "^2.0.0",
-				"expand-template": "^2.0.3",
-				"github-from-package": "0.0.0",
-				"minimist": "^1.2.3",
-				"mkdirp-classic": "^0.5.3",
-				"napi-build-utils": "^1.0.1",
-				"node-abi": "^3.3.0",
-				"pump": "^3.0.0",
-				"rc": "^1.2.7",
-				"simple-get": "^4.0.0",
-				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0"
-			}
-		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -17203,27 +15958,10 @@
 				"sisteransi": "^1.0.5"
 			}
 		},
-		"proper-lockfile": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
-			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.2.4",
-				"retry": "^0.12.0",
-				"signal-exit": "^3.0.2"
-			}
-		},
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
 			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-			"dev": true
-		},
-		"proxy-from-env": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true
 		},
 		"pstree.remy": {
@@ -17243,9 +15981,9 @@
 			}
 		},
 		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true
 		},
 		"pupa": {
@@ -17537,12 +16275,6 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
-		"retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-			"dev": true
-		},
 		"reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -17635,12 +16367,6 @@
 				}
 			}
 		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"dev": true
-		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -17661,23 +16387,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
-		},
-		"simple-concat": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-			"dev": true
-		},
-		"simple-get": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-			"dev": true,
-			"requires": {
-				"decompress-response": "^6.0.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
 		},
 		"simple-update-notifier": {
 			"version": "2.0.0",
@@ -17909,53 +16618,6 @@
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
 			"dev": true
 		},
-		"tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"dev": true,
-			"requires": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			}
-		},
-		"tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-			"dev": true,
-			"requires": {
-				"chownr": "^1.1.1",
-				"mkdirp-classic": "^0.5.2",
-				"pump": "^3.0.0",
-				"tar-stream": "^2.1.4"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
-				}
-			}
-		},
-		"tar-stream": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-			"dev": true,
-			"requires": {
-				"bl": "^4.0.3",
-				"end-of-stream": "^1.4.1",
-				"fs-constants": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.1.1"
-			}
-		},
 		"test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -18029,15 +16691,6 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
 			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
 			"dev": true
-		},
-		"tunnel-agent": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
 		},
 		"type-check": {
 			"version": "0.4.0",
@@ -18116,12 +16769,6 @@
 				"crypto-random-string": "^4.0.0"
 			}
 		},
-		"universalify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-			"dev": true
-		},
 		"untildify": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -18182,12 +16829,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"url-join": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -18264,15 +16905,6 @@
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
-			}
-		},
-		"wide-align": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
 		"widest-line": {

--- a/package.json
+++ b/package.json
@@ -44,8 +44,6 @@
 	},
 	"devDependencies": {
 		"@homer0/prettier-plugin-jsdoc": "9.1.0",
-		"@jazzer.js/core": "2.1.0",
-		"@jazzer.js/jest-runner": "2.1.0",
 		"auto-changelog": "2.5.0",
 		"eslint": "8.57.1",
 		"eslint-config-prettier": "10.0.1",
@@ -58,7 +56,6 @@
 		"nodemon": "3.1.9",
 		"np": "8.0.4",
 		"prettier": "3.5.1",
-		"rxjs": "7.8.1",
 		"xmltest": "2.0.3",
 		"yauzl": "3.2.0"
 	},
@@ -71,5 +68,6 @@
 		"remote": "origin",
 		"tagPrefix": "",
 		"template": "./auto-changelog.hbs"
-	}
+	},
+	"packageManager": "npm@11.1.0+sha512.acf301ad9b9ddba948fcb72341e2f0fcae477f56a95cc2a092934d133a7461062633cefbf93d5934a3dc0768674e2edee9f04dcfcc4bb4c327ff0e3a7d552a1b"
 }


### PR DESCRIPTION
- jazzer [has been deprecated](https://socket.dev/npm/package/@jazzer.js/core/overview/2.1.0) and has tons of deprecated dependencies, and I'm no longer able to install it on my machine, without adding `prebuild` as a devDependency which adds some more deprecated dependencies to the project...
```
npm error code 127
npm error path /home/karfau/dev/xmldom/node_modules/@jazzer.js/fuzzer
npm error command failed
npm error command sh -c prebuild-install --runtime napi || npm run prebuild
npm error > @jazzer.js/fuzzer@2.1.0 prebuild
npm error > prebuild --runtime napi --backend cmake-js --all --strip --verbose
npm error prebuild-install warn This package does not support N-API version undefined
npm error prebuild-install warn install No prebuilt binaries found (target=undefined runtime=napi arch=x64 libc= platform=linux)
npm error sh: line 1: prebuild: command not found
```
- rxjs is only used/needed as a transient dependency for `np`, so there is no need to maintain it (like in #844)