### PR TITLE
fix: XML injection via unsafe CDATA serialization (GHSA-wh4c-j3r5-mjhp) (0.7.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.14](https://github.com/xmldom/xmldom/compare/0.7.13...0.7.14)
+
+### Fixed
+
+- Security: `createCDATASection` now throws `InvalidCharacterError` when `data` contains `"]]>"`, as required by the [WHATWG DOM spec](https://dom.spec.whatwg.org/#dom-document-createcdatasection). [`GHSA-wh4c-j3r5-mjhp`](https://github.com/xmldom/xmldom/security/advisories/GHSA-wh4c-j3r5-mjhp)
+- Security: `XMLSerializer` now splits CDATASection nodes whose data contains `"]]>"` into adjacent CDATA sections at serialization time, preventing XML injection via mutation methods (`appendData`, `replaceData`, `.data =`, `.textContent =`). [`GHSA-wh4c-j3r5-mjhp`](https://github.com/xmldom/xmldom/security/advisories/GHSA-wh4c-j3r5-mjhp)
+
+Code that passes a string containing `"]]>"` to `createCDATASection` and relied on the previously unsafe behavior will now receive `InvalidCharacterError`. Use a mutation method such as `appendData` if you intentionally need `"]]>"` in a CDATASection node's data.
+
+Thank you, [@thesmartshadow](https://github.com/thesmartshadow), for your contributions
+
+
 ## [0.7.13](https://github.com/xmldom/xmldom/compare/0.7.12...0.7.13)
 
 ### Fixed

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,16 @@ declare module "@xmldom/xmldom" {
   }
 
   interface XMLSerializer {
+      /**
+       * Returns the result of serializing `node` to XML.
+       *
+       * __This implementation differs from the specification:__
+       * - CDATASection nodes whose data contains `]]>` are serialized by splitting the section
+       *   at each `]]>` occurrence (following W3C DOM Level 3 Core `split-cdata-sections`
+       *   default behaviour). A configurable option is not yet implemented.
+       *
+       * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
+       */
       serializeToString(node: Node): string;
   }
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1133,7 +1133,22 @@ Document.prototype = {
 		node.appendData(data)
 		return node;
 	},
+	/**
+	 * Returns a new CDATASection node whose data is `data`.
+	 *
+	 * __This implementation differs from the specification:__
+	 * - calling this method on an HTML document does not throw `NotSupportedError`.
+	 *
+	 * @param {string} data
+	 * @returns {CDATASection}
+	 * @throws DOMException with code `INVALID_CHARACTER_ERR` if `data` contains `"]]>"`.
+	 * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/createCDATASection
+	 * @see https://dom.spec.whatwg.org/#dom-document-createcdatasection
+	 */
 	createCDATASection :	function(data){
+		if (data.indexOf(']]>') !== -1) {
+			throw new DOMException(INVALID_CHARACTER_ERR, 'data contains "]]>"');
+		}
 		var node = new CDATASection();
 		node.ownerDocument = this;
 		node.appendData(data)
@@ -1402,6 +1417,20 @@ function ProcessingInstruction() {
 ProcessingInstruction.prototype.nodeType = PROCESSING_INSTRUCTION_NODE;
 _extends(ProcessingInstruction,Node);
 function XMLSerializer(){}
+/**
+ * Returns the result of serializing `node` to XML.
+ *
+ * __This implementation differs from the specification:__
+ * - CDATASection nodes whose data contains `]]>` are serialized by splitting the section
+ *   at each `]]>` occurrence (following W3C DOM Level 3 Core `split-cdata-sections`
+ *   default behaviour). A configurable option is not yet implemented.
+ *
+ * @param {Node} node
+ * @param {boolean} [isHtml]
+ * @param {function} [nodeFilter]
+ * @returns {string}
+ * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
+ */
 XMLSerializer.prototype.serializeToString = function(node,isHtml,nodeFilter){
 	return nodeSerializeToString.call(node,isHtml,nodeFilter);
 }
@@ -1613,7 +1642,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 			.replace(/]]>/g, ']]&gt;')
 		);
 	case CDATA_SECTION_NODE:
-		return buf.push( '<![CDATA[',node.data,']]>');
+		return buf.push('<![CDATA[', node.data.replace(/]]>/g, ']]]]><![CDATA[>'), ']]>');
 	case COMMENT_NODE:
 		return buf.push( "<!--",node.data,"-->");
 	case DOCUMENT_TYPE_NODE:

--- a/test/dom/cdata-section.test.js
+++ b/test/dom/cdata-section.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const { DOMImplementation, DOMException } = require('../../lib/dom')
+const { DOMParser } = require('../../lib')
+
+describe('Document.prototype.createCDATASection', () => {
+	let doc
+	beforeEach(() => {
+		doc = new DOMImplementation().createDocument(null, 'xml')
+	})
+
+	describe('throws InvalidCharacterError', () => {
+		test('when data is exactly "]]>"', () => {
+			expect(() => doc.createCDATASection(']]>')).toThrow(DOMException)
+		})
+
+		test('when data starts with safe content then contains "]]>"', () => {
+			expect(() => doc.createCDATASection('safe]]>data')).toThrow(DOMException)
+		})
+
+		test('when data contains multiple "]]>" occurrences', () => {
+			expect(() => doc.createCDATASection('before]]>after]]>after')).toThrow(
+				DOMException
+			)
+		})
+	})
+
+	describe('does not throw', () => {
+		test('when data is safe', () => {
+			expect(() => doc.createCDATASection('safe')).not.toThrow()
+		})
+
+		test('when data is empty string', () => {
+			expect(() => doc.createCDATASection('')).not.toThrow()
+		})
+	})
+
+	describe('parse path', () => {
+		test('parsing XML containing a CDATA section does not throw', () => {
+			expect(() =>
+				new DOMParser().parseFromString(
+					'<root><![CDATA[some data]]></root>',
+					'text/xml'
+				)
+			).not.toThrow()
+		})
+	})
+})

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -2,6 +2,7 @@
 
 const { DOMParser, XMLSerializer } = require('../../lib')
 const { MIME_TYPE } = require('../../lib/conventions')
+const { DOMImplementation } = require('../../lib/dom')
 
 describe('XML Serializer', () => {
 	it('supports text node containing "]]>"', () => {
@@ -243,6 +244,89 @@ describe('XML Serializer', () => {
 			).toBe(
 				'<test xmlns:attr="&quot;&amp;&lt;" attr:test="" xmlns="&lt;&amp;&quot;"/>'
 			)
+		})
+	})
+})
+
+describe('XMLSerializer CDATASection serialization', () => {
+	let doc
+	beforeEach(() => {
+		doc = new DOMImplementation().createDocument(null, 'root', null)
+	})
+
+	it('serializes a safe CDATASection unchanged', () => {
+		doc.documentElement.appendChild(doc.createCDATASection('safe data'))
+		expect(new XMLSerializer().serializeToString(doc.documentElement)).toBe(
+			'<root><![CDATA[safe data]]></root>'
+		)
+	})
+
+	it('splits a CDATASection whose data contains "]]>"', () => {
+		const cdata = doc.createCDATASection('safe')
+		cdata.data = 'foo]]>bar'
+		doc.documentElement.appendChild(cdata)
+		expect(new XMLSerializer().serializeToString(doc.documentElement)).toBe(
+			'<root><![CDATA[foo]]]]><![CDATA[>bar]]></root>'
+		)
+	})
+
+	it('splits multiple "]]>" occurrences', () => {
+		const cdata = doc.createCDATASection('safe')
+		cdata.data = 'a]]>b]]>c'
+		doc.documentElement.appendChild(cdata)
+		expect(new XMLSerializer().serializeToString(doc.documentElement)).toBe(
+			'<root><![CDATA[a]]]]><![CDATA[>b]]]]><![CDATA[>c]]></root>'
+		)
+	})
+
+	it('split output round-trips through DOMParser to equivalent content', () => {
+		const cdata = doc.createCDATASection('safe')
+		cdata.data = 'foo]]>bar'
+		doc.documentElement.appendChild(cdata)
+		const serialized = new XMLSerializer().serializeToString(
+			doc.documentElement
+		)
+		const reparsed = new DOMParser().parseFromString(
+			serialized,
+			MIME_TYPE.XML_TEXT
+		)
+		expect(reparsed.documentElement.textContent).toBe('foo]]>bar')
+	})
+
+	describe('mutation vectors', () => {
+		// Serializes, then re-parses, and returns true if an <injected> element appears in the tree.
+		function isInjected(root) {
+			const xml = new XMLSerializer().serializeToString(root)
+			const reparsed = new DOMParser().parseFromString(xml, MIME_TYPE.XML_TEXT)
+			return reparsed.getElementsByTagName('injected').length > 0
+		}
+
+		it('appendData introduces "]]>" safely', () => {
+			const cdata = doc.createCDATASection('safe')
+			doc.documentElement.appendChild(cdata)
+			cdata.appendData(']]><injected/>')
+			expect(isInjected(doc.documentElement)).toBe(false)
+		})
+
+		it('replaceData introduces "]]>" safely', () => {
+			const cdata = doc.createCDATASection('safe data')
+			doc.documentElement.appendChild(cdata)
+			cdata.replaceData(4, 5, ']]><injected/>')
+			expect(isInjected(doc.documentElement)).toBe(false)
+		})
+
+		it('.data assignment introduces "]]>" safely', () => {
+			const cdata = doc.createCDATASection('safe')
+			doc.documentElement.appendChild(cdata)
+			cdata.data = 'evil]]><injected/>'
+			expect(isInjected(doc.documentElement)).toBe(false)
+		})
+
+		it('.textContent assignment introduces "]]>" safely', () => {
+			const cdata = doc.createCDATASection('safe')
+			doc.documentElement.appendChild(cdata)
+			cdata.textContent = 'evil]]><injected/>'
+			expect(isInjected(doc.documentElement)).toBe(false)
 		})
 	})
 })


### PR DESCRIPTION
Fixes GHSA-wh4c-j3r5-mjhp — XML injection via unsafe CDATA serialization on the 0.7.x release line.

### Fixed

- Security: `createCDATASection` now throws `InvalidCharacterError` when `data` contains `"]]>"`, as required by the [WHATWG DOM spec](https://dom.spec.whatwg.org/#dom-document-createcdatasection). [`GHSA-wh4c-j3r5-mjhp`](https://github.com/xmldom/xmldom/security/advisories/GHSA-wh4c-j3r5-mjhp)
- Security: `XMLSerializer` now splits CDATASection nodes whose data contains `"]]>"` into adjacent CDATA sections at serialization time, preventing XML injection via mutation methods (`appendData`, `replaceData`, `.data =`, `.textContent =`). [`GHSA-wh4c-j3r5-mjhp`](https://github.com/xmldom/xmldom/security/advisories/GHSA-wh4c-j3r5-mjhp)

Code that passes a string containing `"]]>"` to `createCDATASection` and relied on the previously unsafe behavior will now receive `InvalidCharacterError`. Use a mutation method such as `appendData` if you intentionally need `"]]>"` in a CDATASection node's data.