### PR TITLE
fix: reject invalid element and attribute names when requireWellFormed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.14](https://github.com/xmldom/xmldom/compare/0.8.13...0.8.14)
+
+### Fixed
+
+- Security: `XMLSerializer.serializeToString()` now also rejects invalid element and attribute names when `{ requireWellFormed: true }` is passed, throwing `InvalidStateError` for a name that is not a valid XML [`QName`](https://www.w3.org/TR/xml-names/#NT-QName) (this covers the namespace prefix, which surfaces in the element qualified name or in a synthesized `xmlns:` declaration). This prevents XML injection via `createElement()` / `setAttribute()`, extending the existing `requireWellFormed` checks to the serialized name set. [`GHSA-w2rr-34g9-rvrj`](https://github.com/xmldom/xmldom/security/advisories/GHSA-w2rr-34g9-rvrj) [`GHSA-4w3w-2rp5-g8jm`](https://github.com/xmldom/xmldom/security/advisories/GHSA-4w3w-2rp5-g8jm)
+
+Thank you,
+[@bhaswanthc](https://github.com/bhaswanthc),
+[@jmestwa-coder](https://github.com/jmestwa-coder),
+for your contributions
+
 ## [0.8.13](https://github.com/xmldom/xmldom/compare/0.8.12...0.8.13)
 
 ### Fixed

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,6 +53,9 @@ declare module "@xmldom/xmldom" {
        *
        * @throws {DOMException}
        * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and:
+       * - an Element's qualified name (including any namespace prefix) is not a valid XML QName,
+       * - an attribute's qualified name (including a synthesized `xmlns:` namespace declaration)
+       *   is not a valid XML QName,
        * - a CDATASection node's data contains `"]]>"`,
        * - a Comment node's data contains `"-->"` (bare `"--"` does not throw on this branch),
        * - a ProcessingInstruction's data contains `"?>"`,

--- a/lib/conventions.js
+++ b/lib/conventions.js
@@ -196,8 +196,19 @@ var NAMESPACE = freeze({
 	XMLNS: 'http://www.w3.org/2000/xmlns/',
 })
 
+//[4]   	NameStartChar	   ::=   	":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
+//[4a]   	NameChar	   ::=   	NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
+//[5]   	Name	   ::=   	NameStartChar (NameChar)*
+var nameStartChar = /[A-Z_a-z\xC0-\xD6\xD8-\xF6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]///\u10000-\uEFFFF
+var nameChar = new RegExp("[\\-\\.0-9"+nameStartChar.source.slice(1,-1)+"\\u00B7\\u0300-\\u036F\\u203F-\\u2040]");
+var tagNamePattern = new RegExp('^'+nameStartChar.source+nameChar.source+'*(?:\:'+nameStartChar.source+nameChar.source+'*)?$');
+//var tagNamePattern = /^[a-zA-Z_][\w\-\.]*(?:\:[a-zA-Z_][\w\-\.]*)?$/
+
 exports.assign = assign;
 exports.find = find;
 exports.freeze = freeze;
 exports.MIME_TYPE = MIME_TYPE;
 exports.NAMESPACE = NAMESPACE;
+exports.nameStartChar = nameStartChar;
+exports.nameChar = nameChar;
+exports.tagNamePattern = tagNamePattern;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -2,6 +2,7 @@ var conventions = require("./conventions");
 
 var find = conventions.find;
 var NAMESPACE = conventions.NAMESPACE;
+var tagNamePattern = conventions.tagNamePattern;
 
 /**
  * A prerequisite for `[].filter`, to drop elements that are empty
@@ -1657,6 +1658,9 @@ function XMLSerializer(){}
  * @returns {string}
  * @throws {DOMException}
  * With code `INVALID_STATE_ERR` when `requireWellFormed` is `true` and:
+ * - an Element's qualified name (including any namespace prefix) is not a valid XML QName,
+ * - an attribute's qualified name (including a synthesized `xmlns:` namespace declaration) is
+ *   not a valid XML QName,
  * - a CDATASection node's data contains `"]]>"`,
  * - a Comment node's data contains `"-->"` (bare `"--"` does not throw on this branch),
  * - a ProcessingInstruction's data contains `"?>"`,
@@ -1738,7 +1742,10 @@ function needNamespaceDefine(node, isHTML, visibleNamespaces) {
  * @see https://www.w3.org/TR/xml11/#AVNormalize
  * @see https://w3c.github.io/DOM-Parsing/#serializing-an-element-s-attributes
  */
-function addSerializedAttribute(buf, qualifiedName, value) {
+function addSerializedAttribute(buf, qualifiedName, value, requireWellFormed) {
+	if (requireWellFormed && !tagNamePattern.test(qualifiedName)) {
+		throw new DOMException(INVALID_STATE_ERR, 'The attribute name "' + qualifiedName + '" is not a valid XML QName');
+	}
 	buf.push(' ', qualifiedName, '="', value.replace(/[<>&"\t\n\r]/g, _xmlEncoder), '"')
 }
 
@@ -1804,6 +1811,9 @@ function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, req
 						}
 					}
 
+					if (requireWellFormed && !tagNamePattern.test(prefixedNodeName)) {
+						throw new DOMException(INVALID_STATE_ERR, 'The element name "' + prefixedNodeName + '" is not a valid XML QName');
+					}
 					buf.push('<', prefixedNodeName);
 
 					// Build a fresh namespace snapshot for this element's children.
@@ -1823,7 +1833,7 @@ function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, req
 						if (needNamespaceDefine(attr, html, childNs)) {
 							var attrPrefix = attr.prefix || '';
 							var uri = attr.namespaceURI;
-							addSerializedAttribute(buf, attrPrefix ? 'xmlns:' + attrPrefix : 'xmlns', uri);
+							addSerializedAttribute(buf, attrPrefix ? 'xmlns:' + attrPrefix : 'xmlns', uri, requireWellFormed);
 							childNs.push({ prefix: attrPrefix, namespace: uri });
 						}
 						// Apply nodeFilter and serialize the attribute.
@@ -1832,7 +1842,7 @@ function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, req
 							if (typeof filteredAttr === 'string') {
 								buf.push(filteredAttr);
 							} else {
-								addSerializedAttribute(buf, filteredAttr.name, filteredAttr.value);
+								addSerializedAttribute(buf, filteredAttr.name, filteredAttr.value, requireWellFormed);
 							}
 						}
 					}
@@ -1841,7 +1851,7 @@ function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, req
 					if (nodeName === prefixedNodeName && needNamespaceDefine(n, html, childNs)) {
 						var nodePrefix = n.prefix || '';
 						var uri = n.namespaceURI;
-						addSerializedAttribute(buf, nodePrefix ? 'xmlns:' + nodePrefix : 'xmlns', uri);
+						addSerializedAttribute(buf, nodePrefix ? 'xmlns:' + nodePrefix : 'xmlns', uri, requireWellFormed);
 						childNs.push({ prefix: nodePrefix, namespace: uri });
 					}
 
@@ -1874,7 +1884,7 @@ function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, req
 					return { ns: ns.slice(), isHTML: html, tag: null };
 
 				case ATTRIBUTE_NODE:
-					addSerializedAttribute(buf, n.name, n.value);
+					addSerializedAttribute(buf, n.name, n.value, requireWellFormed);
 					return null;
 
 				case TEXT_NODE:

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -1,12 +1,6 @@
 var NAMESPACE = require("./conventions").NAMESPACE;
+var tagNamePattern = require("./conventions").tagNamePattern;
 
-//[4]   	NameStartChar	   ::=   	":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
-//[4a]   	NameChar	   ::=   	NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
-//[5]   	Name	   ::=   	NameStartChar (NameChar)*
-var nameStartChar = /[A-Z_a-z\xC0-\xD6\xD8-\xF6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]///\u10000-\uEFFFF
-var nameChar = new RegExp("[\\-\\.0-9"+nameStartChar.source.slice(1,-1)+"\\u00B7\\u0300-\\u036F\\u203F-\\u2040]");
-var tagNamePattern = new RegExp('^'+nameStartChar.source+nameChar.source+'*(?:\:'+nameStartChar.source+nameChar.source+'*)?$');
-//var tagNamePattern = /^[a-zA-Z_][\w\-\.]*(?:\:[a-zA-Z_][\w\-\.]*)?$/
 //var handlers = 'resolveEntity,getExternalSubset,characters,endDocument,endElement,endPrefixMapping,ignorableWhitespace,processingInstruction,setDocumentLocator,skippedEntity,startDocument,startElement,startPrefixMapping,notationDecl,unparsedEntityDecl,error,fatalError,warning,attributeDecl,elementDecl,externalEntityDecl,internalEntityDecl,comment,endCDATA,endDTD,endEntity,startCDATA,startDTD,startEntity'.split(',')
 
 //S_TAG,	S_ATTR,	S_EQ,	S_ATTR_NOQUOT_VALUE

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -594,6 +594,95 @@ describe('XMLSerializer serializeToString requireWellFormed option', () => {
 		})
 	})
 
+	describe('Element', () => {
+		it('default: element with invalid name emits verbatim — no throw', () => {
+			doc.documentElement.appendChild(doc.createElement('x><inject'))
+			expect(() => new XMLSerializer().serializeToString(doc)).not.toThrow()
+		})
+
+		it('requireWellFormed: true on element with invalid name throws InvalidStateError', () => {
+			doc.documentElement.appendChild(doc.createElement('x><inject'))
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on element with valid name does not throw', () => {
+			doc.documentElement.appendChild(doc.createElement('child'))
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).not.toThrow()
+		})
+	})
+
+	describe('Attribute', () => {
+		it('default: attribute with invalid name emits verbatim — no throw', () => {
+			doc.documentElement.setAttribute('a><inject ', 'v')
+			expect(() => new XMLSerializer().serializeToString(doc)).not.toThrow()
+		})
+
+		it('requireWellFormed: true on attribute with invalid name throws InvalidStateError', () => {
+			doc.documentElement.setAttribute('a><inject ', 'v')
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on attribute with valid name does not throw', () => {
+			doc.documentElement.setAttribute('class', 'hello')
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).not.toThrow()
+		})
+	})
+
+	describe('Namespace prefix', () => {
+		it('default: invalid prefix in synthesized xmlns declaration emits verbatim — no throw', () => {
+			const el = doc.createElementNS('http://example.com/ns', 'p:child')
+			doc.documentElement.appendChild(el)
+			el.prefix = 'evil>'
+			expect(() => new XMLSerializer().serializeToString(doc)).not.toThrow()
+		})
+
+		it('requireWellFormed: true on invalid prefix in synthesized xmlns declaration throws InvalidStateError', () => {
+			const el = doc.createElementNS('http://example.com/ns', 'p:child')
+			doc.documentElement.appendChild(el)
+			el.prefix = 'evil>'
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on invalid prefix in element qualified name throws InvalidStateError', () => {
+			doc.documentElement.appendChild(doc.createElement('evil>:child'))
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on element with valid prefix does not throw', () => {
+			const el = doc.createElementNS('http://example.com/ns', 'p:child')
+			doc.documentElement.appendChild(el)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).not.toThrow()
+		})
+	})
+
 	describe('EntityReference', () => {
 		test('serializes EntityReference node as &name;', () => {
 			const xmlDoc = new DOMImplementation().createDocument(null, '')


### PR DESCRIPTION
## Backport: reject invalid element and attribute names when `requireWellFormed`

Backports the serializer `requireWellFormed` name checks to the 0.8.x LTS line (approach from #1043 by @jmestwa-coder, adapted to 0.8.x conventions).

Under `{ requireWellFormed: true }`, `serializeToString` now throws `InvalidStateError` when an element's qualified name, or an attribute's qualified name (including a synthesized `xmlns:PREFIX` declaration), is not a valid XML QName — closing the same `createElement()` / `setAttribute()` serializer bypass fixed on `main`. The check is opt-in; default serialization is unchanged.

Two commits:
1. **`refactor:`** — move the `nameStartChar` / `nameChar` / `tagNamePattern` regexes from `lib/sax.js` into `lib/conventions.js` (byte-identical; the parser is unchanged) so the serializer can reuse the anchored name pattern the parser already enforces.
2. **`fix:`** — the serializer element/attribute name checks, tests (element / attribute / namespace-prefix), and synchronized `@throws` docs in `lib/dom.js` + `index.d.ts`.

Fixes (0.8.x line):
- [**GHSA-w2rr-34g9-rvrj**](https://github.com/xmldom/xmldom/security/advisories/GHSA-w2rr-34g9-rvrj) — element name injection via `createElement()`
- [**GHSA-4w3w-2rp5-g8jm**](https://github.com/xmldom/xmldom/security/advisories/GHSA-4w3w-2rp5-g8jm) — attribute name injection via `setAttribute()`

Creation-time name validation is a breaking change deferred to the next breaking release. The PI-ReDoS issue does not affect this line (0.8.x parses PIs via a different, `indexOf('?>')`-bounded path).
