### PR TITLE
check attribute value against char production when requireWellFormed

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -3039,7 +3039,13 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
  * @see https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes
  * @prettierignore
  */
-function addSerializedAttribute(buf, qualifiedName, value) {
+function addSerializedAttribute(buf, qualifiedName, value, requireWellFormed) {
+	if (requireWellFormed && g.InvalidChar.test(value)) {
+		throw new DOMException(
+			'The attribute value contains characters outside the XML Char production',
+			DOMExceptionName.InvalidStateError
+		);
+	}
 	buf.push(' ', qualifiedName, '="', value.replace(/[<>&"\t\n\r]/g, _xmlEncoder), '"');
 }
 
@@ -3135,7 +3141,7 @@ function serializeToString(node, buf, visibleNamespaces, opts) {
 							if (needNamespaceDefine(attr, isHTML, childNamespaces)) {
 								var attrPrefix = attr.prefix || '';
 								var uri = attr.namespaceURI;
-								addSerializedAttribute(buf, attrPrefix ? 'xmlns:' + attrPrefix : 'xmlns', uri);
+								addSerializedAttribute(buf, attrPrefix ? 'xmlns:' + attrPrefix : 'xmlns', uri, requireWellFormed);
 								childNamespaces.push({ prefix: attrPrefix, namespace: uri });
 							}
 							// Apply nodeFilter and serialize the attribute.
@@ -3144,7 +3150,7 @@ function serializeToString(node, buf, visibleNamespaces, opts) {
 								if (typeof filteredAttr === 'string') {
 									buf.push(filteredAttr);
 								} else {
-									addSerializedAttribute(buf, filteredAttr.name, filteredAttr.value);
+									addSerializedAttribute(buf, filteredAttr.name, filteredAttr.value, requireWellFormed);
 								}
 							}
 						}
@@ -3153,7 +3159,7 @@ function serializeToString(node, buf, visibleNamespaces, opts) {
 						if (nodeName === prefixedNodeName && needNamespaceDefine(n, isHTML, childNamespaces)) {
 							var nodePrefix = n.prefix || '';
 							var uri = n.namespaceURI;
-							addSerializedAttribute(buf, nodePrefix ? 'xmlns:' + nodePrefix : 'xmlns', uri);
+							addSerializedAttribute(buf, nodePrefix ? 'xmlns:' + nodePrefix : 'xmlns', uri, requireWellFormed);
 							childNamespaces.push({ prefix: nodePrefix, namespace: uri });
 						}
 
@@ -3197,7 +3203,7 @@ function serializeToString(node, buf, visibleNamespaces, opts) {
 						// Pass namespaces through; each child element will slice independently.
 						return { ns: namespaces };
 					case ATTRIBUTE_NODE:
-						addSerializedAttribute(buf, n.name, n.value);
+						addSerializedAttribute(buf, n.name, n.value, requireWellFormed);
 						return null;
 					case TEXT_NODE:
 						/*

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -500,6 +500,29 @@ describe('XMLSerializer.serializeToString', () => {
 				expectDOMException(() => new XMLSerializer().serializeToString(dtDoc, { requireWellFormed: true }), 'InvalidStateError');
 			});
 		});
+
+		describe('Attribute', () => {
+			test('default: attribute value with invalid XML Char (\\x00) emits verbatim — no throw', () => {
+				doc.documentElement.setAttribute('attr', 'a\x00b');
+				expect(() => new XMLSerializer().serializeToString(doc)).not.toThrow();
+			});
+
+			test('requireWellFormed: true on attribute value with invalid XML Char (\\x00) throws InvalidStateError', () => {
+				doc.documentElement.setAttribute('attr', 'a\x00b');
+				expectDOMException(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true }), 'InvalidStateError');
+			});
+
+			test('requireWellFormed: true on attribute value with valid characters does not throw', () => {
+				doc.documentElement.setAttribute('attr', 'clean value');
+				expect(() => new XMLSerializer().serializeToString(doc, { requireWellFormed: true })).not.toThrow();
+			});
+
+			test('requireWellFormed: true serializing an Attr node directly with invalid XML Char throws InvalidStateError', () => {
+				const attr = doc.createAttribute('attr');
+				attr.value = 'a\x01b';
+				expectDOMException(() => new XMLSerializer().serializeToString(attr, { requireWellFormed: true }), 'InvalidStateError');
+			});
+		});
 	});
 
 	describe('Attribute', () => {


### PR DESCRIPTION
Noticed the requireWellFormed serializer checks text, comment, PI, cdata and doctype content against the Char production but never attribute values. addSerializedAttribute emits raw NUL/control chars and returns without throwing, while the same data in a text node already throws. Added the InvalidChar check there so it also covers namespace declarations and directly serialized Attr nodes.