### PR TITLE
reject charrefs to invalid XML characters in entityReplacer

### DIFF
--- a/lib/sax.js
+++ b/lib/sax.js
@@ -66,6 +66,18 @@ function parse(source, defaultNSMapCopy, entityMap, domBuilder, errorHandler) {
 		}
 	}
 
+	function isValidXmlCodePoint(code) {
+		// XML Char production [2]: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+		return (
+			code === 0x9 ||
+			code === 0xa ||
+			code === 0xd ||
+			(code >= 0x20 && code <= 0xd7ff) ||
+			(code >= 0xe000 && code <= 0xfffd) ||
+			(code >= 0x10000 && code <= 0x10ffff)
+		);
+	}
+
 	function entityReplacer(a) {
 		var complete = a[a.length - 1] === ';' ? a : a + ';';
 		if (!isHTML && complete !== a) {
@@ -81,7 +93,12 @@ function parse(source, defaultNSMapCopy, entityMap, domBuilder, errorHandler) {
 		if (hasOwn(entityMap, k)) {
 			return entityMap[k];
 		} else if (k.charAt(0) === '#') {
-			return fixedFromCharCode(parseInt(k.substring(1).replace('x', '0x')));
+			var code = parseInt(k.substring(1).replace('x', '0x'));
+			if (isValidXmlCodePoint(code)) {
+				return fixedFromCharCode(code);
+			}
+			errorHandler.error('character reference to invalid XML character: ' + a);
+			return a;
 		} else {
 			errorHandler.error('entity not found:' + a);
 			return a;

--- a/test/errors/__snapshots__/reported-levels.test.js.snap
+++ b/test/errors/__snapshots__/reported-levels.test.js.snap
@@ -56,7 +56,7 @@ exports[`SYNTAX_AttributeMissingEndingQuote with mimeType text/html should be re
 exports[`SYNTAX_AttributeMissingEndingQuote with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: element parse error: Error: attribute value no end '"' match
-    at error (lib/sax.js:#11)",
+    at error (lib/sax.js:#12)",
 ]
 `;
 
@@ -76,7 +76,7 @@ exports[`SYNTAX_AttributeMissingEndingQuote with mimeType text/xml should be rep
 exports[`SYNTAX_AttributeMissingEndingQuote with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: element parse error: Error: attribute value no end '"' match
-    at error (lib/sax.js:#11)",
+    at error (lib/sax.js:#12)",
 ]
 `;
 
@@ -96,7 +96,7 @@ exports[`SYNTAX_ElementClosingNotConnected with mimeType text/html should be rep
 exports[`SYNTAX_ElementClosingNotConnected with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: element parse error: Error: elements closed character '/' and '>' must be connected to
-    at error (lib/sax.js:#11)",
+    at error (lib/sax.js:#12)",
 ]
 `;
 
@@ -116,7 +116,7 @@ exports[`SYNTAX_ElementClosingNotConnected with mimeType text/xml should be repo
 exports[`SYNTAX_ElementClosingNotConnected with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: element parse error: Error: elements closed character '/' and '>' must be connected to
-    at error (lib/sax.js:#11)",
+    at error (lib/sax.js:#12)",
 ]
 `;
 
@@ -136,7 +136,7 @@ exports[`SYNTAX_InvalidAttributeName with mimeType text/html should be reported 
 exports[`SYNTAX_InvalidAttributeName with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: element parse error: Error: invalid attribute:123
-    at error (lib/sax.js:#11)",
+    at error (lib/sax.js:#12)",
 ]
 `;
 
@@ -156,7 +156,7 @@ exports[`SYNTAX_InvalidAttributeName with mimeType text/xml should be reported 1
 exports[`SYNTAX_InvalidAttributeName with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: element parse error: Error: invalid attribute:123
-    at error (lib/sax.js:#11)",
+    at error (lib/sax.js:#12)",
 ]
 `;
 
@@ -176,7 +176,7 @@ exports[`SYNTAX_InvalidTagName with mimeType text/html should be reported 1`] = 
 exports[`SYNTAX_InvalidTagName with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: element parse error: Error: invalid tagName:123
-    at error (lib/sax.js:#11)",
+    at error (lib/sax.js:#12)",
 ]
 `;
 
@@ -196,7 +196,7 @@ exports[`SYNTAX_InvalidTagName with mimeType text/xml should be reported 1`] = `
 exports[`SYNTAX_InvalidTagName with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: element parse error: Error: invalid tagName:123
-    at error (lib/sax.js:#11)",
+    at error (lib/sax.js:#12)",
 ]
 `;
 
@@ -243,7 +243,7 @@ exports[`WF_AttributeMissingQuote with mimeType text/html should be reported 1`]
 exports[`WF_AttributeMissingQuote with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute "value" missed quot(")!
-    at warning (lib/sax.js:#21)",
+    at warning (lib/sax.js:#22)",
 ]
 `;
 
@@ -263,7 +263,7 @@ exports[`WF_AttributeMissingQuote with mimeType text/xml should be reported 1`] 
 exports[`WF_AttributeMissingQuote with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute "value" missed quot(")!
-    at warning (lib/sax.js:#21)",
+    at warning (lib/sax.js:#22)",
 ]
 `;
 
@@ -283,7 +283,7 @@ exports[`WF_AttributeMissingQuote2 with mimeType text/html should be reported 1`
 exports[`WF_AttributeMissingQuote2 with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute "&" missed quot(")!!
-    at warning (lib/sax.js:#24)",
+    at warning (lib/sax.js:#25)",
 ]
 `;
 
@@ -303,7 +303,7 @@ exports[`WF_AttributeMissingQuote2 with mimeType text/xml should be reported 1`]
 exports[`WF_AttributeMissingQuote2 with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute "&" missed quot(")!!
-    at warning (lib/sax.js:#24)",
+    at warning (lib/sax.js:#25)",
 ]
 `;
 
@@ -323,7 +323,7 @@ exports[`WF_AttributeMissingStartingQuote with mimeType text/html should be repo
 exports[`WF_AttributeMissingStartingQuote with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute "attr" missed start quot(")!!
-    at warning (lib/sax.js:#17)",
+    at warning (lib/sax.js:#18)",
 ]
 `;
 
@@ -343,7 +343,7 @@ exports[`WF_AttributeMissingStartingQuote with mimeType text/xml should be repor
 exports[`WF_AttributeMissingStartingQuote with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute "attr" missed start quot(")!!
-    at warning (lib/sax.js:#17)",
+    at warning (lib/sax.js:#18)",
 ]
 `;
 
@@ -365,7 +365,7 @@ exports[`WF_AttributeMissingValue with mimeType text/xml should be reported 1`] 
 exports[`WF_AttributeMissingValue with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute "attr" missed value!! "attr" instead!!
-    at warning (lib/sax.js:#22)",
+    at warning (lib/sax.js:#23)",
 ]
 `;
 
@@ -395,7 +395,7 @@ exports[`WF_AttributeMissingValue2 with mimeType text/xml should be reported 1`]
 exports[`WF_AttributeMissingValue2 with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute "attr" missed value!! "attr" instead2!!
-    at warning (lib/sax.js:#25)",
+    at warning (lib/sax.js:#26)",
 ]
 `;
 
@@ -415,7 +415,7 @@ exports[`WF_AttributeValueMustAfterEqual with mimeType text/html should be repor
 exports[`WF_AttributeValueMustAfterEqual with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute value must after "="
-    at warning (lib/sax.js:#15)",
+    at warning (lib/sax.js:#16)",
 ]
 `;
 
@@ -435,7 +435,7 @@ exports[`WF_AttributeValueMustAfterEqual with mimeType text/xml should be report
 exports[`WF_AttributeValueMustAfterEqual with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "warning: attribute value must after "="
-    at warning (lib/sax.js:#15)",
+    at warning (lib/sax.js:#16)",
 ]
 `;
 
@@ -574,7 +574,7 @@ exports[`WF_EntityDeclared with mimeType text/html should be reported 1`] = `
 exports[`WF_EntityDeclared with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: entity not found:&e;
-    at error (lib/sax.js:#3)",
+    at error (lib/sax.js:#4)",
 ]
 `;
 
@@ -594,7 +594,7 @@ exports[`WF_EntityDeclared with mimeType text/xml should be reported 1`] = `
 exports[`WF_EntityDeclared with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: entity not found:&e;
-    at error (lib/sax.js:#3)",
+    at error (lib/sax.js:#4)",
 ]
 `;
 
@@ -614,7 +614,7 @@ exports[`WF_EntityDeclared_Attr with mimeType text/html should be reported 1`] =
 exports[`WF_EntityDeclared_Attr with mimeType text/html should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: entity not found:&e;
-    at error (lib/sax.js:#3)",
+    at error (lib/sax.js:#4)",
 ]
 `;
 
@@ -634,7 +634,7 @@ exports[`WF_EntityDeclared_Attr with mimeType text/xml should be reported 1`] = 
 exports[`WF_EntityDeclared_Attr with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: entity not found:&e;
-    at error (lib/sax.js:#3)",
+    at error (lib/sax.js:#4)",
 ]
 `;
 
@@ -656,7 +656,7 @@ exports[`WF_EntityDeclared_Script with mimeType text/xml should be reported 1`] 
 exports[`WF_EntityDeclared_Script with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: entity not found:&e;
-    at error (lib/sax.js:#3)",
+    at error (lib/sax.js:#4)",
 ]
 `;
 
@@ -770,7 +770,7 @@ exports[`WF_SingleRootElement_ContentAfter with mimeType text/xml should be repo
 exports[`WF_SingleRootElement_ContentAfter with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: Extra content at the end of the document
-    at error (lib/sax.js:#5)",
+    at error (lib/sax.js:#6)",
 ]
 `;
 
@@ -792,6 +792,6 @@ exports[`WF_SingleRootElement_ContentBefore with mimeType text/xml should be rep
 exports[`WF_SingleRootElement_ContentBefore with mimeType text/xml should escalate Error thrown in onError to ParseError 1`] = `
 [
   "error: Unexpected content outside root element: 'textbefore'
-    at error (lib/sax.js:#6)",
+    at error (lib/sax.js:#7)",
 ]
 `;

--- a/test/xmltest/__snapshots__/not-wf.test.js.snap
+++ b/test/xmltest/__snapshots__/not-wf.test.js.snap
@@ -1025,7 +1025,17 @@ exports[`xmltest/not-wellformed standalone should match 142.xml with snapshot: r
   "actual": "<!DOCTYPE doc [
 <!ELEMENT doc (#PCDATA)>
 ]>
-<doc>{!0!}</doc>",
+<doc>&amp;#0;</doc>",
+  "errors": [
+    [
+      "error",
+      "character reference to invalid XML character: &#0;",
+      {
+        "columnNumber": 6,
+        "lineNumber": 4,
+      },
+    ],
+  ],
 }
 `;
 
@@ -1034,7 +1044,17 @@ exports[`xmltest/not-wellformed standalone should match 143.xml with snapshot: r
   "actual": "<!DOCTYPE doc [
 <!ELEMENT doc (#PCDATA)>
 ]>
-<doc>{!1f!}</doc>",
+<doc>&amp;#31;</doc>",
+  "errors": [
+    [
+      "error",
+      "character reference to invalid XML character: &#31;",
+      {
+        "columnNumber": 6,
+        "lineNumber": 4,
+      },
+    ],
+  ],
 }
 `;
 
@@ -1043,7 +1063,17 @@ exports[`xmltest/not-wellformed standalone should match 144.xml with snapshot: r
   "actual": "<!DOCTYPE doc [
 <!ELEMENT doc (#PCDATA)>
 ]>
-<doc>{!ffff!}</doc>",
+<doc>&amp;#xFFFF;</doc>",
+  "errors": [
+    [
+      "error",
+      "character reference to invalid XML character: &#xFFFF;",
+      {
+        "columnNumber": 6,
+        "lineNumber": 4,
+      },
+    ],
+  ],
 }
 `;
 
@@ -1052,7 +1082,17 @@ exports[`xmltest/not-wellformed standalone should match 145.xml with snapshot: r
   "actual": "<!DOCTYPE doc [
 <!ELEMENT doc (#PCDATA)>
 ]>
-<doc>{!d800!}</doc>",
+<doc>&amp;#xD800;</doc>",
+  "errors": [
+    [
+      "error",
+      "character reference to invalid XML character: &#xD800;",
+      {
+        "columnNumber": 6,
+        "lineNumber": 4,
+      },
+    ],
+  ],
 }
 `;
 
@@ -1061,7 +1101,17 @@ exports[`xmltest/not-wellformed standalone should match 146.xml with snapshot: r
   "actual": "<!DOCTYPE doc [
 <!ELEMENT doc (#PCDATA)>
 ]>
-<doc>{!dc00!}{!dc00!}</doc>",
+<doc>&amp;#x110000;</doc>",
+  "errors": [
+    [
+      "error",
+      "character reference to invalid XML character: &#x110000;",
+      {
+        "columnNumber": 6,
+        "lineNumber": 4,
+      },
+    ],
+  ],
 }
 `;
 


### PR DESCRIPTION
entityReplacer decodes numeric character references by passing the parsed value straight to fixedFromCharCode without checking it against the XML Char production, so `&#0;`, `&#xB;`, lone surrogates like `&#xD800;` and out-of-range values like `&#x110000;` end up as control characters or stray surrogate code units in the DOM. Validate the code point inside entityReplacer and report an error leaving the reference unexpanded, the way an unknown named entity is already handled. The updated error snapshots only reflect the new reporting call site.