### PR TITLE
fix: reject invalid element and attribute names when requireWellFormed

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1586,13 +1586,19 @@ declare module '@xmldom/xmldom' {
 		 * concatenated CDATA sections — **deprecated**, will be removed in the next breaking
 		 * release.
 		 * - W3C DOM Parsing §3.2.1.1 requires well-formedness checks on Element `localName`s,
-		 * prefixes, and attribute serialization when `requireWellFormed` is `true`. These checks are
-		 * **not implemented** in this release — see the tracking issue filed against the next
-		 * breaking milestone.
+		 * prefixes, and attribute serialization when `requireWellFormed` is `true`. Element and
+		 * attribute qualified names (which cover the namespace prefix) are validated against the XML
+		 * `QName` production; the remaining §3.2.1.1 checks (duplicate attributes,
+		 * namespace-declaration consistency) and creation-time name validation are **not
+		 * implemented** in this release — see the tracking issue filed against the next breaking
+		 * milestone.
 		 *
 		 * @throws {DOMException}
 		 * `InvalidStateError` when `requireWellFormed` is `true` and any of the following conditions
 		 * hold:
+		 * - an Element's qualified name (including any namespace prefix) is not a valid XML QName
+		 * - an attribute's qualified name (including a synthesized `xmlns:` namespace declaration) is
+		 * not a valid XML QName
 		 * - CDATASection data contains `"]]>"`
 		 * - Text data contains characters outside the XML Char production
 		 * - a Comment node's data contains `--` anywhere or ends with `-`

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3039,7 +3039,13 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
  * @see https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes
  * @prettierignore
  */
-function addSerializedAttribute(buf, qualifiedName, value) {
+function addSerializedAttribute(buf, qualifiedName, value, requireWellFormed) {
+	if (requireWellFormed && !g.QName_exact.test(qualifiedName)) {
+		throw new DOMException(
+			'The attribute name "' + qualifiedName + '" is not a valid XML QName',
+			DOMExceptionName.InvalidStateError
+		);
+	}
 	buf.push(' ', qualifiedName, '="', value.replace(/[<>&"\t\n\r]/g, _xmlEncoder), '"');
 }
 
@@ -3111,6 +3117,13 @@ function serializeToString(node, buf, visibleNamespaces, opts) {
 							}
 						}
 
+						if (requireWellFormed && !g.QName_exact.test(prefixedNodeName)) {
+							throw new DOMException(
+								'The element name "' + prefixedNodeName + '" is not a valid XML QName',
+								DOMExceptionName.InvalidStateError
+							);
+						}
+
 						buf.push('<', prefixedNodeName);
 
 						// Build a fresh namespace snapshot for this element's children.
@@ -3135,7 +3148,7 @@ function serializeToString(node, buf, visibleNamespaces, opts) {
 							if (needNamespaceDefine(attr, isHTML, childNamespaces)) {
 								var attrPrefix = attr.prefix || '';
 								var uri = attr.namespaceURI;
-								addSerializedAttribute(buf, attrPrefix ? 'xmlns:' + attrPrefix : 'xmlns', uri);
+								addSerializedAttribute(buf, attrPrefix ? 'xmlns:' + attrPrefix : 'xmlns', uri, requireWellFormed);
 								childNamespaces.push({ prefix: attrPrefix, namespace: uri });
 							}
 							// Apply nodeFilter and serialize the attribute.
@@ -3144,7 +3157,7 @@ function serializeToString(node, buf, visibleNamespaces, opts) {
 								if (typeof filteredAttr === 'string') {
 									buf.push(filteredAttr);
 								} else {
-									addSerializedAttribute(buf, filteredAttr.name, filteredAttr.value);
+									addSerializedAttribute(buf, filteredAttr.name, filteredAttr.value, requireWellFormed);
 								}
 							}
 						}
@@ -3153,7 +3166,7 @@ function serializeToString(node, buf, visibleNamespaces, opts) {
 						if (nodeName === prefixedNodeName && needNamespaceDefine(n, isHTML, childNamespaces)) {
 							var nodePrefix = n.prefix || '';
 							var uri = n.namespaceURI;
-							addSerializedAttribute(buf, nodePrefix ? 'xmlns:' + nodePrefix : 'xmlns', uri);
+							addSerializedAttribute(buf, nodePrefix ? 'xmlns:' + nodePrefix : 'xmlns', uri, requireWellFormed);
 							childNamespaces.push({ prefix: nodePrefix, namespace: uri });
 						}
 
@@ -3197,7 +3210,7 @@ function serializeToString(node, buf, visibleNamespaces, opts) {
 						// Pass namespaces through; each child element will slice independently.
 						return { ns: namespaces };
 					case ATTRIBUTE_NODE:
-						addSerializedAttribute(buf, n.name, n.value);
+						addSerializedAttribute(buf, n.name, n.value, requireWellFormed);
 						return null;
 					case TEXT_NODE:
 						/*

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2927,8 +2927,11 @@ function XMLSerializer() {}
  * - W3C DOM Parsing §3.2.1.1 requires well-formedness checks on Element `localName`s,
  * prefixes,
  * and attribute serialization (duplicate attributes, namespace declarations, attribute value
- * characters) when `requireWellFormed` is `true`. These checks are **not implemented** in this
- * release — see the tracking issue filed against the next breaking milestone.
+ * characters) when `requireWellFormed` is `true`. Element and attribute qualified names (which
+ * cover the namespace prefix) are validated against the XML `QName` production; the remaining
+ * §3.2.1.1 checks (duplicate attributes, namespace-declaration consistency) and creation-time
+ * name validation are **not implemented** in this release — see the tracking issue filed
+ * against the next breaking milestone.
  *
  * @param {Node} node
  * @param {Object | function} [options]
@@ -2944,6 +2947,9 @@ function XMLSerializer() {}
  * @throws {DOMException}
  * With name `InvalidStateError` when `requireWellFormed` is `true` and any of the following
  * conditions hold:
+ * - an Element's qualified name (including any namespace prefix) is not a valid XML QName
+ * - an attribute's qualified name (including a synthesized `xmlns:` namespace declaration) is
+ * not a valid XML QName
  * - CDATASection data contains `"]]>"`
  * - Text data contains characters outside the XML Char production
  * - a Comment node's data contains `--` anywhere or ends with `-`

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -500,6 +500,35 @@ describe('XMLSerializer.serializeToString', () => {
 				expectDOMException(() => new XMLSerializer().serializeToString(dtDoc, { requireWellFormed: true }), 'InvalidStateError');
 			});
 		});
+
+		describe('Element', () => {
+			test('default: element with invalid name emits verbatim — no throw', () => {
+				doc.documentElement.appendChild(doc.createElement('x><inject'));
+				expect(() => new XMLSerializer().serializeToString(doc)).not.toThrow();
+			});
+
+			test('requireWellFormed: true on element with invalid name throws InvalidStateError', () => {
+				doc.documentElement.appendChild(doc.createElement('x><inject'));
+				expectDOMException(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true }), 'InvalidStateError');
+			});
+
+			test('requireWellFormed: true on element with valid QName does not throw', () => {
+				doc.documentElement.appendChild(doc.createElement('child'));
+				expect(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true })).not.toThrow();
+			});
+		});
+
+		describe('Attribute', () => {
+			test('requireWellFormed: true on attribute with invalid name throws InvalidStateError', () => {
+				doc.documentElement.setAttribute('a><inject ', 'v');
+				expectDOMException(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true }), 'InvalidStateError');
+			});
+
+			test('requireWellFormed: true on attribute with valid name does not throw', () => {
+				doc.documentElement.setAttribute('class', 'hello');
+				expect(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true })).not.toThrow();
+			});
+		});
 	});
 
 	describe('Attribute', () => {

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -529,6 +529,33 @@ describe('XMLSerializer.serializeToString', () => {
 				expect(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true })).not.toThrow();
 			});
 		});
+
+		describe('Namespace prefix', () => {
+			test('default: invalid prefix in synthesized xmlns declaration emits verbatim — no throw', () => {
+				const el = doc.createElementNS('http://example.com/ns', 'p:child');
+				doc.documentElement.appendChild(el);
+				el.prefix = 'evil>';
+				expect(() => new XMLSerializer().serializeToString(doc)).not.toThrow();
+			});
+
+			test('requireWellFormed: true on invalid prefix in synthesized xmlns declaration throws InvalidStateError', () => {
+				const el = doc.createElementNS('http://example.com/ns', 'p:child');
+				doc.documentElement.appendChild(el);
+				el.prefix = 'evil>';
+				expectDOMException(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true }), 'InvalidStateError');
+			});
+
+			test('requireWellFormed: true on invalid prefix in element qualified name throws InvalidStateError', () => {
+				doc.documentElement.appendChild(doc.createElement('evil>:child'));
+				expectDOMException(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true }), 'InvalidStateError');
+			});
+
+			test('requireWellFormed: true on element with valid prefix does not throw', () => {
+				const el = doc.createElementNS('http://example.com/ns', 'p:child');
+				doc.documentElement.appendChild(el);
+				expect(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true })).not.toThrow();
+			});
+		});
 	});
 
 	describe('Attribute', () => {


### PR DESCRIPTION
The requireWellFormed serializer validates Comment, ProcessingInstruction, CDATASection, Text and DocumentType content against their XML productions, but never the element or attribute name. createElement and setAttribute do no Name validation, so createElement('x><inject') or setAttribute('a><inject ', v) serialize to injected markup under { requireWellFormed: true } instead of throwing. Reject names that are not a valid QName, the same check createAttribute already applies at creation time.

The check is opt-in (only under `{ requireWellFormed: true }`); default serialization is unchanged. It also covers the **namespace-prefix** sub-vector: an invalid prefix surfaces in the element qualified name (`PREFIX:local`) or in a synthesized `xmlns:PREFIX` declaration, both of which are QName-checked — a regression test exercises both paths. The `serializeToString` `@throws` documentation is synchronized between `lib/dom.js` and `index.d.ts`.

Fixes:
- [**GHSA-w2rr-34g9-rvrj**](https://github.com/xmldom/xmldom/security/advisories/GHSA-w2rr-34g9-rvrj) — element name injection via `createElement()`
- [**GHSA-4w3w-2rp5-g8jm**](https://github.com/xmldom/xmldom/security/advisories/GHSA-4w3w-2rp5-g8jm) — attribute name injection via `setAttribute()`

Creation-time name validation (rejecting invalid names in `createElement`/`setAttribute`) is a breaking change deferred to the next breaking release.
