### PR TITLE
feat: implement Element.getAttributeNames

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2387,6 +2387,18 @@ Element.prototype = {
 		}
 		return this.attributes.getNamedItem(name);
 	},
+	getAttributeNames: function () {
+		var names = [];
+		if (this.attributes && this.attributes.length) {
+			for (var i = 0; i < this.attributes.length; i++) {
+				var attr = this.attributes.item(i);
+				if (attr) {
+					names.push(attr.nodeName);
+				}
+			}
+		}
+		return names;
+	},
 	/**
 	 * Sets the value of element’s first attribute whose qualified name is qualifiedName to value.
 	 *


### PR DESCRIPTION
Closes #880 

Spec:
[https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNames)
[https://dom.spec.whatwg.org/#dom-element-getattributenames](https://dom.spec.whatwg.org/#dom-element-getattributenames)

Note:
I have found a issue with the serializer in this test:
```
	test('should handle duplicate qualified names from different namespaces', () => {
		const doc = new DOMImplementation().createDocument(null, 'xml');
		const element = doc.documentElement;

		// Create attributes with same local name but different namespaces
		element.setAttributeNS('http://ns1.example.com', 'test', 'value1');
		element.setAttributeNS('http://ns2.example.com', 'test', 'value2');

		// Should return both attributes
		expect(element.getAttributeNames()).toEqual(['test', 'test']);

		// TODO: there seems to be a bug in the serialization of this document.
		//       It outputs xmlns twice, the serializer should probably automatically prefix the namespaces
	});
```

When this document is serialized the result is:
```
<xml xmlns="http://ns1.example.com" test="value1" xmlns="http://ns2.example.com" test="value2"/>
```

If you do the same in a browser:
```
const doc = document.implementation.createDocument(null, 'xml');
const element = doc.documentElement;

element.setAttributeNS('http://ns1.example.com', 'test', 'value1');
element.setAttributeNS('http://ns2.example.com', 'test', 'value2');

const serializer = new XMLSerializer();
const xmlStr = serializer.serializeToString(doc);
```
The serializer automatically adds prefixes:
```
<xml xmlns:ns1="http://ns1.example.com" ns1:test="value1" xmlns:ns2="http://ns2.example.com" ns2:test="value2"/>
```