### PR TITLE
fix: security release 0.8.13 (comment/PI/DOCTYPE injection + DoS recursion)

### DIFF
--- a/.github/workflows/ci-local.sh
+++ b/.github/workflows/ci-local.sh
@@ -12,7 +12,7 @@ fi
 # Remove generated test artefacts that differ between branches to avoid cross-branch contamination
 rm -f test/error/reported.json test/errors/reported.json
 
-npm ci
+npm ci --loglevel error --no-audit --no-update-notifier --no-fund
 npm run test
 npm run lint
 npm run format:check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.13](https://github.com/xmldom/xmldom/compare/0.8.12...0.8.13)
+
+### Fixed
+
+- Security: `XMLSerializer.serializeToString()` (and `Node.toString()`, `NodeList.toString()`) now accept a `requireWellFormed` option (fourth argument, after `isHtml` and `nodeFilter`). When `{ requireWellFormed: true }` is passed, the serializer throws `InvalidStateError` for injection-prone node content, preventing XML injection via attacker-controlled node data. [`GHSA-j759-j44w-7fr8`](https://github.com/xmldom/xmldom/security/advisories/GHSA-j759-j44w-7fr8) [`GHSA-x6wf-f3px-wcqx`](https://github.com/xmldom/xmldom/security/advisories/GHSA-x6wf-f3px-wcqx) [`GHSA-f6ww-3ggp-fr8h`](https://github.com/xmldom/xmldom/security/advisories/GHSA-f6ww-3ggp-fr8h)
+  - Comment: throws when `data` contains `-->`
+  - ProcessingInstruction: throws when `data` contains `?>`
+  - DocumentType: throws when `publicId` fails `PubidLiteral`, `systemId` fails `SystemLiteral`, or `internalSubset` contains `]>`
+- Security: DOM traversal operations (`XMLSerializer.serializeToString()`, `Node.prototype.normalize()`, `Node.prototype.cloneNode(true)`, `Document.prototype.importNode(node, true)`, `node.textContent` getter, `getElementsByTagName()` / `getElementsByTagNameNS()` / `getElementsByClassName()` / `getElementById()`) are now iterative. Previously, deeply nested DOM trees would exhaust the JavaScript call stack and throw an unrecoverable `RangeError`. [`GHSA-2v35-w6hq-6mfw`](https://github.com/xmldom/xmldom/security/advisories/GHSA-2v35-w6hq-6mfw)
+
+Thank you,
+[@Jvr2022](https://github.com/Jvr2022),
+[@praveen-kv](https://github.com/praveen-kv),
+[@TharVid](https://github.com/TharVid),
+[@decsecre583](https://github.com/decsecre583),
+[@tlsbollei](https://github.com/tlsbollei),
+[@KarimTantawey](https://github.com/KarimTantawey),
+for your contributions
+
 ## [0.8.12](https://github.com/xmldom/xmldom/compare/0.8.11...0.8.12)
 
 ### Fixed

--- a/docs/walk-dom.md
+++ b/docs/walk-dom.md
@@ -1,0 +1,117 @@
+# `walkDOM` — iterative tree traversal
+
+**Source**: [`lib/dom.js`](../lib/dom.js)
+
+`walkDOM` visits every node in a DOM subtree in depth-first order, calling
+caller-supplied `enter` and `exit` callbacks. It uses an explicit stack instead
+of recursion, so it is safe on arbitrarily deep trees.
+
+## Stack frame
+
+Each item on the work stack is a frame with three fields:
+
+| Field     | Purpose                                              |
+|-----------|------------------------------------------------------|
+| `node`    | The DOM node to process                              |
+| `context` | Opaque value threaded through the traversal          |
+| `phase`   | `ENTER` — call `enter`, schedule children and exit  |
+|           | `EXIT`  — call `exit` for the matching `enter`       |
+
+Each frame starts its life as `ENTER` and, after being processed, causes an
+`EXIT` frame for the same node to be pushed. The `EXIT` frame fires only after
+all descendants have been fully processed — which is exactly the post-order
+guarantee.
+
+## Control flow
+
+```mermaid
+flowchart TD
+    start([push ENTER frame for root]) --> loop
+
+    loop{stack empty?} -- no --> pop[pop frame]
+    loop -- yes --> done([return])
+
+    pop --> phase{frame.phase}
+
+    phase -- ENTER --> callEnter["childContext = enter(node, context)"]
+    callEnter --> check{childContext?}
+
+    phase -- EXIT --> callExit["call exit(node, context)\nif provided"]
+    callExit --> loop
+
+    check -- STOP --> ret([return STOP])
+    check -- otherwise --> pushExit["push EXIT frame\n{node, childContext}"]
+    pushExit --> descend{childContext\nnull or undefined?}
+    descend -- yes\nskip children --> loop
+    descend -- no --> pushChildren["push ENTER frames\nfrom lastChild via previousSibling\n(firstChild lands on top)"]
+    pushChildren --> loop
+```
+
+`EXIT` is always pushed — even when children are skipped — so `exit` is called
+once for every `enter`, symmetric and unconditional.
+
+## Why pushing EXIT before children guarantees post-order
+
+The stack is last-in-first-out. When an `ENTER` frame is processed, the following are
+pushed in this order:
+
+1. `EXIT` frame for the current node
+2. `ENTER` frames for children, traversed from `lastChild` via `previousSibling` — so `firstChild` lands on top and is processed first
+
+Because children are on top, they are processed first. The parent's `EXIT`
+frame sits below all of them and fires only after the last descendant finishes.
+
+### Stack trace
+
+```xml
+<root>
+  <A>
+    <A1/>
+  </A>
+  <B/>
+</root>
+```
+
+| Step | Actions                                                                                         | Stack after <br/>(list order, last item = next to pop)          |
+|------|-------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| init | push `ENTER(root)`                                                                              | `ENTER(root)`                                                   |
+| 1    | pop `ENTER(root)`,<br/> `enter(root)`,<br/> push `EXIT(root)`, `ENTER(B)`, `ENTER(A)` | `EXIT(root)`,<br/> `ENTER(B)`,<br/> `ENTER(A)`                  |
+| 2    | pop `ENTER(A)`,<br/> `enter(A)`,<br/> push `EXIT(A)`, `ENTER(A1)`                          | `EXIT(root)`,<br/> `ENTER(B)`,<br/> `EXIT(A)`,<br/> `ENTER(A1)` |
+| 3    | pop `ENTER(A1)`,<br/> `enter(A1)`,<br/> push `EXIT(A1)`                                         | `EXIT(root)`,<br/> `ENTER(B)`,<br/> `EXIT(A)`,<br/> `EXIT(A1)`  |
+| 4    | pop `EXIT(A1)`,<br/> `exit(A1)`                                                                 | `EXIT(root)`,<br/> `ENTER(B)`,<br/> `EXIT(A)`                   |
+| 5    | pop `EXIT(A)`,<br/> `exit(A)`                                                                   | `EXIT(root)`,<br/> `ENTER(B)`                                   |
+| 6    | pop `ENTER(B)`,<br/> `enter(B)`,<br/> push `EXIT(B)`                                            | `EXIT(root)`,<br/> `EXIT(B)`                                    |
+| 7    | pop `EXIT(B)`,<br/> `exit(B)`                                                                   | `EXIT(root)`                                                    |
+| 8    | pop `EXIT(root)`,<br/> `exit(root)`                                                             | _(empty)_                                                       |
+
+Call order: `enter(root)` → `enter(A)` → `enter(A1)` → `exit(A1)` → `exit(A)` → `enter(B)` → `exit(B)` → `exit(root)`.
+
+## Context isolation
+
+The value returned by `enter` becomes `childContext`. It is stored in:
+
+- the `EXIT` frame, so `exit` receives exactly what `enter` returned
+- all children's `ENTER` frames, so each child starts with the parent's output
+
+Siblings share the same `childContext` reference from their common parent.
+Callers that need per-element isolation must produce a fresh value inside
+`enter` (e.g. `namespaces.slice()` in `serializeToString`).
+
+## DOM mutation during traversal
+
+Only mutations to a node's **own children** inside its `enter` callback are
+supported. Because `lastChild` and `previousSibling` are read after `enter` returns, any
+children added or removed there are correctly reflected when the walker
+schedules the next level of frames.
+
+Mutating anything else — siblings of the current node, ancestors, or unrelated
+subtrees — produces unpredictable results. Nodes already queued on the stack
+are visited regardless of subsequent DOM changes; nodes inserted outside the
+current child list are never queued and therefore never visited. Neither
+`enter` nor `exit` is guaranteed to be called for such nodes.
+
+## `walkDOM.STOP`
+
+Returning `walkDOM.STOP` from `enter` causes the function to return `STOP`
+immediately, discarding the rest of the stack. No further `enter` or `exit`
+calls are made — including any pending `EXIT` frames for ancestors.

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,18 +22,35 @@ declare module "@xmldom/xmldom" {
       parseFromString(xmlsource: string, mimeType?: string): Document;
   }
 
+  /** Options accepted by `XMLSerializer.prototype.serializeToString`. */
+  interface XMLSerializerOptions {
+      /**
+       * When `true`, the serializer throws for content that would produce ill-formed XML.
+       *
+       * @default false
+       */
+      requireWellFormed?: boolean;
+  }
+
   interface XMLSerializer {
       /**
        * Returns the result of serializing `node` to XML.
        *
+       * When `options.requireWellFormed` is `true`, the serializer throws for content that would
+       * produce ill-formed XML.
+       *
        * __This implementation differs from the specification:__
        * - CDATASection nodes whose data contains `]]>` are serialized by splitting the section
        *   at each `]]>` occurrence (following W3C DOM Level 3 Core `split-cdata-sections`
-       *   default behaviour). A configurable option is not yet implemented.
+       *   default behaviour) unless `requireWellFormed` is `true`.
+       * - W3C DOM Parsing §3.2.1.1 requires well-formedness checks on Element `localName`s,
+       *   prefixes, and attribute serialization when `requireWellFormed` is `true`. These checks
+       *   are not implemented in this release.
        *
        * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
+       * @see https://github.com/w3c/DOM-Parsing/issues/84
        */
-      serializeToString(node: Node): string;
+      serializeToString(node: Node, isHtml?: boolean, nodeFilter?: (node: Node) => Node | null | undefined, options?: XMLSerializerOptions): string;
   }
 
   interface Options {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,8 @@ declare module "@xmldom/xmldom" {
   /** Options accepted by `XMLSerializer.prototype.serializeToString`. */
   interface XMLSerializerOptions {
       /**
-       * When `true`, the serializer throws for content that would produce ill-formed XML.
+       * When `true`, the serializer throws a DOMException with code `INVALID_STATE_ERR` if the
+       * CDATASection data contains `"]]>"`.
        *
        * @default false
        */
@@ -47,6 +48,9 @@ declare module "@xmldom/xmldom" {
        *   prefixes, and attribute serialization when `requireWellFormed` is `true`. These checks
        *   are not implemented in this release.
        *
+       * @throws {DOMException}
+       * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and the CDATASection
+       * data contains `"]]>"`.
        * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
        * @see https://github.com/w3c/DOM-Parsing/issues/84
        */

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,8 +25,11 @@ declare module "@xmldom/xmldom" {
   /** Options accepted by `XMLSerializer.prototype.serializeToString`. */
   interface XMLSerializerOptions {
       /**
-       * When `true`, the serializer throws a DOMException with code `INVALID_STATE_ERR` if the
-       * CDATASection data contains `"]]>"`.
+       * When `true`, the serializer throws a DOMException with code `INVALID_STATE_ERR` if:
+       * - A CDATASection node's data contains `"]]>"`.
+       * - A Comment node's data contains `"-->"` (the injection sequence that terminates a
+       *   comment). Comments whose data contains `"--"` but not `"-->"` are accepted on this
+       *   branch — the 0.8.x parser does not validate bare `"--"` in comment content.
        *
        * @default false
        */
@@ -50,7 +53,9 @@ declare module "@xmldom/xmldom" {
        *
        * @throws {DOMException}
        * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and the CDATASection
-       * data contains `"]]>"`.
+       * data contains `"]]>"`, or a Comment node's data contains `"-->"`.
+       * (On this 0.8.x branch, bare `"--"` in comment data does not throw — see
+       * `XMLSerializerOptions.requireWellFormed` for details.)
        * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
        * @see https://github.com/w3c/DOM-Parsing/issues/84
        */

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ declare module "@xmldom/xmldom" {
        * - A Comment node's data contains `"-->"` (the injection sequence that terminates a
        *   comment). Comments whose data contains `"--"` but not `"-->"` are accepted on this
        *   branch — the 0.8.x parser does not validate bare `"--"` in comment content.
+       * - A ProcessingInstruction's data contains `"?>"` (W3C DOM Parsing §3.2.1.7).
        *
        * @default false
        */
@@ -47,16 +48,16 @@ declare module "@xmldom/xmldom" {
        * - CDATASection nodes whose data contains `]]>` are serialized by splitting the section
        *   at each `]]>` occurrence (following W3C DOM Level 3 Core `split-cdata-sections`
        *   default behaviour) unless `requireWellFormed` is `true`.
-       * - W3C DOM Parsing §3.2.1.1 requires well-formedness checks on Element `localName`s,
-       *   prefixes, and attribute serialization when `requireWellFormed` is `true`. These checks
-       *   are not implemented in this release.
+       * - when `requireWellFormed` is `true`, `DOMException` with code `INVALID_STATE_ERR`
+       *   is only thrown to prevent injection vectors, not for all the spec mandated checks.
        *
        * @throws {DOMException}
        * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and the CDATASection
-       * data contains `"]]>"`, or a Comment node's data contains `"-->"`.
-       * (On this 0.8.x branch, bare `"--"` in comment data does not throw — see
-       * `XMLSerializerOptions.requireWellFormed` for details.)
+       * data contains `"]]>"`, a Comment node's data contains `"-->"`, or a
+       * ProcessingInstruction's data contains `"?>"`.
+       * (On this 0.8.x branch, bare `"--"` in comment data does not throw!)
        * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
+       * @see https://w3c.github.io/DOM-Parsing/#xml-serialization
        * @see https://github.com/w3c/DOM-Parsing/issues/84
        */
       serializeToString(node: Node, isHtml?: boolean, nodeFilter?: (node: Node) => Node | null | undefined, options?: XMLSerializerOptions): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,10 +52,17 @@ declare module "@xmldom/xmldom" {
        *   is only thrown to prevent injection vectors, not for all the spec mandated checks.
        *
        * @throws {DOMException}
-       * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and the CDATASection
-       * data contains `"]]>"`, a Comment node's data contains `"-->"`, or a
-       * ProcessingInstruction's data contains `"?>"`.
-       * (On this 0.8.x branch, bare `"--"` in comment data does not throw!)
+       * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and:
+       * - a CDATASection node's data contains `"]]>"`,
+       * - a Comment node's data contains `"-->"` (bare `"--"` does not throw on this branch),
+       * - a ProcessingInstruction's data contains `"?>"`,
+       * - a DocumentType's `publicId` is non-empty and does not match the XML `PubidLiteral`
+       *   production,
+       * - a DocumentType's `systemId` is non-empty and does not match the XML `SystemLiteral`
+       *   production, or
+       * - a DocumentType's `internalSubset` contains `"]>"`.
+       * Note: xmldom does not enforce `readonly` on DocumentType fields — direct property
+       * writes succeed and are covered by the serializer-level checks above.
        * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
        * @see https://w3c.github.io/DOM-Parsing/#xml-serialization
        * @see https://github.com/w3c/DOM-Parsing/issues/84

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1936,43 +1936,56 @@ function importNode(doc,node,deep){
 //
 //var _relationMap = {firstChild:1,lastChild:1,previousSibling:1,nextSibling:1,
 //					attributes:1,childNodes:1,parentNode:1,documentElement:1,doctype,};
-function cloneNode(doc,node,deep){
-	var node2 = new node.constructor();
-	for (var n in node) {
-		if (Object.prototype.hasOwnProperty.call(node, n)) {
-			var v = node[n];
-			if (typeof v != "object") {
-				if (v != node2[n]) {
-					node2[n] = v;
+function cloneNode(doc, node, deep) {
+	var destRoot;
+	walkDOM(node, null, {
+		enter: function (srcNode, destParent) {
+			// 1. Create a blank node of the same type and copy all scalar own properties.
+			var destNode = new srcNode.constructor();
+			for (var n in srcNode) {
+				if (Object.prototype.hasOwnProperty.call(srcNode, n)) {
+					var v = srcNode[n];
+					if (typeof v != 'object') {
+						if (v != destNode[n]) {
+							destNode[n] = v;
+						}
+					}
 				}
 			}
-		}
-	}
-	if(node.childNodes){
-		node2.childNodes = new NodeList();
-	}
-	node2.ownerDocument = doc;
-	switch (node2.nodeType) {
-	case ELEMENT_NODE:
-		var attrs	= node.attributes;
-		var attrs2	= node2.attributes = new NamedNodeMap();
-		var len = attrs.length
-		attrs2._ownerElement = node2;
-		for(var i=0;i<len;i++){
-			node2.setAttributeNode(cloneNode(doc,attrs.item(i),true));
-		}
-		break;;
-	case ATTRIBUTE_NODE:
-		deep = true;
-	}
-	if(deep){
-		var child = node.firstChild;
-		while(child){
-			node2.appendChild(cloneNode(doc,child,deep));
-			child = child.nextSibling;
-		}
-	}
-	return node2;
+			if (srcNode.childNodes) {
+				destNode.childNodes = new NodeList();
+			}
+			destNode.ownerDocument = doc;
+			// 2. Handle node-type-specific setup.
+			//    Attributes are not DOM children, so they are cloned inline here
+			//    rather than by walkDOM descent.
+			//    ATTRIBUTE_NODE forces deep=true so its own children are walked.
+			var shouldDeep = deep;
+			switch (destNode.nodeType) {
+				case ELEMENT_NODE:
+					var attrs = srcNode.attributes;
+					var attrs2 = (destNode.attributes = new NamedNodeMap());
+					var len = attrs.length;
+					attrs2._ownerElement = destNode;
+					for (var i = 0; i < len; i++) {
+						destNode.setAttributeNode(cloneNode(doc, attrs.item(i), true));
+					}
+					break;
+				case ATTRIBUTE_NODE:
+					shouldDeep = true;
+			}
+			// 3. Attach to parent, or capture as the root of the cloned subtree.
+			if (destParent !== null) {
+				destParent.appendChild(destNode);
+			} else {
+				destRoot = destNode;
+			}
+			// 4. Return destNode as the context for children (causes walkDOM to descend),
+			//    or null to skip children (shallow clone).
+			return shouldDeep ? destNode : null;
+		},
+	});
+	return destRoot;
 }
 
 function __set__(object,key,value){

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -171,9 +171,10 @@ NodeList.prototype = {
 	item: function(index) {
 		return index >= 0 && index < this.length ? this[index] : null;
 	},
-	toString:function(isHTML,nodeFilter){
+	toString:function(isHTML,nodeFilter,options){
+		var requireWellFormed = options != null ? !!options.requireWellFormed : false;
 		for(var buf = [], i = 0;i<this.length;i++){
-			serializeToString(this[i],buf,isHTML,nodeFilter);
+			serializeToString(this[i],buf,isHTML,nodeFilter,null,requireWellFormed);
 		}
 		return buf.join('');
 	},
@@ -1484,22 +1485,33 @@ function XMLSerializer(){}
 /**
  * Returns the result of serializing `node` to XML.
  *
+ * When `options.requireWellFormed` is `true`, the serializer throws for content that would
+ * produce ill-formed XML.
+ *
  * __This implementation differs from the specification:__
  * - CDATASection nodes whose data contains `]]>` are serialized by splitting the section
  *   at each `]]>` occurrence (following W3C DOM Level 3 Core `split-cdata-sections`
- *   default behaviour). A configurable option is not yet implemented.
+ *   default behaviour) unless `requireWellFormed` is `true`.
+ * - W3C DOM Parsing §3.2.1.1 requires well-formedness checks on Element `localName`s,
+ *   prefixes, and attribute serialization when `requireWellFormed` is `true`. These checks
+ *   are **not implemented** in this release.
  *
  * @param {Node} node
  * @param {boolean} [isHtml]
  * @param {function} [nodeFilter]
+ * @param {Object} [options]
+ * @param {boolean} [options.requireWellFormed=false]
+ * When `true`, throws for content that would produce ill-formed XML.
  * @returns {string}
  * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
+ * @see https://github.com/w3c/DOM-Parsing/issues/84
  */
-XMLSerializer.prototype.serializeToString = function(node,isHtml,nodeFilter){
-	return nodeSerializeToString.call(node,isHtml,nodeFilter);
+XMLSerializer.prototype.serializeToString = function(node,isHtml,nodeFilter,options){
+	return nodeSerializeToString.call(node,isHtml,nodeFilter,options);
 }
 Node.prototype.toString = nodeSerializeToString;
-function nodeSerializeToString(isHtml,nodeFilter){
+function nodeSerializeToString(isHtml,nodeFilter,options){
+	var requireWellFormed = options != null ? !!options.requireWellFormed : false;
 	var buf = [];
 	var refNode = this.nodeType == 9 && this.documentElement || this;
 	var prefix = refNode.prefix;
@@ -1516,7 +1528,7 @@ function nodeSerializeToString(isHtml,nodeFilter){
 			]
 		}
 	}
-	serializeToString(this,buf,isHtml,nodeFilter,visibleNamespaces);
+	serializeToString(this,buf,isHtml,nodeFilter,visibleNamespaces,requireWellFormed);
 	//console.log('###',this.nodeType,uri,prefix,buf.join(''))
 	return buf.join('');
 }
@@ -1565,7 +1577,7 @@ function addSerializedAttribute(buf, qualifiedName, value) {
 	buf.push(' ', qualifiedName, '="', value.replace(/[<>&"\t\n\r]/g, _xmlEncoder), '"')
 }
 
-function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
+function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces,requireWellFormed){
 	if (!visibleNamespaces) {
 		visibleNamespaces = [];
 	}
@@ -1645,7 +1657,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 				addSerializedAttribute(buf, prefix ? 'xmlns:' + prefix : "xmlns", uri);
 				visibleNamespaces.push({ prefix: prefix, namespace:uri });
 			}
-			serializeToString(attr,buf,isHTML,nodeFilter,visibleNamespaces);
+			serializeToString(attr,buf,isHTML,nodeFilter,visibleNamespaces,requireWellFormed);
 		}
 
 		// add namespace for current node
@@ -1664,14 +1676,14 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 					if(child.data){
 						buf.push(child.data);
 					}else{
-						serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice());
+						serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice(), requireWellFormed);
 					}
 					child = child.nextSibling;
 				}
 			}else
 			{
 				while(child){
-					serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice());
+					serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice(), requireWellFormed);
 					child = child.nextSibling;
 				}
 			}
@@ -1686,7 +1698,7 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces){
 	case DOCUMENT_FRAGMENT_NODE:
 		var child = node.firstChild;
 		while(child){
-			serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice());
+			serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice(), requireWellFormed);
 			child = child.nextSibling;
 		}
 		return;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1684,209 +1684,231 @@ function addSerializedAttribute(buf, qualifiedName, value) {
 	buf.push(' ', qualifiedName, '="', value.replace(/[<>&"\t\n\r]/g, _xmlEncoder), '"')
 }
 
-function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces,requireWellFormed){
+function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, requireWellFormed) {
 	if (!visibleNamespaces) {
 		visibleNamespaces = [];
 	}
+	walkDOM(node, { ns: visibleNamespaces, isHTML: isHTML }, {
+		enter: function (n, ctx) {
+			var ns = ctx.ns;
+			var html = ctx.isHTML;
 
-	if(nodeFilter){
-		node = nodeFilter(node);
-		if(node){
-			if(typeof node == 'string'){
-				buf.push(node);
-				return;
-			}
-		}else{
-			return;
-		}
-		//buf.sort.apply(attrs, attributeSorter);
-	}
-
-	switch(node.nodeType){
-	case ELEMENT_NODE:
-		var attrs = node.attributes;
-		var len = attrs.length;
-		var child = node.firstChild;
-		var nodeName = node.tagName;
-
-		isHTML = NAMESPACE.isHTML(node.namespaceURI) || isHTML
-
-		var prefixedNodeName = nodeName
-		if (!isHTML && !node.prefix && node.namespaceURI) {
-			var defaultNS
-			// lookup current default ns from `xmlns` attribute
-			for (var ai = 0; ai < attrs.length; ai++) {
-				if (attrs.item(ai).name === 'xmlns') {
-					defaultNS = attrs.item(ai).value
-					break
-				}
-			}
-			if (!defaultNS) {
-				// lookup current default ns in visibleNamespaces
-				for (var nsi = visibleNamespaces.length - 1; nsi >= 0; nsi--) {
-					var namespace = visibleNamespaces[nsi]
-					if (namespace.prefix === '' && namespace.namespace === node.namespaceURI) {
-						defaultNS = namespace.namespace
-						break
+			if (nodeFilter) {
+				n = nodeFilter(n);
+				if (n) {
+					if (typeof n == 'string') {
+						buf.push(n);
+						return null;
 					}
+				} else {
+					return null;
 				}
 			}
-			if (defaultNS !== node.namespaceURI) {
-				for (var nsi = visibleNamespaces.length - 1; nsi >= 0; nsi--) {
-					var namespace = visibleNamespaces[nsi]
-					if (namespace.namespace === node.namespaceURI) {
-						if (namespace.prefix) {
-							prefixedNodeName = namespace.prefix + ':' + nodeName
+
+			switch (n.nodeType) {
+				case ELEMENT_NODE:
+					var attrs = n.attributes;
+					var len = attrs.length;
+					var nodeName = n.tagName;
+
+					html = NAMESPACE.isHTML(n.namespaceURI) || html;
+
+					var prefixedNodeName = nodeName;
+					if (!html && !n.prefix && n.namespaceURI) {
+						var defaultNS;
+						// lookup current default ns from `xmlns` attribute
+						for (var ai = 0; ai < attrs.length; ai++) {
+							if (attrs.item(ai).name === 'xmlns') {
+								defaultNS = attrs.item(ai).value;
+								break;
+							}
 						}
-						break
+						if (!defaultNS) {
+							// lookup current default ns in visibleNamespaces
+							for (var nsi = ns.length - 1; nsi >= 0; nsi--) {
+								var nsEntry = ns[nsi];
+								if (nsEntry.prefix === '' && nsEntry.namespace === n.namespaceURI) {
+									defaultNS = nsEntry.namespace;
+									break;
+								}
+							}
+						}
+						if (defaultNS !== n.namespaceURI) {
+							for (var nsi = ns.length - 1; nsi >= 0; nsi--) {
+								var nsEntry = ns[nsi];
+								if (nsEntry.namespace === n.namespaceURI) {
+									if (nsEntry.prefix) {
+										prefixedNodeName = nsEntry.prefix + ':' + nodeName;
+									}
+									break;
+								}
+							}
+						}
 					}
-				}
-			}
-		}
 
-		buf.push('<', prefixedNodeName);
+					buf.push('<', prefixedNodeName);
 
-		for(var i=0;i<len;i++){
-			// add namespaces for attributes
-			var attr = attrs.item(i);
-			if (attr.prefix == 'xmlns') {
-				visibleNamespaces.push({ prefix: attr.localName, namespace: attr.value });
-			}else if(attr.nodeName == 'xmlns'){
-				visibleNamespaces.push({ prefix: '', namespace: attr.value });
-			}
-		}
-
-		for(var i=0;i<len;i++){
-			var attr = attrs.item(i);
-			if (needNamespaceDefine(attr,isHTML, visibleNamespaces)) {
-				var prefix = attr.prefix||'';
-				var uri = attr.namespaceURI;
-				addSerializedAttribute(buf, prefix ? 'xmlns:' + prefix : "xmlns", uri);
-				visibleNamespaces.push({ prefix: prefix, namespace:uri });
-			}
-			serializeToString(attr,buf,isHTML,nodeFilter,visibleNamespaces,requireWellFormed);
-		}
-
-		// add namespace for current node
-		if (nodeName === prefixedNodeName && needNamespaceDefine(node, isHTML, visibleNamespaces)) {
-			var prefix = node.prefix||'';
-			var uri = node.namespaceURI;
-			addSerializedAttribute(buf, prefix ? 'xmlns:' + prefix : "xmlns", uri);
-			visibleNamespaces.push({ prefix: prefix, namespace:uri });
-		}
-
-		if(child || isHTML && !/^(?:meta|link|img|br|hr|input)$/i.test(nodeName)){
-			buf.push('>');
-			//if is cdata child node
-			if(isHTML && /^script$/i.test(nodeName)){
-				while(child){
-					if(child.data){
-						buf.push(child.data);
-					}else{
-						serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice(), requireWellFormed);
+					// Build a fresh namespace snapshot for this element's children.
+					// The slice prevents sibling elements from inheriting each other's declarations.
+					var childNs = ns.slice();
+					for (var i = 0; i < len; i++) {
+						var attr = attrs.item(i);
+						if (attr.prefix == 'xmlns') {
+							childNs.push({ prefix: attr.localName, namespace: attr.value });
+						} else if (attr.nodeName == 'xmlns') {
+							childNs.push({ prefix: '', namespace: attr.value });
+						}
 					}
-					child = child.nextSibling;
-				}
-			}else
-			{
-				while(child){
-					serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice(), requireWellFormed);
-					child = child.nextSibling;
-				}
+
+					for (var i = 0; i < len; i++) {
+						var attr = attrs.item(i);
+						if (needNamespaceDefine(attr, html, childNs)) {
+							var attrPrefix = attr.prefix || '';
+							var uri = attr.namespaceURI;
+							addSerializedAttribute(buf, attrPrefix ? 'xmlns:' + attrPrefix : 'xmlns', uri);
+							childNs.push({ prefix: attrPrefix, namespace: uri });
+						}
+						// Apply nodeFilter and serialize the attribute.
+						var filteredAttr = nodeFilter ? nodeFilter(attr) : attr;
+						if (filteredAttr) {
+							if (typeof filteredAttr === 'string') {
+								buf.push(filteredAttr);
+							} else {
+								addSerializedAttribute(buf, filteredAttr.name, filteredAttr.value);
+							}
+						}
+					}
+
+					// add namespace for current node
+					if (nodeName === prefixedNodeName && needNamespaceDefine(n, html, childNs)) {
+						var nodePrefix = n.prefix || '';
+						var uri = n.namespaceURI;
+						addSerializedAttribute(buf, nodePrefix ? 'xmlns:' + nodePrefix : 'xmlns', uri);
+						childNs.push({ prefix: nodePrefix, namespace: uri });
+					}
+
+					var child = n.firstChild;
+					if (child || html && !/^(?:meta|link|img|br|hr|input)$/i.test(nodeName)) {
+						buf.push('>');
+						if (html && /^script$/i.test(nodeName)) {
+							// Inline serialization for <script> children; return null to skip walkDOM descent.
+							while (child) {
+								if (child.data) {
+									buf.push(child.data);
+								} else {
+									serializeToString(child, buf, html, nodeFilter, childNs.slice(), requireWellFormed);
+								}
+								child = child.nextSibling;
+							}
+							buf.push('</', nodeName, '>');
+							return null;
+						}
+						// Return child context; walkDOM descends and exit emits the closing tag.
+						return { ns: childNs, isHTML: html, tag: prefixedNodeName };
+					} else {
+						buf.push('/>');
+						return null;
+					}
+
+				case DOCUMENT_NODE:
+				case DOCUMENT_FRAGMENT_NODE:
+					// Descend into children; exit is a no-op (tag is null).
+					return { ns: ns.slice(), isHTML: html, tag: null };
+
+				case ATTRIBUTE_NODE:
+					addSerializedAttribute(buf, n.name, n.value);
+					return null;
+
+				case TEXT_NODE:
+					/**
+					 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,
+					 * except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section.
+					 * If they are needed elsewhere, they must be escaped using either numeric character references or the strings
+					 * `&amp;` and `&lt;` respectively.
+					 * The right angle bracket (>) may be represented using the string " &gt; ", and must, for compatibility,
+					 * be escaped using either `&gt;` or a character reference when it appears in the string `]]>` in content,
+					 * when that string is not marking the end of a CDATA section.
+					 *
+					 * In the content of elements, character data is any string of characters
+					 * which does not contain the start-delimiter of any markup
+					 * and does not include the CDATA-section-close delimiter, `]]>`.
+					 *
+					 * @see https://www.w3.org/TR/xml/#NT-CharData
+					 * @see https://w3c.github.io/DOM-Parsing/#xml-serializing-a-text-node
+					 */
+					buf.push(n.data.replace(/[<&>]/g, _xmlEncoder));
+					return null;
+
+				case CDATA_SECTION_NODE:
+					if (requireWellFormed && n.data.indexOf(']]>') !== -1) {
+						throw new DOMException(INVALID_STATE_ERR, 'The CDATASection data contains "]]>"');
+					}
+					buf.push('<![CDATA[', n.data.replace(/]]>/g, ']]]]><![CDATA[>'), ']]>');
+					return null;
+
+				case COMMENT_NODE:
+					if (requireWellFormed && n.data.indexOf('-->') !== -1) {
+						throw new DOMException(INVALID_STATE_ERR, 'The comment node data contains "-->"');
+					}
+					buf.push('<!--', n.data, '-->');
+					return null;
+
+				case DOCUMENT_TYPE_NODE:
+					if (requireWellFormed) {
+						if (n.publicId && !/^("[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%']*"|'[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%'"]*')$/.test(n.publicId)) {
+							throw new DOMException(INVALID_STATE_ERR, 'DocumentType publicId is not a valid PubidLiteral');
+						}
+						if (n.systemId && !/^("[^"]*"|'[^']*')$/.test(n.systemId)) {
+							throw new DOMException(INVALID_STATE_ERR, 'DocumentType systemId is not a valid SystemLiteral');
+						}
+						if (n.internalSubset && n.internalSubset.indexOf(']>') !== -1) {
+							throw new DOMException(INVALID_STATE_ERR, 'DocumentType internalSubset contains "]>"');
+						}
+					}
+					var pubid = n.publicId;
+					var sysid = n.systemId;
+					buf.push('<!DOCTYPE ', n.name);
+					if (pubid) {
+						buf.push(' PUBLIC ', pubid);
+						if (sysid && sysid != '.') {
+							buf.push(' ', sysid);
+						}
+						buf.push('>');
+					} else if (sysid && sysid != '.') {
+						buf.push(' SYSTEM ', sysid, '>');
+					} else {
+						var sub = n.internalSubset;
+						if (sub) {
+							buf.push(' [', sub, ']');
+						}
+						buf.push('>');
+					}
+					return null;
+
+				case PROCESSING_INSTRUCTION_NODE:
+					if (requireWellFormed && n.data.indexOf('?>') !== -1) {
+						throw new DOMException(INVALID_STATE_ERR, 'The ProcessingInstruction data contains "?>"');
+					}
+					buf.push('<?', n.target, ' ', n.data, '?>');
+					return null;
+
+				case ENTITY_REFERENCE_NODE:
+					buf.push('&', n.nodeName, ';');
+					return null;
+
+				//case ENTITY_NODE:
+				//case NOTATION_NODE:
+				default:
+					buf.push('??', n.nodeName);
+					return null;
 			}
-			buf.push('</',prefixedNodeName,'>');
-		}else{
-			buf.push('/>');
-		}
-		// remove added visible namespaces
-		//visibleNamespaces.length = startVisibleNamespaces;
-		return;
-	case DOCUMENT_NODE:
-	case DOCUMENT_FRAGMENT_NODE:
-		var child = node.firstChild;
-		while(child){
-			serializeToString(child, buf, isHTML, nodeFilter, visibleNamespaces.slice(), requireWellFormed);
-			child = child.nextSibling;
-		}
-		return;
-	case ATTRIBUTE_NODE:
-		return addSerializedAttribute(buf, node.name, node.value);
-	case TEXT_NODE:
-		/**
-		 * The ampersand character (&) and the left angle bracket (<) must not appear in their literal form,
-		 * except when used as markup delimiters, or within a comment, a processing instruction, or a CDATA section.
-		 * If they are needed elsewhere, they must be escaped using either numeric character references or the strings
-		 * `&amp;` and `&lt;` respectively.
-		 * The right angle bracket (>) may be represented using the string " &gt; ", and must, for compatibility,
-		 * be escaped using either `&gt;` or a character reference when it appears in the string `]]>` in content,
-		 * when that string is not marking the end of a CDATA section.
-		 *
-		 * In the content of elements, character data is any string of characters
-		 * which does not contain the start-delimiter of any markup
-		 * and does not include the CDATA-section-close delimiter, `]]>`.
-		 *
-		 * @see https://www.w3.org/TR/xml/#NT-CharData
-		 * @see https://w3c.github.io/DOM-Parsing/#xml-serializing-a-text-node
-		 */
-		return buf.push(node.data
-			.replace(/[<&>]/g,_xmlEncoder)
-		);
-	case CDATA_SECTION_NODE:
-		if (requireWellFormed && node.data.indexOf(']]>') !== -1) {
-			throw new DOMException(INVALID_STATE_ERR, 'The CDATASection data contains "]]>"');
-		}
-		return buf.push('<![CDATA[', node.data.replace(/]]>/g, ']]]]><![CDATA[>'), ']]>');
-	case COMMENT_NODE:
-		if (requireWellFormed && node.data.indexOf('-->') !== -1) {
-			throw new DOMException(
-				INVALID_STATE_ERR,
-				'The comment node data contains "-->"'
-			);
-		}
-		return buf.push( "<!--",node.data,"-->");
-	case DOCUMENT_TYPE_NODE:
-		if (requireWellFormed) {
-			if (node.publicId && !/^("[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%']*"|'[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%'"]*')$/.test(node.publicId)) {
-				throw new DOMException(INVALID_STATE_ERR, 'DocumentType publicId is not a valid PubidLiteral');
+		},
+		exit: function (n, childCtx) {
+			if (childCtx && childCtx.tag) {
+				buf.push('</', childCtx.tag, '>');
 			}
-			if (node.systemId && !/^("[^"]*"|'[^']*')$/.test(node.systemId)) {
-				throw new DOMException(INVALID_STATE_ERR, 'DocumentType systemId is not a valid SystemLiteral');
-			}
-			if (node.internalSubset && node.internalSubset.indexOf(']>') !== -1) {
-				throw new DOMException(INVALID_STATE_ERR, 'DocumentType internalSubset contains "]>"');
-			}
-		}
-		var pubid = node.publicId;
-		var sysid = node.systemId;
-		buf.push('<!DOCTYPE ',node.name);
-		if(pubid){
-			buf.push(' PUBLIC ', pubid);
-			if (sysid && sysid!='.') {
-				buf.push(' ', sysid);
-			}
-			buf.push('>');
-		}else if(sysid && sysid!='.'){
-			buf.push(' SYSTEM ', sysid, '>');
-		}else{
-			var sub = node.internalSubset;
-			if(sub){
-				buf.push(" [",sub,"]");
-			}
-			buf.push(">");
-		}
-		return;
-	case PROCESSING_INSTRUCTION_NODE:
-		if (requireWellFormed && node.data.indexOf('?>') !== -1) {
-			throw new DOMException(INVALID_STATE_ERR, 'The ProcessingInstruction data contains "?>"');
-		}
-		return buf.push( "<?",node.target," ",node.data,"?>");
-	case ENTITY_REFERENCE_NODE:
-		return buf.push( '&',node.nodeName,';');
-	//case ENTITY_NODE:
-	//case NOTATION_NODE:
-	default:
-		buf.push('??',node.nodeName);
-	}
+		},
+	});
 }
 /**
  * Imports a node from a different document into `doc`, creating a new copy.

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1888,50 +1888,43 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces,requireW
 		buf.push('??',node.nodeName);
 	}
 }
-function importNode(doc,node,deep){
-	var node2;
-	switch (node.nodeType) {
-	case ELEMENT_NODE:
-		node2 = node.cloneNode(false);
-		node2.ownerDocument = doc;
-		//var attrs = node2.attributes;
-		//var len = attrs.length;
-		//for(var i=0;i<len;i++){
-			//node2.setAttributeNodeNS(importNode(doc,attrs.item(i),deep));
-		//}
-	case DOCUMENT_FRAGMENT_NODE:
-		break;
-	case ATTRIBUTE_NODE:
-		deep = true;
-		break;
-	//case ENTITY_REFERENCE_NODE:
-	//case PROCESSING_INSTRUCTION_NODE:
-	////case TEXT_NODE:
-	//case CDATA_SECTION_NODE:
-	//case COMMENT_NODE:
-	//	deep = false;
-	//	break;
-	//case DOCUMENT_NODE:
-	//case DOCUMENT_TYPE_NODE:
-	//cannot be imported.
-	//case ENTITY_NODE:
-	//case NOTATION_NODE：
-	//can not hit in level3
-	//default:throw e;
-	}
-	if(!node2){
-		node2 = node.cloneNode(false);//false
-	}
-	node2.ownerDocument = doc;
-	node2.parentNode = null;
-	if(deep){
-		var child = node.firstChild;
-		while(child){
-			node2.appendChild(importNode(doc,child,deep));
-			child = child.nextSibling;
-		}
-	}
-	return node2;
+/**
+ * Imports a node from a different document into `doc`, creating a new copy.
+ * Delegates to {@link walkDOM} for traversal. Each node in the subtree is shallow-cloned,
+ * stamped with `doc` as its `ownerDocument`, and detached (`parentNode` set to `null`).
+ * Children are imported recursively when `deep` is `true`; for {@link Attr} nodes `deep` is
+ * always forced to `true`
+ * because an attribute's value lives in a child text node.
+ *
+ * @param {Document} doc
+ * The document that will own the imported node.
+ * @param {Node} node
+ * The node to import.
+ * @param {boolean} deep
+ * If `true`, descendants are imported recursively.
+ * @returns {Node}
+ * The newly imported node, now owned by `doc`.
+ */
+function importNode(doc, node, deep) {
+	var destRoot;
+	walkDOM(node, null, {
+		enter: function (srcNode, destParent) {
+			// Shallow-clone the node and stamp it into the target document.
+			var destNode = srcNode.cloneNode(false);
+			destNode.ownerDocument = doc;
+			destNode.parentNode = null;
+			// capture as the root of the imported subtree or attach to parent.
+			if (destParent === null) {
+				destRoot = destNode;
+			} else {
+				destParent.appendChild(destNode);
+			}
+			// ATTRIBUTE_NODE must always be imported deeply: its value lives in a child text node.
+			var shouldDeep = srcNode.nodeType === ATTRIBUTE_NODE || deep;
+			return shouldDeep ? destNode : null;
+		},
+	});
+	return destRoot;
 }
 //
 //var _relationMap = {firstChild:1,lastChild:1,previousSibling:1,nextSibling:1,

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -609,7 +609,61 @@ function _visitNode(node,callback){
     }
 }
 
+/**
+ * Depth-first pre/post-order DOM tree walker.
+ *
+ * Visits every node in the subtree rooted at `node`. For each node:
+ *
+ * 1. Calls `callbacks.enter(node, context)` before descending into the node's children. The
+ * return value becomes the `context` passed to each child's `enter` call and to the matching
+ * `exit` call.
+ * 2. If `enter` returns `null` or `undefined`, the node's children are skipped;
+ * sibling traversal continues normally.
+ * 3. If `enter` returns `walkDOM.STOP`, the entire traversal is aborted immediately — no
+ * further `enter` or `exit` calls are made.
+ * 4. `firstChild` is read **after** `enter` returns, so `enter` may safely modify the node's
+ * child list before the walker descends.
+ * 5. Calls `callbacks.exit(node, context)` (if provided) after all of a node's children have
+ * been visited, passing the same `context` that `enter`
+ * returned for that node.
+ *
+ * Note: this implementation is recursive. It will be converted to an iterative form in a later
+ * step to eliminate stack-overflow risk on very deep trees.
+ *
+ * @param {Node} node
+ * Root of the subtree to walk.
+ * @param {*} context
+ * Initial context value passed to the root node's `enter`.
+ * @param {{ enter: function(Node, *): *, exit?: function(Node, *): void }} callbacks
+ * @returns {void | walkDOM.STOP}
+ */
+function walkDOM(node, context, callbacks) {
+	var childContext = callbacks.enter(node, context);
+	if (childContext === walkDOM.STOP) {
+		return walkDOM.STOP;
+	}
+	if (childContext !== null && childContext !== undefined) {
+		var child = node.firstChild;
+		while (child) {
+			var next = child.nextSibling;
+			if (walkDOM(child, childContext, callbacks) === walkDOM.STOP) {
+				return walkDOM.STOP;
+			}
+			child = next;
+		}
+	}
+	if (callbacks.exit) {
+		callbacks.exit(node, childContext);
+	}
+}
 
+/**
+ * Sentinel value returned from a `walkDOM` `enter` callback to abort the entire traversal
+ * immediately.
+ *
+ * @type {symbol}
+ */
+walkDOM.STOP = Symbol('walkDOM.STOP');
 
 function Document(){
 	this.ownerDocument = this;
@@ -1996,5 +2050,6 @@ try{
 	exports.Element = Element;
 	exports.Node = Node;
 	exports.NodeList = NodeList;
+	exports.walkDOM = walkDOM;
 	exports.XMLSerializer = XMLSerializer;
 //}

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -617,14 +617,17 @@ function _visitNode(node, callback) {
  * sibling traversal continues normally.
  * 3. If `enter` returns `walkDOM.STOP`, the entire traversal is aborted immediately — no
  * further `enter` or `exit` calls are made.
- * 4. `firstChild` is read **after** `enter` returns, so `enter` may safely modify the node's
- * child list before the walker descends.
+ * 4. `lastChild` and `previousSibling` are read **after** `enter` returns, so `enter` may
+ * safely modify the node's own child list before the walker descends. Modifying siblings of
+ * the current node or any other part of the tree produces unpredictable results: nodes already
+ * queued on the stack are visited regardless of DOM changes, and newly inserted nodes outside
+ * the current child list are never visited.
  * 5. Calls `callbacks.exit(node, context)` (if provided) after all of a node's children have
  * been visited, passing the same `context` that `enter`
  * returned for that node.
  *
- * Note: this implementation is recursive. It will be converted to an iterative form in a later
- * step to eliminate stack-overflow risk on very deep trees.
+ * This implementation uses an explicit stack and does not recurse — it is safe on arbitrarily
+ * deep trees.
  *
  * @param {Node} node
  * Root of the subtree to walk.
@@ -632,24 +635,39 @@ function _visitNode(node, callback) {
  * Initial context value passed to the root node's `enter`.
  * @param {{ enter: function(Node, *): *, exit?: function(Node, *): void }} callbacks
  * @returns {void | walkDOM.STOP}
+ * @see ../docs/walk-dom.md.
  */
 function walkDOM(node, context, callbacks) {
-	var childContext = callbacks.enter(node, context);
-	if (childContext === walkDOM.STOP) {
-		return walkDOM.STOP;
-	}
-	if (childContext !== null && childContext !== undefined) {
-		var child = node.firstChild;
-		while (child) {
-			var next = child.nextSibling;
-			if (walkDOM(child, childContext, callbacks) === walkDOM.STOP) {
+	// Each stack frame is {node, context, phase}:
+	//   walkDOM.ENTER — call enter, then push children
+	//   walkDOM.EXIT  — call exit
+	var stack = [{ node: node, context: context, phase: walkDOM.ENTER }];
+	while (stack.length > 0) {
+		var frame = stack.pop();
+		if (frame.phase === walkDOM.ENTER) {
+			var childContext = callbacks.enter(frame.node, frame.context);
+			if (childContext === walkDOM.STOP) {
 				return walkDOM.STOP;
 			}
-			child = next;
+			// Push exit frame before children so it fires after all children are processed (Last In First Out)
+			stack.push({ node: frame.node, context: childContext, phase: walkDOM.EXIT });
+			if (childContext === null || childContext === undefined) {
+				continue; // skip children
+			}
+			// lastChild is read after enter returns, so enter may modify the child list.
+			var child = frame.node.lastChild;
+			// Traverse from lastChild backwards so that pushing onto the stack
+			// naturally yields firstChild on top (processed first).
+			while (child) {
+				stack.push({ node: child, context: childContext, phase: walkDOM.ENTER });
+				child = child.previousSibling;
+			}
+		} else {
+			// frame.phase === walkDOM.EXIT
+			if (callbacks.exit) {
+				callbacks.exit(frame.node, frame.context);
+			}
 		}
-	}
-	if (callbacks.exit) {
-		callbacks.exit(node, childContext);
 	}
 }
 
@@ -660,6 +678,20 @@ function walkDOM(node, context, callbacks) {
  * @type {symbol}
  */
 walkDOM.STOP = Symbol('walkDOM.STOP');
+/**
+ * Phase constant for a stack frame that has not yet been visited.
+ * The `enter` callback is called and children are scheduled.
+ *
+ * @type {number}
+ */
+walkDOM.ENTER = 0;
+/**
+ * Phase constant for a stack frame whose subtree has been fully visited.
+ * The `exit` callback is called.
+ *
+ * @type {number}
+ */
+walkDOM.EXIT = 1;
 
 function Document(){
 	this.ownerDocument = this;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -420,13 +420,28 @@ DOMImplementation.prototype = {
 	/**
 	 * Returns a doctype, with the given `qualifiedName`, `publicId`, and `systemId`.
 	 *
-	 * __This behavior is slightly different from the in the specs__:
+	 * __This implementation differs from the specification:__
 	 * - this implementation is not validating names or qualified names
 	 *   (when parsing XML strings, the SAX parser takes care of that)
 	 *
+	 * Note: `internalSubset` can only be introduced via a direct property write to `node.internalSubset` after creation.
+	 * Creation-time validation of `publicId`, `systemId` is not enforced.
+	 * The serializer-level check covers all mutation vectors, including direct property writes.
+	 * `internalSubset` is only serialized as `[ ... ]` when both `publicId` and `systemId` are
+	 * absent (empty or `'.'`) — if either external identifier is present, `internalSubset` is
+	 * silently omitted from the serialized output.
+	 *
 	 * @param {string} qualifiedName
 	 * @param {string} [publicId]
+	 * The external subset public identifier. Stored verbatim including surrounding quotes.
+	 * When serialized with `requireWellFormed: true` (via the 4th-parameter options object),
+	 * throws `DOMException` with code `INVALID_STATE_ERR` if the value is non-empty and does
+	 * not match the XML `PubidLiteral` production (W3C DOM Parsing §3.2.1.3; XML 1.0 [12]).
 	 * @param {string} [systemId]
+	 * The external subset system identifier. Stored verbatim including surrounding quotes.
+	 * When serialized with `requireWellFormed: true`, throws `DOMException` with code
+	 * `INVALID_STATE_ERR` if the value is non-empty and does not match the XML `SystemLiteral`
+	 * production (W3C DOM Parsing §3.2.1.3; XML 1.0 [11]).
 	 * @returns {DocumentType} which can either be used with `DOMImplementation.createDocument` upon document creation
 	 * 				  or can be put into the document via methods like `Node.insertBefore()` or `Node.replaceChild()`
 	 *
@@ -1467,6 +1482,19 @@ CDATASection.prototype = {
 _extends(CDATASection,CharacterData);
 
 
+/**
+ * Represents a DocumentType node (the `<!DOCTYPE ...>` declaration).
+ *
+ * `publicId`, `systemId`, and `internalSubset` are plain own-property assignments.
+ * xmldom does not enforce the `readonly` constraint declared by the WHATWG DOM spec —
+ * direct property writes succeed silently. Values are serialized verbatim when
+ * `requireWellFormed` is false (the default). When the serializer is invoked with
+ * `requireWellFormed: true` (via the 4th-parameter options object), it validates each
+ * field and throws `DOMException` with code `INVALID_STATE_ERR` on invalid values.
+ *
+ * @class
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/DocumentType MDN
+ */
 function DocumentType() {
 };
 DocumentType.prototype.nodeType = DOCUMENT_TYPE_NODE;
@@ -1520,10 +1548,17 @@ function XMLSerializer(){}
  * When `true`, throws for content that would produce ill-formed XML.
  * @returns {string}
  * @throws {DOMException}
- * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and the CDATASection
- * data contains `"]]>"`, a Comment node's data contains `"-->"`, or a
- * ProcessingInstruction's data contains `"?>"`.
- * (On this 0.8.x branch, bare `"--"` in comment data does not throw!)
+ * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and:
+ * - a CDATASection node's data contains `"]]>"`,
+ * - a Comment node's data contains `"-->"` (bare `"--"` does not throw on this branch),
+ * - a ProcessingInstruction's data contains `"?>"`,
+ * - a DocumentType's `publicId` is non-empty and does not match the XML `PubidLiteral`
+ *   production,
+ * - a DocumentType's `systemId` is non-empty and does not match the XML `SystemLiteral`
+ *   production, or
+ * - a DocumentType's `internalSubset` contains `"]>"`.
+ * Note: xmldom does not enforce `readonly` on DocumentType fields — direct property
+ * writes succeed and are covered by the serializer-level checks above.
  * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
  * @see https://w3c.github.io/DOM-Parsing/#xml-serialization
  * @see https://github.com/w3c/DOM-Parsing/issues/84
@@ -1760,6 +1795,17 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces,requireW
 		}
 		return buf.push( "<!--",node.data,"-->");
 	case DOCUMENT_TYPE_NODE:
+		if (requireWellFormed) {
+			if (node.publicId && !/^("[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%']*"|'[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%'"]*')$/.test(node.publicId)) {
+				throw new DOMException(INVALID_STATE_ERR, 'DocumentType publicId is not a valid PubidLiteral');
+			}
+			if (node.systemId && !/^("[^"]*"|'[^']*')$/.test(node.systemId)) {
+				throw new DOMException(INVALID_STATE_ERR, 'DocumentType systemId is not a valid SystemLiteral');
+			}
+			if (node.internalSubset && node.internalSubset.indexOf(']>') !== -1) {
+				throw new DOMException(INVALID_STATE_ERR, 'DocumentType internalSubset contains "]>"');
+			}
+		}
 		var pubid = node.publicId;
 		var sysid = node.systemId;
 		buf.push('<!DOCTYPE ',node.name);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1503,6 +1503,9 @@ function XMLSerializer(){}
  * @param {boolean} [options.requireWellFormed=false]
  * When `true`, throws for content that would produce ill-formed XML.
  * @returns {string}
+ * @throws {DOMException}
+ * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and the CDATASection
+ * data contains `"]]>"`.
  * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
  * @see https://github.com/w3c/DOM-Parsing/issues/84
  */
@@ -1725,6 +1728,9 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces,requireW
 			.replace(/[<&>]/g,_xmlEncoder)
 		);
 	case CDATA_SECTION_NODE:
+		if (requireWellFormed && node.data.indexOf(']]>') !== -1) {
+			throw new DOMException(INVALID_STATE_ERR, 'The CDATASection data contains "]]>"');
+		}
 		return buf.push('<![CDATA[', node.data.replace(/]]>/g, ']]]]><![CDATA[>'), ']]>');
 	case COMMENT_NODE:
 		return buf.push( "<!--",node.data,"-->");

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -595,18 +595,14 @@ copy(NodeType,Node);
 copy(NodeType,Node.prototype);
 
 /**
- * @param callback return true for continue,false for break
- * @return boolean true: break visit;
+ * @param {Node} node
+ * Root of the subtree to visit.
+ * @param {function(Node): boolean} callback
+ * Called for each node in depth-first pre-order. Return a truthy value to stop traversal early.
+ * @return {boolean} `true` if traversal was aborted by the callback, `false` otherwise.
  */
-function _visitNode(node,callback){
-	if(callback(node)){
-		return true;
-	}
-	if(node = node.firstChild){
-		do{
-			if(_visitNode(node,callback)){return true}
-        }while(node=node.nextSibling)
-    }
+function _visitNode(node, callback) {
+	return walkDOM(node, null, { enter: function (n) { return callback(n) ? walkDOM.STOP : true; } }) === walkDOM.STOP;
 }
 
 /**

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1988,48 +1988,54 @@ try{
 			}
 		});
 
-		Object.defineProperty(Node.prototype,'textContent',{
-			get:function(){
-				return getTextContent(this);
+		/**
+		 * The text content of this node and its descendants.
+		 *
+		 * Setting `textContent` on an element or document fragment replaces all child nodes with a
+		 * single text node; on other nodes it sets `data`, `value`, and `nodeValue` directly.
+		 *
+		 * @type {string | null}
+		 * @see {@link https://dom.spec.whatwg.org/#dom-node-textcontent}
+		 */
+		Object.defineProperty(Node.prototype, 'textContent', {
+			get: function () {
+				if (this.nodeType === ELEMENT_NODE || this.nodeType === DOCUMENT_FRAGMENT_NODE) {
+					var buf = [];
+					walkDOM(this, null, {
+						enter: function (n) {
+							if (n.nodeType === ELEMENT_NODE || n.nodeType === DOCUMENT_FRAGMENT_NODE) {
+								return true; // enter children
+							}
+							if (n.nodeType === PROCESSING_INSTRUCTION_NODE || n.nodeType === COMMENT_NODE) {
+								return null; // excluded from text content
+							}
+							buf.push(n.nodeValue);
+						},
+					});
+					return buf.join('');
+				}
+				return this.nodeValue;
 			},
 
-			set:function(data){
-				switch(this.nodeType){
-				case ELEMENT_NODE:
-				case DOCUMENT_FRAGMENT_NODE:
-					while(this.firstChild){
-						this.removeChild(this.firstChild);
-					}
-					if(data || String(data)){
-						this.appendChild(this.ownerDocument.createTextNode(data));
-					}
-					break;
+			set: function (data) {
+				switch (this.nodeType) {
+					case ELEMENT_NODE:
+					case DOCUMENT_FRAGMENT_NODE:
+						while (this.firstChild) {
+							this.removeChild(this.firstChild);
+						}
+						if (data || String(data)) {
+							this.appendChild(this.ownerDocument.createTextNode(data));
+						}
+						break;
 
-				default:
-					this.data = data;
-					this.value = data;
-					this.nodeValue = data;
+					default:
+						this.data = data;
+						this.value = data;
+						this.nodeValue = data;
 				}
-			}
+			},
 		})
-
-		function getTextContent(node){
-			switch(node.nodeType){
-			case ELEMENT_NODE:
-			case DOCUMENT_FRAGMENT_NODE:
-				var buf = [];
-				node = node.firstChild;
-				while(node){
-					if(node.nodeType!==7 && node.nodeType !==8){
-						buf.push(getTextContent(node));
-					}
-					node = node.nextSibling;
-				}
-				return buf.join('');
-			default:
-				return node.nodeValue;
-			}
-		}
 
 		__set__ = function(object,key,value){
 			//console.log(value)

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1506,6 +1506,11 @@ function XMLSerializer(){}
  * @throws {DOMException}
  * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and the CDATASection
  * data contains `"]]>"`.
+ * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and a Comment node's
+ * data contains `"-->"` (the injection sequence that terminates a comment and allows
+ * arbitrary XML to follow). Comments whose data contains `"--"` but not `"-->"` are
+ * accepted — the 0.8.x parser does not validate bare `"--"` inside comment content,
+ * so throwing would break a previously-working round-trip.
  * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
  * @see https://github.com/w3c/DOM-Parsing/issues/84
  */
@@ -1733,6 +1738,12 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces,requireW
 		}
 		return buf.push('<![CDATA[', node.data.replace(/]]>/g, ']]]]><![CDATA[>'), ']]>');
 	case COMMENT_NODE:
+		if (requireWellFormed && node.data.indexOf('-->') !== -1) {
+			throw new DOMException(
+				INVALID_STATE_ERR,
+				'The comment node data contains "-->"'
+			);
+		}
 		return buf.push( "<!--",node.data,"-->");
 	case DOCUMENT_TYPE_NODE:
 		var pubid = node.publicId;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1219,6 +1219,23 @@ Document.prototype = {
 		node.appendData(data)
 		return node;
 	},
+	/**
+	 * Returns a ProcessingInstruction node whose target is target and data is data.
+	 *
+	 * __This implementation differs from the specification:__
+	 * - it does not do any input validation on the arguments and doesn't throw "InvalidCharacterError".
+	 *
+	 * Note: When the resulting document is serialized with `requireWellFormed: true`, the
+	 * serializer throws with code `INVALID_STATE_ERR` if `.data` contains `?>` (W3C DOM Parsing
+	 * §3.2.1.7). Without that option the data is emitted verbatim.
+	 *
+	 * @param {string} target
+	 * @param {string} data
+	 * @returns {ProcessingInstruction}
+	 * @see https://developer.mozilla.org/docs/Web/API/Document/createProcessingInstruction
+	 * @see https://dom.spec.whatwg.org/#dom-document-createprocessinginstruction
+	 * @see https://www.w3.org/TR/DOM-Parsing/#dfn-concept-serialize-xml §3.2.1.7
+	 */
 	createProcessingInstruction :	function(target,data){
 		var node = new ProcessingInstruction();
 		node.ownerDocument = this;
@@ -1492,9 +1509,8 @@ function XMLSerializer(){}
  * - CDATASection nodes whose data contains `]]>` are serialized by splitting the section
  *   at each `]]>` occurrence (following W3C DOM Level 3 Core `split-cdata-sections`
  *   default behaviour) unless `requireWellFormed` is `true`.
- * - W3C DOM Parsing §3.2.1.1 requires well-formedness checks on Element `localName`s,
- *   prefixes, and attribute serialization when `requireWellFormed` is `true`. These checks
- *   are **not implemented** in this release.
+ * - when `requireWellFormed` is `true`, `DOMException` with code `INVALID_STATE_ERR`
+ *   is only thrown to prevent injection vectors, not for all the spec mandated checks.
  *
  * @param {Node} node
  * @param {boolean} [isHtml]
@@ -1505,13 +1521,11 @@ function XMLSerializer(){}
  * @returns {string}
  * @throws {DOMException}
  * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and the CDATASection
- * data contains `"]]>"`.
- * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and a Comment node's
- * data contains `"-->"` (the injection sequence that terminates a comment and allows
- * arbitrary XML to follow). Comments whose data contains `"--"` but not `"-->"` are
- * accepted — the 0.8.x parser does not validate bare `"--"` inside comment content,
- * so throwing would break a previously-working round-trip.
+ * data contains `"]]>"`, a Comment node's data contains `"-->"`, or a
+ * ProcessingInstruction's data contains `"?>"`.
+ * (On this 0.8.x branch, bare `"--"` in comment data does not throw!)
  * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
+ * @see https://w3c.github.io/DOM-Parsing/#xml-serialization
  * @see https://github.com/w3c/DOM-Parsing/issues/84
  */
 XMLSerializer.prototype.serializeToString = function(node,isHtml,nodeFilter,options){
@@ -1766,6 +1780,9 @@ function serializeToString(node,buf,isHTML,nodeFilter,visibleNamespaces,requireW
 		}
 		return;
 	case PROCESSING_INSTRUCTION_NODE:
+		if (requireWellFormed && node.data.indexOf('?>') !== -1) {
+			throw new DOMException(INVALID_STATE_ERR, 'The ProcessingInstruction data contains "?>"');
+		}
 		return buf.push( "<?",node.target," ",node.data,"?>");
 	case ENTITY_REFERENCE_NODE:
 		return buf.push( '&',node.nodeName,';');

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -172,7 +172,7 @@ NodeList.prototype = {
 		return index >= 0 && index < this.length ? this[index] : null;
 	},
 	toString:function(isHTML,nodeFilter,options){
-		var requireWellFormed = options != null ? !!options.requireWellFormed : false;
+		var requireWellFormed = !!options && !!options.requireWellFormed;
 		for(var buf = [], i = 0;i<this.length;i++){
 			serializeToString(this[i],buf,isHTML,nodeFilter,null,requireWellFormed);
 		}
@@ -1568,7 +1568,7 @@ XMLSerializer.prototype.serializeToString = function(node,isHtml,nodeFilter,opti
 }
 Node.prototype.toString = nodeSerializeToString;
 function nodeSerializeToString(isHtml,nodeFilter,options){
-	var requireWellFormed = options != null ? !!options.requireWellFormed : false;
+	var requireWellFormed = !!options && !!options.requireWellFormed;
 	var buf = [];
 	var refNode = this.nodeType == 9 && this.documentElement || this;
 	var prefix = refNode.prefix;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -508,18 +508,44 @@ Node.prototype = {
 		return cloneNode(this.ownerDocument||this,this,deep);
 	},
 	// Modified in DOM Level 2:
-	normalize:function(){
-		var child = this.firstChild;
-		while(child){
-			var next = child.nextSibling;
-			if(next && next.nodeType == TEXT_NODE && child.nodeType == TEXT_NODE){
-				this.removeChild(next);
-				child.appendData(next.data);
-			}else{
-				child.normalize();
-				child = next;
-			}
-		}
+	/**
+	 * Puts the specified node and all of its subtree into a "normalized" form. In a normalized
+	 * subtree, no text nodes in the subtree are empty and there are no adjacent text nodes.
+	 *
+	 * Specifically, this method merges any adjacent text nodes (i.e., nodes for which `nodeType`
+	 * is `TEXT_NODE`) into a single node with the combined data. It also removes any empty text
+	 * nodes.
+	 *
+	 * This method iteratively traverses all child nodes to normalize all descendant nodes within
+	 * the subtree.
+	 *
+	 * @throws {DOMException}
+	 * May throw a DOMException if operations within removeChild or appendData (which are
+	 * potentially invoked in this method) do not meet their specific constraints.
+	 * @see {@link Node.removeChild}
+	 * @see {@link CharacterData.appendData}
+	 * @see ../docs/walk-dom.md.
+	 */
+	normalize: function () {
+		walkDOM(this, null, {
+			enter: function (node) {
+				// Merge adjacent text children of node before walkDOM schedules them.
+				// walkDOM reads lastChild/previousSibling after enter returns, so the
+				// surviving post-merge children are what it descends into.
+				var child = node.firstChild;
+				while (child) {
+					var next = child.nextSibling;
+					if (next !== null && next.nodeType === TEXT_NODE && child.nodeType === TEXT_NODE) {
+						node.removeChild(next);
+						child.appendData(next.data);
+						// Do not advance child: re-check new nextSibling for another text run
+					} else {
+						child = next;
+					}
+				}
+				return true; // descend into surviving children
+			},
+		});
 	},
   	// Introduced in DOM Level 2:
 	isSupported:function(feature, version){

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
 		"index.d.ts",
 		"lib"
 	],
+	"config": {
+		"test_stack_size": 256
+	},
 	"scripts": {
 		"lint": "eslint lib test",
 		"format": "prettier --write test",
@@ -35,7 +38,7 @@
 		"start": "nodemon --watch package.json --watch lib --watch test --exec 'npm --silent run test && npm --silent run lint'",
 		"stryker": "stryker run",
 		"stryker:dry-run": "stryker run -m '' --reporters progress",
-		"test": "jest",
+		"test": "node --stack-size=$npm_package_config_test_stack_size ./node_modules/.bin/jest",
 		"testrelease": "npm test && eslint lib",
 		"version": "./changelog-has-version.sh",
 		"release": "np --no-yarn --test-script testrelease --branch release-0.8.x patch"

--- a/test/dom/node.test.js
+++ b/test/dom/node.test.js
@@ -264,4 +264,66 @@ describe('Node.prototype', () => {
 			expect(imported.ownerDocument).toBe(dstDoc)
 		})
 	})
+	describe('normalize', () => {
+		let doc
+		beforeEach(() => {
+			doc = new DOMImplementation().createDocument(null, 'root')
+		})
+
+		test('merges two adjacent text nodes into one', () => {
+			const el = doc.createElement('el')
+			el.appendChild(doc.createTextNode('foo'))
+			el.appendChild(doc.createTextNode('bar'))
+			el.normalize()
+			expect(el.childNodes.length).toBe(1)
+			expect(el.firstChild.nodeValue).toBe('foobar')
+		})
+
+		test('merges a run of three or more adjacent text nodes', () => {
+			const el = doc.createElement('el')
+			el.appendChild(doc.createTextNode('a'))
+			el.appendChild(doc.createTextNode('b'))
+			el.appendChild(doc.createTextNode('c'))
+			el.normalize()
+			expect(el.childNodes.length).toBe(1)
+			expect(el.firstChild.nodeValue).toBe('abc')
+		})
+
+		test('does not merge text nodes separated by an element', () => {
+			const el = doc.createElement('el')
+			el.appendChild(doc.createTextNode('before'))
+			el.appendChild(doc.createElement('mid'))
+			el.appendChild(doc.createTextNode('after'))
+			el.normalize()
+			expect(el.childNodes.length).toBe(3)
+			expect(el.firstChild.nodeValue).toBe('before')
+			expect(el.lastChild.nodeValue).toBe('after')
+		})
+
+		test('normalizes text nodes at multiple levels of nesting', () => {
+			const parent = doc.createElement('parent')
+			const child = doc.createElement('child')
+			child.appendChild(doc.createTextNode('x'))
+			child.appendChild(doc.createTextNode('y'))
+			parent.appendChild(child)
+			parent.normalize()
+			expect(child.childNodes.length).toBe(1)
+			expect(child.firstChild.nodeValue).toBe('xy')
+		})
+
+		test('is a no-op on an already-normalized tree', () => {
+			const el = doc.createElement('el')
+			el.appendChild(doc.createTextNode('single'))
+			el.normalize()
+			expect(el.childNodes.length).toBe(1)
+			expect(el.firstChild.nodeValue).toBe('single')
+		})
+
+		test('is a no-op on a tree with no text nodes', () => {
+			const el = doc.createElement('el')
+			el.appendChild(doc.createElement('child'))
+			el.normalize()
+			expect(el.childNodes.length).toBe(1)
+		})
+	})
 })

--- a/test/dom/node.test.js
+++ b/test/dom/node.test.js
@@ -176,4 +176,92 @@ describe('Node.prototype', () => {
 			expect(clone.firstChild.nodeValue).toBe('a')
 		})
 	})
+
+	describe('importNode', () => {
+		const impl2 = new DOMImplementation()
+		const srcDoc = impl2.createDocument(null, '')
+		const dstDoc = impl2.createDocument(null, '')
+
+		test('shallow import does not copy children', () => {
+			const el = srcDoc.createElement('root')
+			el.appendChild(srcDoc.createElement('child'))
+			const imported = dstDoc.importNode(el, false)
+			expect(imported.childNodes.length).toBe(0)
+		})
+		test('deep import copies all descendants', () => {
+			const el = srcDoc.createElement('root')
+			el.appendChild(srcDoc.createElement('child'))
+			const imported = dstDoc.importNode(el, true)
+			expect(imported.childNodes.length).toBe(1)
+			expect(imported.firstChild.nodeName).toBe('child')
+		})
+		test('ownerDocument of imported node is the target document', () => {
+			const el = srcDoc.createElement('el')
+			const imported = dstDoc.importNode(el, false)
+			expect(imported.ownerDocument).toBe(dstDoc)
+		})
+		test('ownerDocument of imported descendants is the target document', () => {
+			const el = srcDoc.createElement('root')
+			el.appendChild(srcDoc.createElement('child'))
+			const imported = dstDoc.importNode(el, true)
+			expect(imported.firstChild.ownerDocument).toBe(dstDoc)
+		})
+		test('parentNode of imported node is null', () => {
+			const el = srcDoc.createElement('el')
+			const imported = dstDoc.importNode(el, false)
+			expect(imported.parentNode).toBeNull()
+		})
+		test('imported node is a different object from the source', () => {
+			const el = srcDoc.createElement('el')
+			const imported = dstDoc.importNode(el, false)
+			expect(imported).not.toBe(el)
+		})
+		test('source document is not modified after deep import', () => {
+			const el = srcDoc.createElement('root')
+			el.appendChild(srcDoc.createElement('child'))
+			dstDoc.importNode(el, true)
+			expect(el.ownerDocument).toBe(srcDoc)
+			expect(el.childNodes.length).toBe(1)
+		})
+		test('imports a Text node', () => {
+			const text = srcDoc.createTextNode('hello')
+			const imported = dstDoc.importNode(text, false)
+			expect(imported.nodeValue).toBe('hello')
+			expect(imported.ownerDocument).toBe(dstDoc)
+		})
+		test('imports a CDATASection node', () => {
+			const cdata = srcDoc.createCDATASection('<raw>')
+			const imported = dstDoc.importNode(cdata, false)
+			expect(imported.nodeValue).toBe('<raw>')
+			expect(imported.ownerDocument).toBe(dstDoc)
+		})
+		test('imports a Comment node', () => {
+			const comment = srcDoc.createComment('note')
+			const imported = dstDoc.importNode(comment, false)
+			expect(imported.nodeValue).toBe('note')
+			expect(imported.ownerDocument).toBe(dstDoc)
+		})
+		test('imports a ProcessingInstruction node', () => {
+			const pi = srcDoc.createProcessingInstruction('target', 'data')
+			const imported = dstDoc.importNode(pi, false)
+			expect(imported.target).toBe('target')
+			expect(imported.data).toBe('data')
+			expect(imported.ownerDocument).toBe(dstDoc)
+		})
+		test('imports a DocumentFragment with children (deep)', () => {
+			const frag = srcDoc.createDocumentFragment()
+			frag.appendChild(srcDoc.createTextNode('a'))
+			frag.appendChild(srcDoc.createElement('el'))
+			const imported = dstDoc.importNode(frag, true)
+			expect(imported.childNodes.length).toBe(2)
+			expect(imported.firstChild.nodeValue).toBe('a')
+		})
+		test('importing an Attribute forces deep and copies its child text node', () => {
+			const attr = srcDoc.createAttribute('key')
+			attr.value = 'val'
+			const imported = dstDoc.importNode(attr, false)
+			expect(imported.value).toBe('val')
+			expect(imported.ownerDocument).toBe(dstDoc)
+		})
+	})
 })

--- a/test/dom/node.test.js
+++ b/test/dom/node.test.js
@@ -104,4 +104,76 @@ describe('Node.prototype', () => {
 			})
 		})
 	})
+
+	describe('cloneNode', () => {
+		const impl = new DOMImplementation()
+		const doc = impl.createDocument(null, '')
+
+		test('returns a new object, not the same reference', () => {
+			const el = doc.createElement('el')
+			expect(el.cloneNode(false)).not.toBe(el)
+		})
+		test('shallow clone (false) does not include children', () => {
+			const el = doc.createElement('parent')
+			el.appendChild(doc.createElement('child'))
+			expect(el.cloneNode(false).firstChild).toBeNull()
+		})
+		test('deep clone (true) includes all descendants', () => {
+			const el = doc.createElement('parent')
+			const child = doc.createElement('child')
+			child.appendChild(doc.createTextNode('text'))
+			el.appendChild(child)
+			const clone = el.cloneNode(true)
+			expect(clone.firstChild.nodeName).toBe('child')
+			expect(clone.firstChild.firstChild.nodeValue).toBe('text')
+		})
+		test('attributes are cloned for Element', () => {
+			const el = doc.createElement('el')
+			el.setAttribute('foo', 'bar')
+			expect(el.cloneNode(false).getAttribute('foo')).toBe('bar')
+		})
+		test('modifying clone attributes does not affect original', () => {
+			const el = doc.createElement('el')
+			el.setAttribute('foo', 'original')
+			el.cloneNode(false).setAttribute('foo', 'modified')
+			expect(el.getAttribute('foo')).toBe('original')
+		})
+		test('modifying clone children does not affect original', () => {
+			const el = doc.createElement('parent')
+			el.appendChild(doc.createElement('child'))
+			const clone = el.cloneNode(true)
+			clone.removeChild(clone.firstChild)
+			expect(el.firstChild).not.toBeNull()
+		})
+		test('ownerDocument is preserved', () => {
+			const el = doc.createElement('el')
+			expect(el.cloneNode(false).ownerDocument).toBe(doc)
+		})
+		test('Text node: clones nodeValue', () => {
+			const node = doc.createTextNode('hello')
+			const clone = node.cloneNode()
+			expect(clone.nodeValue).toBe('hello')
+			expect(clone).not.toBe(node)
+		})
+		test('CDATASection node: clones data', () => {
+			const node = doc.createCDATASection('raw<data>')
+			const clone = node.cloneNode()
+			expect(clone.nodeValue).toBe('raw<data>')
+			expect(clone.nodeType).toBe(node.nodeType)
+		})
+		test('Comment node: clones data', () => {
+			const node = doc.createComment('a comment')
+			const clone = node.cloneNode()
+			expect(clone.nodeValue).toBe('a comment')
+			expect(clone.nodeType).toBe(node.nodeType)
+		})
+		test('DocumentFragment: deep clone includes children', () => {
+			const frag = doc.createDocumentFragment()
+			frag.appendChild(doc.createTextNode('a'))
+			frag.appendChild(doc.createElement('el'))
+			const clone = frag.cloneNode(true)
+			expect(clone.childNodes.length).toBe(2)
+			expect(clone.firstChild.nodeValue).toBe('a')
+		})
+	})
 })

--- a/test/dom/node.test.js
+++ b/test/dom/node.test.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const { DOMImplementation } = require('../../lib')
+
+describe('Node.prototype', () => {
+	describe('textContent', () => {
+		const impl = new DOMImplementation()
+		const doc = impl.createDocument(null, '')
+
+		describe('on Element', () => {
+			test('returns empty string when element has no children', () => {
+				const el = doc.createElement('root')
+				expect(el.textContent).toBe('')
+			})
+			test('returns data of a Text child', () => {
+				const el = doc.createElement('root')
+				el.appendChild(doc.createTextNode('hello'))
+				expect(el.textContent).toBe('hello')
+			})
+			test('returns data of a CDATASection child', () => {
+				const el = doc.createElement('root')
+				el.appendChild(doc.createCDATASection('raw<data>'))
+				expect(el.textContent).toBe('raw<data>')
+			})
+			test('excludes Comment nodes', () => {
+				const el = doc.createElement('root')
+				el.appendChild(doc.createComment('ignored'))
+				expect(el.textContent).toBe('')
+			})
+			test('excludes ProcessingInstruction nodes', () => {
+				const el = doc.createElement('root')
+				el.appendChild(doc.createProcessingInstruction('pi', 'ignored'))
+				expect(el.textContent).toBe('')
+			})
+			test('concatenates text from nested elements in document order', () => {
+				const el = doc.createElement('root')
+				const child = doc.createElement('child')
+				child.appendChild(doc.createTextNode('world'))
+				el.appendChild(doc.createTextNode('hello '))
+				el.appendChild(child)
+				expect(el.textContent).toBe('hello world')
+			})
+			test('concatenates only text across mixed content (text + comment + text)', () => {
+				const el = doc.createElement('root')
+				el.appendChild(doc.createTextNode('a'))
+				el.appendChild(doc.createComment('ignored'))
+				el.appendChild(doc.createTextNode('b'))
+				expect(el.textContent).toBe('ab')
+			})
+			test('concatenates only text across mixed content (text + PI + text)', () => {
+				const el = doc.createElement('root')
+				el.appendChild(doc.createTextNode('a'))
+				el.appendChild(doc.createProcessingInstruction('pi', 'ignored'))
+				el.appendChild(doc.createTextNode('b'))
+				expect(el.textContent).toBe('ab')
+			})
+		})
+
+		describe('on DocumentFragment', () => {
+			test('returns empty string for an empty fragment', () => {
+				const frag = doc.createDocumentFragment()
+				expect(frag.textContent).toBe('')
+			})
+			test('concatenates text, excludes Comment and ProcessingInstruction descendants', () => {
+				const frag = doc.createDocumentFragment()
+				frag.appendChild(doc.createTextNode('a'))
+				frag.appendChild(doc.createComment('ignored'))
+				frag.appendChild(doc.createProcessingInstruction('pi', 'ignored'))
+				frag.appendChild(doc.createTextNode('b'))
+				expect(frag.textContent).toBe('ab')
+			})
+		})
+
+		describe('on other node types (returns nodeValue)', () => {
+			test('Text node returns its data', () => {
+				const node = doc.createTextNode('hello')
+				expect(node.textContent).toBe('hello')
+			})
+			test('CDATASection node returns its data', () => {
+				const node = doc.createCDATASection('raw<data>')
+				expect(node.textContent).toBe('raw<data>')
+			})
+			test('Comment node returns its own data', () => {
+				const node = doc.createComment('comment text')
+				expect(node.textContent).toBe('comment text')
+			})
+			test('ProcessingInstruction node returns its data', () => {
+				const node = doc.createProcessingInstruction('target', 'pi data')
+				expect(node.textContent).toBe('pi data')
+			})
+			test('Attr node returns its value', () => {
+				const el = doc.createElement('el')
+				el.setAttribute('name', 'attr value')
+				const node = el.getAttributeNode('name')
+				expect(node.textContent).toBe('attr value')
+			})
+			test('Document node returns null', () => {
+				const d = impl.createDocument(null, null)
+				expect(d.textContent).toBeNull()
+			})
+			test('DocumentType node returns null', () => {
+				const doctype = impl.createDocumentType('html', '', '')
+				expect(doctype.textContent).toBeNull()
+			})
+		})
+	})
+})

--- a/test/dom/processing-instruction.test.js
+++ b/test/dom/processing-instruction.test.js
@@ -26,4 +26,15 @@ describe('ProcessingInstruction', () => {
 		expect(pi.target).toBe('xml-stylesheet')
 		expect(pi.data).toBe('href="mycss.css"\n')
 	})
+
+	test('createProcessingInstruction accepts any target or data without throwing', () => {
+		const doc = new DOMParser().parseFromString('<xml/>', MIME_TYPE.XML_TEXT)
+		expect(() =>
+			doc.createProcessingInstruction('ns:bad', 'data')
+		).not.toThrow()
+		expect(() => doc.createProcessingInstruction('xml', '?>')).not.toThrow()
+		expect(() =>
+			doc.createProcessingInstruction('foo', 'inject?>evil')
+		).not.toThrow()
+	})
 })

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -471,4 +471,108 @@ describe('XMLSerializer serializeToString requireWellFormed option', () => {
 			).toThrow(DOMException)
 		})
 	})
+
+	describe('DocumentType', () => {
+		it('default: DocumentType with invalid publicId serializes verbatim — no throw', () => {
+			const doctype = new DOMImplementation().createDocumentType(
+				'name',
+				'"invalid<char"',
+				''
+			)
+			const dtDoc = new DOMImplementation().createDocument(
+				null,
+				'root',
+				doctype
+			)
+			expect(() => new XMLSerializer().serializeToString(dtDoc)).not.toThrow()
+		})
+
+		it('requireWellFormed: true on DocumentType with invalid publicId throws', () => {
+			const doctype = new DOMImplementation().createDocumentType(
+				'name',
+				'"invalid<char"',
+				''
+			)
+			const dtDoc = new DOMImplementation().createDocument(
+				null,
+				'root',
+				doctype
+			)
+			expect(() =>
+				new XMLSerializer().serializeToString(dtDoc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on DocumentType with invalid systemId throws', () => {
+			const doctype = new DOMImplementation().createDocumentType(
+				'name',
+				'',
+				'no-quotes-around-this'
+			)
+			const dtDoc = new DOMImplementation().createDocument(
+				null,
+				'root',
+				doctype
+			)
+			expect(() =>
+				new XMLSerializer().serializeToString(dtDoc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on DocumentType with "]>" in internalSubset throws', () => {
+			const doctype = new DOMImplementation().createDocumentType('name', '', '')
+			const dtDoc = new DOMImplementation().createDocument(
+				null,
+				'root',
+				doctype
+			)
+			doctype.internalSubset = ']><injected/>'
+			expect(() =>
+				new XMLSerializer().serializeToString(dtDoc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on DocumentType with valid fields does not throw', () => {
+			const doctype = new DOMImplementation().createDocumentType(
+				'html',
+				'"-//W3C//DTD HTML 4.01//EN"',
+				'"http://www.w3.org/TR/html4/strict.dtd"'
+			)
+			const dtDoc = new DOMImplementation().createDocument(
+				null,
+				'root',
+				doctype
+			)
+			expect(() =>
+				new XMLSerializer().serializeToString(dtDoc, false, null, {
+					requireWellFormed: true,
+				})
+			).not.toThrow()
+		})
+
+		it('direct property write: setting invalid publicId then requireWellFormed: true throws', () => {
+			const doctype = new DOMImplementation().createDocumentType(
+				'name',
+				'"-//W3C//DTD//EN"',
+				''
+			)
+			const dtDoc = new DOMImplementation().createDocument(
+				null,
+				'root',
+				doctype
+			)
+			doctype.publicId = '"invalid<char"'
+			expect(() =>
+				new XMLSerializer().serializeToString(dtDoc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+	})
 })

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -387,4 +387,44 @@ describe('XMLSerializer serializeToString requireWellFormed option', () => {
 			doc.toString(false, null, { requireWellFormed: true })
 		).toThrow(DOMException)
 	})
+
+	describe('Comment', () => {
+		it('default: comment with "-->" in data emits verbatim — no throw', () => {
+			const comment = doc.createComment('safe-->evil')
+			doc.documentElement.appendChild(comment)
+			expect(new XMLSerializer().serializeToString(doc.documentElement)).toBe(
+				'<root><!--safe-->evil--></root>'
+			)
+		})
+
+		it('requireWellFormed: true on comment with "-->" throws InvalidStateError', () => {
+			const comment = doc.createComment('safe-->evil')
+			doc.documentElement.appendChild(comment)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on comment with "--" (no "-->") does not throw — intentional on 0.8.x', () => {
+			const comment = doc.createComment('hello--world')
+			doc.documentElement.appendChild(comment)
+			expect(
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toBe('<root><!--hello--world--></root>')
+		})
+
+		it('requireWellFormed: true on comment with clean data serializes correctly', () => {
+			const comment = doc.createComment('safe comment')
+			doc.documentElement.appendChild(comment)
+			expect(
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toBe('<root><!--safe comment--></root>')
+		})
+	})
 })

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -358,8 +358,33 @@ describe('XMLSerializer serializeToString requireWellFormed option', () => {
 		const cdata = doc.createCDATASection('safe')
 		cdata.data = 'foo]]>bar'
 		doc.documentElement.appendChild(cdata)
-		expect(new XMLSerializer().serializeToString(doc.documentElement, false, null, null)).toBe(
-			'<root><![CDATA[foo]]]]><![CDATA[>bar]]></root>'
-		)
+		expect(
+			new XMLSerializer().serializeToString(
+				doc.documentElement,
+				false,
+				null,
+				null
+			)
+		).toBe('<root><![CDATA[foo]]]]><![CDATA[>bar]]></root>')
+	})
+
+	it('requireWellFormed: true on CDATA with "]]>" throws', () => {
+		const cdata = doc.createCDATASection('safe')
+		cdata.data = 'foo]]>bar'
+		doc.documentElement.appendChild(cdata)
+		expect(() =>
+			new XMLSerializer().serializeToString(doc, false, null, {
+				requireWellFormed: true,
+			})
+		).toThrow(DOMException)
+	})
+
+	it('node.toString with requireWellFormed: true on CDATA with "]]>" throws', () => {
+		const cdata = doc.createCDATASection('safe')
+		cdata.data = 'foo]]>bar'
+		doc.documentElement.appendChild(cdata)
+		expect(() =>
+			doc.toString(false, null, { requireWellFormed: true })
+		).toThrow(DOMException)
 	})
 })

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -119,6 +119,24 @@ describe('XML Serializer', () => {
 				'<a:foo xmlns:a="AAA"><child xmlns="BBB"><nested/></child></a:foo>'
 			)
 		})
+		it('namespace declarations are isolated between siblings (no cross-sibling leakage)', () => {
+			// child re-declares xmlns="ns2"; sibling must declare xmlns="ns3" independently.
+			// If the per-level namespace snapshot (ns.slice()) were shared between siblings,
+			// sibling might incorrectly see ns2 in scope and omit its own xmlns declaration.
+			// This confirms correct isolation of the {namespaces, isHTML} context per element.
+			const xml =
+				'<root xmlns="ns1">' +
+				'<child xmlns="ns2"><grandchild xmlns="ns1"/></child>' +
+				'<sibling xmlns="ns3"/>' +
+				'</root>'
+			const nsDoc = new DOMParser().parseFromString(xml, MIME_TYPE.XML_TEXT)
+			expect(new XMLSerializer().serializeToString(nsDoc)).toBe(
+				'<root xmlns="ns1">' +
+					'<child xmlns="ns2"><grandchild xmlns="ns1"/></child>' +
+					'<sibling xmlns="ns3"/>' +
+					'</root>'
+			)
+		})
 	})
 	describe('is insensitive to namespace order', () => {
 		it('should preserve prefixes for inner elements and attributes', () => {

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -575,4 +575,40 @@ describe('XMLSerializer serializeToString requireWellFormed option', () => {
 			).toThrow(DOMException)
 		})
 	})
+
+	describe('EntityReference', () => {
+		test('serializes EntityReference node as &name;', () => {
+			const xmlDoc = new DOMImplementation().createDocument(null, '')
+			const entityRef = xmlDoc.createEntityReference('amp')
+			expect(new XMLSerializer().serializeToString(entityRef)).toBe('&amp;')
+		})
+	})
+
+	describe('unknown node type (default case)', () => {
+		test('serializes unrecognized node type with "??" prefix', () => {
+			const xmlDoc = new DOMImplementation().createDocument(null, '')
+			// Construct a duck-typed node with a non-standard nodeType to exercise the default branch.
+			const fakeNode = {
+				nodeType: 99,
+				nodeName: 'fake',
+				ownerDocument: xmlDoc,
+				firstChild: null,
+			}
+			expect(new XMLSerializer().serializeToString(fakeNode)).toBe('??fake')
+		})
+	})
+
+	describe('HTML raw text element with non-data child', () => {
+		test('falls back to full serialization for a child with empty data inside <script>', () => {
+			const doc = new DOMParser().parseFromString('<html/>', MIME_TYPE.HTML)
+			const script = doc.createElement('script')
+			// A ProcessingInstruction with empty data has child.data === '' (falsy),
+			// which triggers the serializeToString fallback path inside raw text elements.
+			const pi = doc.createProcessingInstruction('target', '')
+			script.appendChild(pi)
+			expect(new XMLSerializer().serializeToString(script)).toBe(
+				'<script><?target ?></script>'
+			)
+		})
+	})
 })

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -2,7 +2,7 @@
 
 const { DOMParser, XMLSerializer } = require('../../lib')
 const { MIME_TYPE } = require('../../lib/conventions')
-const { DOMImplementation } = require('../../lib/dom')
+const { DOMException, DOMImplementation } = require('../../lib/dom')
 
 describe('XML Serializer', () => {
 	it('supports text node containing "]]>"', () => {
@@ -336,5 +336,30 @@ describe('XMLSerializer CDATASection serialization', () => {
 			cdata.textContent = 'evil]]><injected/>'
 			expect(isInjected(doc.documentElement)).toBe(false)
 		})
+	})
+})
+
+describe('XMLSerializer serializeToString requireWellFormed option', () => {
+	let doc
+	beforeEach(() => {
+		doc = new DOMImplementation().createDocument(null, 'root', null)
+	})
+
+	it('CDATA with "]]>" still splits when no options are passed (regression)', () => {
+		const cdata = doc.createCDATASection('safe')
+		cdata.data = 'foo]]>bar'
+		doc.documentElement.appendChild(cdata)
+		expect(new XMLSerializer().serializeToString(doc.documentElement)).toBe(
+			'<root><![CDATA[foo]]]]><![CDATA[>bar]]></root>'
+		)
+	})
+
+	it('CDATA with "]]>" still splits when options is null (regression)', () => {
+		const cdata = doc.createCDATASection('safe')
+		cdata.data = 'foo]]>bar'
+		doc.documentElement.appendChild(cdata)
+		expect(new XMLSerializer().serializeToString(doc.documentElement, false, null, null)).toBe(
+			'<root><![CDATA[foo]]]]><![CDATA[>bar]]></root>'
+		)
 	})
 })

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -427,4 +427,48 @@ describe('XMLSerializer serializeToString requireWellFormed option', () => {
 			).toBe('<root><!--safe comment--></root>')
 		})
 	})
+
+	describe('ProcessingInstruction', () => {
+		it('default: PI with "?>" in data emits verbatim — no throw', () => {
+			const pi = doc.createProcessingInstruction('foo', 'inject?>evil')
+			doc.documentElement.appendChild(pi)
+			expect(new XMLSerializer().serializeToString(doc.documentElement)).toBe(
+				'<root><?foo inject?>evil?></root>'
+			)
+		})
+
+		it('requireWellFormed: true on PI with "?>" in data throws', () => {
+			const pi = doc.createProcessingInstruction('foo', 'inject?>evil')
+			doc.documentElement.appendChild(pi)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on PI with clean data does not throw', () => {
+			const pi = doc.createProcessingInstruction(
+				'xml-stylesheet',
+				'href="style.css"'
+			)
+			doc.documentElement.appendChild(pi)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).not.toThrow()
+		})
+
+		it('mutation vector: set PI data to "?>" then requireWellFormed: true throws', () => {
+			const pi = doc.createProcessingInstruction('foo', 'clean')
+			doc.documentElement.appendChild(pi)
+			pi.data = 'inject?>evil'
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+	})
 })

--- a/test/dom/walk-dom.test.js
+++ b/test/dom/walk-dom.test.js
@@ -1,0 +1,224 @@
+'use strict'
+
+const { describe, test, expect, beforeEach } = require('@jest/globals')
+const { DOMImplementation, walkDOM } = require('../../lib/dom')
+
+/**
+ * Build a small DOM tree for testing:
+ *
+ *   root (Element)
+ *     childA (Element)
+ *       grandchildA1 (Element)
+ *       grandchildA2 (Element)
+ *     childB (Element)
+ *       grandchildB1 (Element)
+ */
+function buildTree() {
+	const impl = new DOMImplementation()
+	const doc = impl.createDocument(null, 'root')
+	const root = doc.documentElement
+
+	const childA = doc.createElement('childA')
+	root.appendChild(childA)
+	const grandchildA1 = doc.createElement('grandchildA1')
+	childA.appendChild(grandchildA1)
+	const grandchildA2 = doc.createElement('grandchildA2')
+	childA.appendChild(grandchildA2)
+	const childB = doc.createElement('childB')
+	root.appendChild(childB)
+	const grandchildB1 = doc.createElement('grandchildB1')
+	childB.appendChild(grandchildB1)
+
+	return { doc, root, childA, grandchildA1, grandchildA2, childB, grandchildB1 }
+}
+
+describe('walkDOM', () => {
+	describe('pre-order entry', () => {
+		test('calls enter on parent before children', () => {
+			const { root } = buildTree()
+			const visited = []
+			walkDOM(root, null, {
+				enter(node) {
+					visited.push(node.nodeName)
+					// Descend into root so childA/childB are visited, but skip grandchildren
+					if (node === root) return 'ctx'
+					return null
+				},
+			})
+			// root entered first; childA and childB entered; grandchildren skipped
+			expect(visited).toEqual(['root', 'childA', 'childB'])
+		})
+
+		test('visits all nodes in depth-first pre-order when enter returns a truthy context', () => {
+			const { root } = buildTree()
+			const visited = []
+			walkDOM(root, 'ctx', {
+				enter(node) {
+					visited.push(node.nodeName)
+					return 'ctx'
+				},
+			})
+			expect(visited).toEqual([
+				'root',
+				'childA',
+				'grandchildA1',
+				'grandchildA2',
+				'childB',
+				'grandchildB1',
+			])
+		})
+	})
+
+	describe('post-order exit', () => {
+		test('calls exit on a node after all its children have been exited', () => {
+			const { root } = buildTree()
+			const log = []
+			walkDOM(root, 'ctx', {
+				enter(node) {
+					log.push('enter:' + node.nodeName)
+					return 'ctx'
+				},
+				exit(node) {
+					log.push('exit:' + node.nodeName)
+				},
+			})
+			// grandchildA1 exited before childA, childA exited before root
+			const grandchildA1Exit = log.indexOf('exit:grandchildA1')
+			const childAExit = log.indexOf('exit:childA')
+			const rootExit = log.indexOf('exit:root')
+			expect(grandchildA1Exit).toBeLessThan(childAExit)
+			expect(childAExit).toBeLessThan(rootExit)
+		})
+
+		test('passes the context returned by enter to exit', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createDocument(null, 'root')
+			const root = doc.documentElement
+			root.appendChild(doc.createElement('child'))
+
+			const exitContexts = []
+			walkDOM(root, 0, {
+				enter(node, ctx) {
+					return ctx + 1
+				},
+				exit(node, ctx) {
+					exitContexts.push({ name: node.nodeName, ctx })
+				},
+			})
+			// root enter gets ctx=0, returns 1; child enter gets ctx=1, returns 2
+			// child exit gets ctx=2; root exit gets ctx=1
+			expect(exitContexts).toEqual([
+				{ name: 'child', ctx: 2 },
+				{ name: 'root', ctx: 1 },
+			])
+		})
+	})
+
+	describe('context propagation', () => {
+		test('each child receives the return value of its parent enter', () => {
+			const { root } = buildTree()
+			const receivedCtx = {}
+			walkDOM(root, 0, {
+				enter(node, ctx) {
+					receivedCtx[node.nodeName] = ctx
+					return ctx + 1
+				},
+			})
+			expect(receivedCtx['root']).toBe(0)
+			expect(receivedCtx['childA']).toBe(1)
+			expect(receivedCtx['grandchildA1']).toBe(2)
+			expect(receivedCtx['grandchildA2']).toBe(2)
+			expect(receivedCtx['childB']).toBe(1)
+			expect(receivedCtx['grandchildB1']).toBe(2)
+		})
+	})
+
+	describe('STOP sentinel', () => {
+		test('returning walkDOM.STOP from enter aborts the entire traversal immediately', () => {
+			const { root } = buildTree()
+			const visited = []
+			walkDOM(root, null, {
+				enter(node) {
+					visited.push(node.nodeName)
+					if (node.nodeName === 'childA') {
+						return walkDOM.STOP
+					}
+					return 'ctx'
+				},
+				exit(node) {
+					visited.push('exit:' + node.nodeName)
+				},
+			})
+			// root and childA entered; traversal stops at childA — no children of childA,
+			// no siblings (childB), no exit calls
+			expect(visited).toEqual(['root', 'childA'])
+		})
+	})
+
+	describe('skip children', () => {
+		test('returning null from enter skips children but continues with siblings', () => {
+			const { root } = buildTree()
+			const visited = []
+			walkDOM(root, null, {
+				enter(node) {
+					visited.push(node.nodeName)
+					if (node.nodeName === 'childA') {
+						return null // skip grandchildA1, grandchildA2
+					}
+					return 'ctx'
+				},
+			})
+			expect(visited).toContain('root')
+			expect(visited).toContain('childA')
+			expect(visited).not.toContain('grandchildA1')
+			expect(visited).not.toContain('grandchildA2')
+			// childB and its child are still walked (null only skips childA's children)
+			expect(visited).toContain('childB')
+			expect(visited).toContain('grandchildB1')
+		})
+
+		test('returning undefined from enter skips children but continues with siblings', () => {
+			const { root } = buildTree()
+			const visited = []
+			walkDOM(root, null, {
+				enter(node) {
+					visited.push(node.nodeName)
+					if (node.nodeName === 'childA') {
+						return undefined // skip grandchildA1, grandchildA2
+					}
+					return 'ctx'
+				},
+			})
+			expect(visited).toContain('root')
+			expect(visited).toContain('childA')
+			expect(visited).not.toContain('grandchildA1')
+			expect(visited).not.toContain('grandchildA2')
+			// childB and its child are still walked (undefined only skips childA's children)
+			expect(visited).toContain('childB')
+			expect(visited).toContain('grandchildB1')
+		})
+	})
+
+	describe('enter modifies firstChild before descent', () => {
+		test('walker visits the modified child list when enter adds a child before returning', () => {
+			const impl = new DOMImplementation()
+			const doc = impl.createDocument(null, 'root')
+			const root = doc.documentElement
+			const original = doc.createElement('original')
+			root.appendChild(original)
+
+			const visited = []
+			walkDOM(root, null, {
+				enter(node) {
+					visited.push(node.nodeName)
+					if (node.nodeName === 'root') {
+						// Add a new child before returning — walker should see it
+						root.appendChild(doc.createElement('added'))
+					}
+					return 'ctx'
+				},
+			})
+			expect(visited).toContain('added')
+		})
+	})
+})

--- a/test/dom/walk-dom.test.js
+++ b/test/dom/walk-dom.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { describe, test, expect, beforeEach } = require('@jest/globals')
+const { describe, test, expect } = require('@jest/globals')
 const { DOMImplementation, walkDOM } = require('../../lib/dom')
 
 /**

--- a/test/recursion-regression.test.js
+++ b/test/recursion-regression.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const { describe, test, expect, beforeAll } = require('@jest/globals')
+const { DOMImplementation, walkDOM } = require('../lib/dom')
+const { XMLSerializer } = require('../lib')
+const pkgJson = require('../package.json')
+
+// Must exceed the recursive-overflow threshold at the configured stack size
+// (~2,600 frames at 256 KB) so that re-introducing any recursive tree walk
+// causes these tests to fail.
+const DEEP_TREE_DEPTH = 3000
+
+test('npm_package_config_test_stack_size env var matches package.json config.test_stack_size', () => {
+	expect(process.env.npm_package_config_test_stack_size).toBe(
+		`${pkgJson.config.test_stack_size}`
+	)
+})
+test('test script uses $npm_package_config_test_stack_size', () => {
+	expect(pkgJson.scripts.test).toMatch(
+		' --stack-size=$npm_package_config_test_stack_size'
+	)
+})
+test('recursive function overflows within DEEP_TREE_DEPTH frames', () => {
+	function throwsAtLevel(lvl) {
+		var nextLvl = (lvl || 0) + 1
+		try {
+			return throwsAtLevel(nextLvl)
+		} catch (e) {
+			return nextLvl
+		}
+	}
+	expect(throwsAtLevel()).toBeLessThanOrEqual(DEEP_TREE_DEPTH)
+})
+
+describe('deep tree stack overflow guard (GHSA-2v35-w6hq-6mfw)', () => {
+	var deepRoot
+	beforeAll(() => {
+		var doc = new DOMImplementation().createDocument(null, 'root')
+		var current = doc.documentElement
+		for (var i = 0; i < DEEP_TREE_DEPTH; i++) {
+			var child = doc.createElement('n')
+			current.appendChild(child)
+			current = child
+		}
+		deepRoot = doc.documentElement
+	})
+
+	test('walkDOM', () => {
+		expect(() =>
+			walkDOM(deepRoot, null, {
+				enter: function () {
+					return 'ctx'
+				},
+			})
+		).not.toThrow()
+	})
+	test('getElementsByTagName', () => {
+		expect(() => deepRoot.getElementsByTagName('n')).not.toThrow()
+	})
+	test('textContent', () => {
+		expect(() => void deepRoot.textContent).not.toThrow()
+	})
+	test('serializeToString', () => {
+		expect(() => new XMLSerializer().serializeToString(deepRoot)).not.toThrow()
+	})
+	test('cloneNode(true)', () => {
+		expect(() => deepRoot.cloneNode(true)).not.toThrow()
+	})
+	test('importNode(node, true)', () => {
+		var destDoc = new DOMImplementation().createDocument(null, 'dest')
+		expect(() => destDoc.importNode(deepRoot, true)).not.toThrow()
+	})
+})

--- a/test/recursion-regression.test.js
+++ b/test/recursion-regression.test.js
@@ -70,4 +70,7 @@ describe('deep tree stack overflow guard (GHSA-2v35-w6hq-6mfw)', () => {
 		var destDoc = new DOMImplementation().createDocument(null, 'dest')
 		expect(() => destDoc.importNode(deepRoot, true)).not.toThrow()
 	})
+	test('normalize', () => {
+		expect(() => deepRoot.normalize()).not.toThrow()
+	})
 })


### PR DESCRIPTION
fix: security release 0.8.13 (comment/PI/DOCTYPE injection + DoS recursion)

Introduce `requireWellFormed` option on `XMLSerializer.serializeToString()`
(as the fourth argument, after `isHtml` and `nodeFilter`), `Node.toString()`,
and `NodeList.toString()`. When `{ requireWellFormed: true }` is passed, the
serializer enforces injection-preventing checks on `Comment`, `ProcessingInstruction`,
and `DocumentType` nodes.

[GHSA-j759-j44w-7fr8](https://github.com/xmldom/xmldom/security/advisories/GHSA-j759-j44w-7fr8) — Comment injection
- throw `InvalidStateError` at serializer when comment data contains `-->` (`requireWellFormed: true`)

[GHSA-x6wf-f3px-wcqx](https://github.com/xmldom/xmldom/security/advisories/GHSA-x6wf-f3px-wcqx) — PI injection
- throw `InvalidStateError` at serializer when PI data contains `?>` (`requireWellFormed: true`)

[GHSA-f6ww-3ggp-fr8h](https://github.com/xmldom/xmldom/security/advisories/GHSA-f6ww-3ggp-fr8h) — DOCTYPE injection
- throw `InvalidStateError` at serializer when `publicId` fails `PubidLiteral` production,
  `systemId` fails `SystemLiteral` production, or `internalSubset` contains `]>`
  (`requireWellFormed: true`)

[GHSA-2v35-w6hq-6mfw](https://github.com/xmldom/xmldom/security/advisories/GHSA-2v35-w6hq-6mfw) — DoS recursion
- introduce iterative `walkDOM(node, context, callbacks)` utility in `lib/dom.js`
- migrate `_visitNode`, `getTextContent`, `cloneNode`, `importNode`, `serializeToString`,
  `normalize` to `walkDOM`