### PR TITLE
Fix Node.contains() not traversing ancestor chain correctly

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1082,7 +1082,7 @@ Node.prototype = {
 		var parent = other;
 		do {
 			if (this === parent) return true;
-			parent = other.parentNode;
+			parent = parent.parentNode;
 		} while (parent);
 		return false;
 	},

--- a/test/dom/node.test.js
+++ b/test/dom/node.test.js
@@ -79,10 +79,15 @@ describe('Node.prototype', () => {
 		const doc = impl.createDocument(null, '');
 		const el1 = doc.createElement('test1');
 		const el2 = doc.createElement('test2');
+		const el3 = doc.createElement('test3');
 		el1.appendChild(el2);
+		el2.appendChild(el3);
 
 		test('should return true if otherNode is a child of this node', () => {
 			expect(el1.contains(el2)).toBe(true);
+		});
+		test('should return true if otherNode is a descendant of this node', () => {
+			expect(el1.contains(el3)).toBe(true);
 		});
 		test('should return true if otherNode is this node', () => {
 			expect(el1.contains(el1)).toBe(true);


### PR DESCRIPTION
Hello, and thank you for maintaining this project! 
I found a small bug in `Node.contains()` and would like to propose a fix.

### Description

`Node.contains()` currently does not traverse the ancestor chain correctly, and therefore does not work correctly when the reference node is a deeper descendant.

### Problem:

The current implementation resets parent to `other.parentNode` in each loop iteration, so it only checks the immediate parent and in an infinite loop.

### Fix:

Assign `parent = parent.parentNode` instead, so the loop correctly walks up the ancestor chain.

### Reproduction Example:

```js
const { DOMParser } = require("@xmldom/xmldom");

const xml = "<root><foo><bar><baz>test</baz></bar></foo></root>";
const doc = new DOMParser().parseFromString(xml, "application/xml");
const rootNode = doc.documentElement;
const fooNode = rootNode?.firstChild;
const barNode = fooNode?.firstChild;
const bazNode = barNode?.firstChild;

console.log(fooNode?.contains(barNode)); // <- true
console.log(fooNode?.contains(bazNode)); // <- Before fix: infinite loop, After fix: true
```

---

Thank you for reviewing this pull request! I hope this helps improve the library.
