### PR TITLE
docs(changelog): fix 0.9.8 compare link direction (0.9.7...0.9.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ for your contributions
 
 Thank you, [@shunkica](https://github.com/shunkica), for your contributions
 
-## [0.9.8](https://github.com/xmldom/xmldom/compare/0.9.8...0.9.7)
+## [0.9.8](https://github.com/xmldom/xmldom/compare/0.9.7...0.9.8)
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

The 0.9.8 entry in \`CHANGELOG.md\` links to \`compare/0.9.8...0.9.7\`, which reverses the diff direction (shown as \"from 0.9.8 back to 0.9.7\"). Every other section header in this changelog uses the \`<previous>...<current>\` order, e.g. \`0.9.7...0.9.8\`, so GitHub shows the changes that went into the release.

Swapped refs so it matches the convention used throughout the file.

Closes #954

## Testing

Documentation-only change. Verified the new URL (https://github.com/xmldom/xmldom/compare/0.9.7...0.9.8) resolves and shows the commits that went into 0.9.8.