### PR TITLE
ci: execute checks on 0.8.x release branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ master, release-0.8.x ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ master, release-0.8.x ]
     paths-ignore:
       - '**/*.md'
       - '**/*.puml'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -3,9 +3,9 @@ name: examples
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release-0.8.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release-0.8.x ]
 
 permissions:
   contents: read

--- a/.github/workflows/test-node.js.yml
+++ b/.github/workflows/test-node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release-0.8.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, release-0.8.x ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Since contributions regularly effect 0.8.x let's use GitHub actions to run the checks.
Following the usual pattern, this is first applied to the master branch, before being ported to the release branch.