### PR TITLE
perf: improve line detection regular expression for locator

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -167,6 +167,9 @@ module.exports = {
 	// This option allows use of a custom test runner
 	// testRunner: "jasmine2",
 
+	// global max, can be configured to be less strict as the third option for each test function
+	testTimeout: 500,
+
 	// This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
 	// testURL: "http://localhost",
 

--- a/test/get-test-parser.js
+++ b/test/get-test-parser.js
@@ -25,7 +25,7 @@ const { DOMParser } = require('../lib/dom-parser');
  * locator?: boolean }}
  * @returns {{ parser: DOMParser; errors: [ErrorLevel, string, Object][] }}
  */
-function getTestParser({ onError, errors = [], locator = true } = {}) {
+function getTestParser({ onError, errors = [], locator = true, normalizeLineEndings } = {}) {
 	onError =
 		onError ||
 		((level, msg, { locator }) => {
@@ -33,7 +33,7 @@ function getTestParser({ onError, errors = [], locator = true } = {}) {
 		});
 	return {
 		errors,
-		parser: new DOMParser({ onError, locator }),
+		parser: new DOMParser({ onError, locator, normalizeLineEndings }),
 	};
 }
 

--- a/test/xmltest/not-wf.test.js
+++ b/test/xmltest/not-wf.test.js
@@ -25,7 +25,7 @@ describe('xmltest/not-wellformed', () => {
 					expect(e.message).toMatchSnapshot('caught');
 				}
 				actual && expect(generateSnapshot(actual, errors)).toMatchSnapshot('reported');
-			});
+			}, 2000);
 		});
 	});
 });

--- a/test/xmltest/valid.test.js
+++ b/test/xmltest/valid.test.js
@@ -24,7 +24,7 @@ describe('xmltest/valid', () => {
 					expect({ error, expected }).toMatchSnapshot('caught');
 				}
 				actual && expect(generateSnapshot(actual, errors, expected)).toMatchSnapshot();
-			});
+			}, 2000);
 		});
 	});
 });


### PR DESCRIPTION
- enforce timeouts on tests and specifically for the one not using the default `normalizeLineEndings`, so it actually fails.