### PR TITLE
Backport security release 0.8.15 — parser/DOM DoS, serializer name checks, end-tag reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.15](https://github.com/xmldom/xmldom/compare/0.8.14...0.8.15)
+
+### Fixed
+
+- Security: parsing a deeply or repeatedly namespaced document no longer consumes quadratic memory; the in-scope namespace map is inherited through the prototype chain instead of being copied for every prefix-declaring element (O(N) instead of O(N²)), preventing a denial-of-service reachable from `DOMParser.parseFromString` with default options. Serialized output is byte-identical. [`GHSA-965w-775f-mr7g`](https://github.com/xmldom/xmldom/security/advisories/GHSA-965w-775f-mr7g)
+- Security: attribute de-duplication during parsing is now O(M) instead of O(M²); the `NamedNodeMap` parse-time dedup path uses a null-prototype membership index, so a well-formed document with a hostile number of duplicate attributes can no longer wedge the parse. Attribute order and duplicate resolution (last value wins, first position kept) are byte-identical, preserving the XML [no-duplicate-attributes well-formedness constraint](https://www.w3.org/TR/xml/#uniqattspec). [`GHSA-8344-3jmq-59r6`](https://github.com/xmldom/xmldom/security/advisories/GHSA-8344-3jmq-59r6)
+- Security: trimming trailing whitespace from an XML end tag ([`ETag`](https://www.w3.org/TR/xml/#NT-ETag)) is now anchored so it runs in linear time instead of backtracking quadratically on a long whitespace run, preventing a ReDoS reachable from `DOMParser.parseFromString`. Trimmed output is byte-identical. [`GHSA-x4fp-j954-r2f4`](https://github.com/xmldom/xmldom/security/advisories/GHSA-x4fp-j954-r2f4)
+- Security: malformed-input recovery is now linear instead of quadratic — the malformed tag-name scan terminates at an embedded `<`, and `Node.prototype.normalize()` merges adjacent text nodes in O(K) instead of O(K²) (also reachable programmatically), per [`normalize()`](https://dom.spec.whatwg.org/#dom-node-normalize) in the WHATWG DOM spec. DOM output is unchanged; only the reported error text differs. [`GHSA-93r5-fhx6-vmg9`](https://github.com/xmldom/xmldom/security/advisories/GHSA-93r5-fhx6-vmg9)
+- Security: `XMLSerializer.serializeToString()` under `{ requireWellFormed: true }` now rejects a DocType `name` that is not a valid XML [`Name`](https://www.w3.org/TR/xml/#NT-Name), throwing `InvalidStateError` — matching the sibling `publicId`/`systemId`/`internalSubset` checks and preventing XML injection via `DocumentType.name`. [`GHSA-27p8-2357-5qqv`](https://github.com/xmldom/xmldom/security/advisories/GHSA-27p8-2357-5qqv)
+- Security: `XMLSerializer.serializeToString()` under `{ requireWellFormed: true }` now validates a processing-instruction target as an XML [`NCName`](https://www.w3.org/TR/xml-names/#NT-NCName) and rejects a case-insensitive `xml`, throwing `InvalidStateError` — a check `0.8.x` did not previously perform, preventing PI-target injection via `>`, `?`, or whitespace. [`GHSA-c7q8-3ch8-vqpv`](https://github.com/xmldom/xmldom/security/advisories/GHSA-c7q8-3ch8-vqpv)
+- Security: `Document.createEntityReference()` now rejects an invalid XML [`Name`](https://www.w3.org/TR/xml/#NT-Name) at creation, and `XMLSerializer.serializeToString()` under `{ requireWellFormed: true }` validates an `EntityReference` `nodeName` as an XML `Name`, throwing `InvalidStateError` — preventing XML injection via an entity-reference name. [`GHSA-6gmq-8vp8-gcm6`](https://github.com/xmldom/xmldom/security/advisories/GHSA-6gmq-8vp8-gcm6)
+- Security: the parser now reports a not-well-formed end tag whose valid name is followed by trailing content as a recoverable `error` instead of accepting it silently, per the XML [`ETag`](https://www.w3.org/TR/xml/#NT-ETag) production; parsing recovers to the byte-identical DOM. Consumers that want strict rejection can escalate the reported `error` to fatal via the parser's `errorHandler`. [`GHSA-6h8r-xr42-gp59`](https://github.com/xmldom/xmldom/security/advisories/GHSA-6h8r-xr42-gp59)
+
+Thank you,
+[@ericchiang](https://github.com/ericchiang),
+[@bhaswanthc](https://github.com/bhaswanthc),
+[@arpitjain099](https://github.com/arpitjain099),
+[@Paranoidgrinch](https://github.com/Paranoidgrinch),
+for your contributions
+
 ## [0.8.14](https://github.com/xmldom/xmldom/compare/0.8.13...0.8.14)
 
 ### Fixed

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,9 @@ declare module "@xmldom/xmldom" {
        * - A Comment node's data contains `"-->"` (the injection sequence that terminates a
        *   comment). Comments whose data contains `"--"` but not `"-->"` are accepted on this
        *   branch — the 0.8.x parser does not validate bare `"--"` in comment content.
-       * - A ProcessingInstruction's data contains `"?>"` (W3C DOM Parsing §3.2.1.7).
+       * - A ProcessingInstruction's target is not a valid XML `NCName` (a `Name` with no colon)
+       *   or is an ASCII case-insensitive match for `"xml"`, or its data contains `"?>"`
+       *   (W3C DOM Parsing §3.2.1.7).
        *
        * @default false
        */
@@ -58,7 +60,8 @@ declare module "@xmldom/xmldom" {
        *   is not a valid XML QName,
        * - a CDATASection node's data contains `"]]>"`,
        * - a Comment node's data contains `"-->"` (bare `"--"` does not throw on this branch),
-       * - a ProcessingInstruction's data contains `"?>"`,
+       * - a ProcessingInstruction's target is not a valid XML `NCName` (a `Name` with no colon) or
+       *   is an ASCII case-insensitive match for `"xml"`, or its data contains `"?>"`,
        * - a DocumentType's `name` is not a valid XML `Name` (XML 1.0 production [5]),
        * - a DocumentType's `publicId` is non-empty and does not match the XML `PubidLiteral`
        *   production,

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,7 @@ declare module "@xmldom/xmldom" {
        * - a CDATASection node's data contains `"]]>"`,
        * - a Comment node's data contains `"-->"` (bare `"--"` does not throw on this branch),
        * - a ProcessingInstruction's data contains `"?>"`,
+       * - a DocumentType's `name` is not a valid XML `Name` (XML 1.0 production [5]),
        * - a DocumentType's `publicId` is non-empty and does not match the XML `PubidLiteral`
        *   production,
        * - a DocumentType's `systemId` is non-empty and does not match the XML `SystemLiteral`

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ declare module "@xmldom/xmldom" {
        * - A ProcessingInstruction's target is not a valid XML `NCName` (a `Name` with no colon)
        *   or is an ASCII case-insensitive match for `"xml"`, or its data contains `"?>"`
        *   (W3C DOM Parsing §3.2.1.7).
+       * - An EntityReference's `nodeName` is not a valid XML `Name`.
        *
        * @default false
        */
@@ -66,8 +67,9 @@ declare module "@xmldom/xmldom" {
        * - a DocumentType's `publicId` is non-empty and does not match the XML `PubidLiteral`
        *   production,
        * - a DocumentType's `systemId` is non-empty and does not match the XML `SystemLiteral`
-       *   production, or
-       * - a DocumentType's `internalSubset` contains `"]>"`.
+       *   production,
+       * - a DocumentType's `internalSubset` contains `"]>"`, or
+       * - an EntityReference's `nodeName` is not a valid XML `Name` (XML 1.0 production [5]).
        * Note: xmldom does not enforce `readonly` on DocumentType fields — direct property
        * writes succeed and are covered by the serializer-level checks above.
        * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -564,9 +564,38 @@ Node.prototype = {
 				while (child) {
 					var next = child.nextSibling;
 					if (next !== null && next.nodeType === TEXT_NODE && child.nodeType === TEXT_NODE) {
-						node.removeChild(next);
-						child.appendData(next.data);
-						// Do not advance child: re-check new nextSibling for another text run
+						// Merge the whole run of adjacent text nodes at once: gather the
+						// following text siblings' data, unlink them in a single pass, and
+						// re-index the child list a single time. Per-sibling `removeChild`
+						// (each an O(K) re-index) plus per-sibling `appendData` (each an O(K)
+						// string rebuild) is O(K^2) over a long run of single-character text
+						// nodes; this keeps it O(K). The first text node of the run survives
+						// and carries the concatenated data, preserving node identity and
+						// locator semantics.
+						var tail = [];
+						var sibling = next;
+						while (sibling !== null && sibling.nodeType === TEXT_NODE) {
+							tail.push(sibling.data);
+							sibling = sibling.nextSibling;
+						}
+						// `sibling` is now the first non-text node after the run, or null.
+						var removed = child.nextSibling;
+						while (removed !== sibling) {
+							var following = removed.nextSibling;
+							removed.parentNode = null;
+							removed.previousSibling = null;
+							removed.nextSibling = null;
+							removed = following;
+						}
+						child.nextSibling = sibling;
+						if (sibling !== null) {
+							sibling.previousSibling = child;
+						} else {
+							node.lastChild = child;
+						}
+						child.appendData(tail.join('')); // single O(K) string rebuild
+						_onUpdateChild(node.ownerDocument, node); // single O(K) re-index
+						child = sibling;
 					} else {
 						child = next;
 					}

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1350,8 +1350,10 @@ Document.prototype = {
 	 * - it does not do any input validation on the arguments and doesn't throw "InvalidCharacterError".
 	 *
 	 * Note: When the resulting document is serialized with `requireWellFormed: true`, the
-	 * serializer throws with code `INVALID_STATE_ERR` if `.data` contains `?>` (W3C DOM Parsing
-	 * §3.2.1.7). Without that option the data is emitted verbatim.
+	 * serializer throws with code `INVALID_STATE_ERR` if `.target` is not a valid XML `NCName`
+	 * (a `Name` with no colon) or is an ASCII case-insensitive match for `"xml"`, or if `.data`
+	 * contains `?>` (W3C DOM Parsing §3.2.1.7). Without that option the target and data are
+	 * emitted verbatim.
 	 *
 	 * @param {string} target
 	 * @param {string} data
@@ -1664,7 +1666,8 @@ function XMLSerializer(){}
  *   not a valid XML QName,
  * - a CDATASection node's data contains `"]]>"`,
  * - a Comment node's data contains `"-->"` (bare `"--"` does not throw on this branch),
- * - a ProcessingInstruction's data contains `"?>"`,
+ * - a ProcessingInstruction's target is not a valid XML `NCName` (a `Name` with no colon) or is
+ *   an ASCII case-insensitive match for `"xml"`, or its data contains `"?>"`,
  * - a DocumentType's `name` is not a valid XML `Name` (XML 1.0 production [5]),
  * - a DocumentType's `publicId` is non-empty and does not match the XML `PubidLiteral`
  *   production,
@@ -1959,8 +1962,16 @@ function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, req
 					return null;
 
 				case PROCESSING_INSTRUCTION_NODE:
-					if (requireWellFormed && n.data.indexOf('?>') !== -1) {
-						throw new DOMException(INVALID_STATE_ERR, 'The ProcessingInstruction data contains "?>"');
+					if (requireWellFormed) {
+						if (!tagNamePattern.test(n.target) || n.target.indexOf(':') !== -1 || n.target.toLowerCase() === 'xml') {
+							throw new DOMException(
+								INVALID_STATE_ERR,
+								'The processing instruction target "' + n.target + '" is not a valid XML NCName or is reserved'
+							);
+						}
+						if (n.data.indexOf('?>') !== -1) {
+							throw new DOMException(INVALID_STATE_ERR, 'The ProcessingInstruction data contains "?>"');
+						}
 					}
 					buf.push('<?', n.target, ' ', n.data, '?>');
 					return null;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -237,6 +237,13 @@ _extends(LiveNodeList,NodeList);
  * used for attributes or DocumentType entities
  */
 function NamedNodeMap() {
+	// nodeName -> Attr membership index; lets the parse-time de-duplication in
+	// setNamedItem resolve an existing attribute in O(1) instead of scanning the
+	// list, so building an element with M attributes costs O(M) rather than O(M^2).
+	// The numbered entries and length remain the sole authority for attribute order.
+	// Object.create(null) so an attribute named __proto__ or constructor is an
+	// ordinary key.
+	this._nameIndex = Object.create(null);
 };
 
 function _findNodeIndex(list,node){
@@ -246,12 +253,27 @@ function _findNodeIndex(list,node){
 	}
 }
 
+function _nnmIndexAdd(list, attr) {
+	list._nameIndex[attr.nodeName] = attr;
+}
+function _nnmIndexRemove(list, attr) {
+	// Only drop the entry if it still points at this attribute; a replacement with
+	// a different nodeName may already have re-keyed it.
+	if (list._nameIndex[attr.nodeName] === attr) {
+		delete list._nameIndex[attr.nodeName];
+	}
+}
+
 function _addNamedNode(el,list,newAttr,oldAttr){
 	if(oldAttr){
 		list[_findNodeIndex(list,oldAttr)] = newAttr;
+		// oldAttr leaves the list; drop its index entry (its nodeName may differ
+		// from newAttr's when the replacement came via setNamedItemNS).
+		_nnmIndexRemove(list, oldAttr);
 	}else{
 		list[list.length++] = newAttr;
 	}
+	_nnmIndexAdd(list, newAttr);
 	if(el){
 		newAttr.ownerElement = el;
 		var doc = el.ownerDocument;
@@ -270,6 +292,7 @@ function _removeNamedNode(el,list,attr){
 			list[i] = list[++i]
 		}
 		list.length = lastIndex;
+		_nnmIndexRemove(list, attr);
 		if(el){
 			var doc = el.ownerDocument;
 			if(doc){
@@ -303,7 +326,11 @@ NamedNodeMap.prototype = {
 		if(el && el!=this._ownerElement){
 			throw new DOMException(INUSE_ATTRIBUTE_ERR);
 		}
-		var oldAttr = this.getNamedItem(attr.nodeName);
+		// Resolve any existing attribute with the same nodeName through the O(1)
+		// membership index rather than an O(M) scan — this is the parse-dedup hot
+		// path (setAttributeNode per attribute during parse). Absent -> undefined,
+		// matching getNamedItem's contract.
+		var oldAttr = this._nameIndex[attr.nodeName];
 		_addNamedNode(this._ownerElement,this,attr,oldAttr);
 		return oldAttr;
 	},

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1594,15 +1594,16 @@ _extends(CDATASection,CharacterData);
 /**
  * Represents a DocumentType node (the `<!DOCTYPE ...>` declaration).
  *
- * `publicId`, `systemId`, and `internalSubset` are plain own-property assignments.
+ * `name`, `publicId`, `systemId`, and `internalSubset` are plain own-property assignments.
  * xmldom does not enforce the `readonly` constraint declared by the WHATWG DOM spec —
  * direct property writes succeed silently. Values are serialized verbatim when
  * `requireWellFormed` is false (the default). When the serializer is invoked with
  * `requireWellFormed: true` (via the 4th-parameter options object), it validates each
- * field and throws `DOMException` with code `INVALID_STATE_ERR` on invalid values.
+ * field — including `name`, which is checked against the XML `Name` production — and throws
+ * `DOMException` with code `INVALID_STATE_ERR` on invalid values.
  *
  * @class
- * @see https://developer.mozilla.org/en-US/docs/Web/API/DocumentType MDN
+ * @see https://developer.mozilla.org/docs/Web/API/DocumentType MDN
  */
 function DocumentType() {
 };
@@ -1664,6 +1665,7 @@ function XMLSerializer(){}
  * - a CDATASection node's data contains `"]]>"`,
  * - a Comment node's data contains `"-->"` (bare `"--"` does not throw on this branch),
  * - a ProcessingInstruction's data contains `"?>"`,
+ * - a DocumentType's `name` is not a valid XML `Name` (XML 1.0 production [5]),
  * - a DocumentType's `publicId` is non-empty and does not match the XML `PubidLiteral`
  *   production,
  * - a DocumentType's `systemId` is non-empty and does not match the XML `SystemLiteral`
@@ -1923,6 +1925,9 @@ function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, req
 
 				case DOCUMENT_TYPE_NODE:
 					if (requireWellFormed) {
+						if (!tagNamePattern.test(n.name)) {
+							throw new DOMException(INVALID_STATE_ERR, 'The doctype name "' + n.name + '" is not a valid XML Name');
+						}
 						if (n.publicId && !/^("[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%']*"|'[\x20\r\na-zA-Z0-9\-()+,.\/:=?;!*#@$_%'"]*')$/.test(n.publicId)) {
 							throw new DOMException(INVALID_STATE_ERR, 'DocumentType publicId is not a valid PubidLiteral');
 						}

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1378,7 +1378,27 @@ Document.prototype = {
 		node.specified = true;
 		return node;
 	},
+	/**
+	 * Creates an EntityReference object, serialized as `&name;`.
+	 *
+	 * The `name` is validated against the XML `Name` production at creation time; an invalid name
+	 * throws a `DOMException` with code `INVALID_CHARACTER_ERR`. When the resulting node is
+	 * serialized with `requireWellFormed: true`, the serializer re-validates `nodeName` and throws
+	 * a `DOMException` with code `INVALID_STATE_ERR` if a later `nodeName` mutation made it invalid;
+	 * without that option the name is emitted verbatim.
+	 *
+	 * Note: xmldom does not expand entities — the parser resolves entity references inline and never
+	 * constructs `EntityReference` nodes, so this method is the only producer.
+	 *
+	 * @param {string} name The name of the entity to reference.
+	 * @returns {EntityReference}
+	 * @throws {DOMException} With code `INVALID_CHARACTER_ERR` when `name` is not a valid XML `Name`.
+	 * @see https://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-392B75AE
+	 */
 	createEntityReference :	function(name){
+		if (!tagNamePattern.test(name)) {
+			throw new DOMException(INVALID_CHARACTER_ERR, 'not a valid xml name "' + name + '"');
+		}
 		var node = new EntityReference();
 		node.ownerDocument	= this;
 		node.nodeName	= name;
@@ -1622,6 +1642,20 @@ function Entity() {
 Entity.prototype.nodeType = ENTITY_NODE;
 _extends(Entity,Node);
 
+/**
+ * Represents an EntityReference node, serialized as `&nodeName;`.
+ *
+ * `nodeName` is the referenced entity's name, stored verbatim. When serialized with
+ * `requireWellFormed: true`, the serializer validates `nodeName` against the XML `Name` production
+ * and throws a `DOMException` with code `INVALID_STATE_ERR` if it does not match; without that
+ * option the name is emitted verbatim between `&` and `;`.
+ *
+ * Note: xmldom does not expand entities — the parser resolves entity references inline and never
+ * constructs `EntityReference` nodes, so the only producer is `Document.createEntityReference`.
+ *
+ * @class
+ * @see https://www.w3.org/TR/xml/#NT-Name
+ */
 function EntityReference() {
 };
 EntityReference.prototype.nodeType = ENTITY_REFERENCE_NODE;
@@ -1672,8 +1706,9 @@ function XMLSerializer(){}
  * - a DocumentType's `publicId` is non-empty and does not match the XML `PubidLiteral`
  *   production,
  * - a DocumentType's `systemId` is non-empty and does not match the XML `SystemLiteral`
- *   production, or
- * - a DocumentType's `internalSubset` contains `"]>"`.
+ *   production,
+ * - a DocumentType's `internalSubset` contains `"]>"`, or
+ * - an EntityReference's `nodeName` is not a valid XML `Name` (XML 1.0 production [5]).
  * Note: xmldom does not enforce `readonly` on DocumentType fields — direct property
  * writes succeed and are covered by the serializer-level checks above.
  * @see https://html.spec.whatwg.org/#dom-xmlserializer-serializetostring
@@ -1977,6 +2012,12 @@ function serializeToString(node, buf, isHTML, nodeFilter, visibleNamespaces, req
 					return null;
 
 				case ENTITY_REFERENCE_NODE:
+					if (requireWellFormed && !tagNamePattern.test(n.nodeName)) {
+						throw new DOMException(
+							INVALID_STATE_ERR,
+							'The entity reference name "' + n.nodeName + '" is not a valid XML Name'
+						);
+					}
 					buf.push('&', n.nodeName, ';');
 					return null;
 

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -259,6 +259,15 @@ function parseElementStartPart(source,start,el,currentNSMap,entityReplacer,error
 	var s = S_TAG;//status
 	while(true){
 		var c = source.charAt(p);
+		if (s === S_TAG && c === '<') {
+			// A `<` can never occur inside a tag name. Without this guard the scan runs
+			// on to the next `>` (or EOF) before the tag name is rejected, so a document
+			// with many `<` inside a malformed tag makes each one-character recovery step
+			// re-scan to the distant `>` — O(n^2). Stopping at the `<` keeps each recovery
+			// step bounded. The candidate scanned so far is reported raw, consistent with
+			// the sibling invalid-tag-name throw below.
+			throw new Error('unexpected < in tag name: ' + source.slice(start, p));
+		}
 		switch(c){
 		case '=':
 			if(s === S_ATTR){//attrName

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -111,7 +111,13 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 			switch(source.charAt(tagStart+1)){
 			case '/':
 				var end = source.indexOf('>',tagStart+3);
-				var tagName = source.substring(tagStart + 2, end).replace(/[ \t\n\r]+$/g, '');
+				// Anchored trailing-whitespace trim. The former `/[ \t\n\r]+$/g` backtracked
+				// quadratically on a name shaped `whitespace-run + non-whitespace char`
+				// (an end tag `</   …   x>`): from every start position it extended `[ws]+`
+				// to the end and then failed the `$` anchor. This anchored form matches the
+				// whole string once and captures everything up to the last non-whitespace
+				// character, so it trims in linear time with byte-identical output.
+				var tagName = source.substring(tagStart + 2, end).replace(/^([\s\S]*?[^ \t\n\r])?[ \t\n\r]*$/, '$1');
 				var config = parseStack.pop();
 				if(end<0){
 

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -445,9 +445,13 @@ function appendElement(el,domBuilder,currentNSMap){
 		if(nsPrefix !== false){//hack!!
 			if(localNSMap == null){
 				localNSMap = {}
-				//console.log(currentNSMap,0)
-				_copy(currentNSMap,currentNSMap={})
-				//console.log(currentNSMap,1)
+				// Derive the child scope's namespace map by prototype-chain inheritance
+				// instead of a flat copy: lookups inherit ancestor prefixes transparently,
+				// so a document nesting N scopes retains O(N) map entries rather than
+				// sum(1..N) = O(N^2). localNSMap stays a flat own-only record of the
+				// prefixes declared at THIS element, so own-property enumeration
+				// (endPrefixMapping below) still reports only local declarations.
+				currentNSMap = Object.create(currentNSMap)
 			}
 			currentNSMap[nsPrefix] = localNSMap[nsPrefix] = value;
 			a.uri = NAMESPACE.XMLNS

--- a/lib/sax.js
+++ b/lib/sax.js
@@ -122,6 +122,14 @@ function parse(source,defaultNSMapCopy,entityMap,domBuilder,errorHandler){
 	        		tagName = tagName.replace(/[\s<].*/,'');
 	        		errorHandler.error("end tag name: "+tagName+' maybe not complete');
 	        		end = tagStart+1+tagName.length;
+				}else if(/[ \t\n\r]/.test(tagName) && tagNamePattern.test(tagName.split(/[ \t\n\r]/)[0])){
+					// The XML `ETag` production is `'</' Name S? '>'`: only optional whitespace may follow
+					// the `Name`. A valid `Name` followed by whitespace and non-whitespace residue (e.g.
+					// `</a\nbogus>` or `</a bogus>`) is not well-formed, but historically it was silently
+					// accepted (the malformed end tag ignored, the residue dropped, the element left on the
+					// stack). Report it as a recoverable `error` (which a custom errorHandler may escalate to
+					// fatal) while keeping the existing recovery so the parsed DOM stays byte-identical.
+					errorHandler.error('end tag name is followed by whitespace and trailing content: "'+tagName+'"');
 				}
 				var localNSMap = config.localNSMap;
 				var endMatch = config.tagName == tagName;

--- a/test/algorithmic-complexity-regression.test.js
+++ b/test/algorithmic-complexity-regression.test.js
@@ -1,0 +1,86 @@
+'use strict'
+
+/**
+ * Regression guards for the CWE-407 weakness class (Inefficient Algorithmic
+ * Complexity) and its ReDoS child CWE-1333.
+ *
+ *   {@link https://cwe.mitre.org/data/definitions/407.html CWE-407 Inefficient Algorithmic Complexity}
+ *   {@link https://cwe.mitre.org/data/definitions/1333.html CWE-1333 Inefficient Regular Expression Complexity}
+ *
+ * Each guard drives a public seam (`DOMParser#parseFromString`, `Node#normalize`,
+ * `NamedNodeMap`) with an attack-shaped input and asserts the fixed asymptotic
+ * behaviour as a hard pass/fail — never inspecting private state (index shape,
+ * regex form, or state-machine internals). A re-introduced super-linear path
+ * fails these tests.
+ *
+ * Where a super-linear cost is a transient allocation peak that GC releases (so
+ * it cannot be sampled in-process), the guard runs the parse in a child node
+ * process constrained to a small old-space heap: the quadratic input exhausts
+ * that budget and the child crashes, the linear fix completes — the same
+ * constrained-resource / fixed-workload shape the CWE-674 recursion guard uses
+ * for stack depth.
+ */
+
+const { describe, test, expect } = require('@jest/globals')
+const { spawnSync } = require('child_process')
+const path = require('path')
+
+const LIB = path.resolve(__dirname, '..', 'lib')
+
+/**
+ * Runs `script` in a child node process whose V8 old-space is capped at `heapMb`
+ * megabytes, and reports whether it completed within that budget.
+ *
+ * @param script {string} Source passed to `node -e`.
+ * @param heapMb {number} Old-space cap in MB (`--max-old-space-size`).
+ * @returns {{ ok: boolean, status: number | null, stderr: string }}
+ * `ok` is `true` iff the child exited 0 (parse fit the heap budget).
+ */
+function runUnderHeapCap(script, heapMb) {
+	const res = spawnSync(
+		process.execPath,
+		['--max-old-space-size=' + heapMb, '-e', script],
+		{ encoding: 'utf8' }
+	)
+	return { ok: res.status === 0, status: res.status, stderr: res.stderr || '' }
+}
+
+/**
+ * Builds a `node -e` script that parses a document nesting `depth` elements, each
+ * declaring and using one unique namespace prefix — the GHSA-965w input.
+ *
+ * @param depth {number} Nesting depth / number of distinct namespace prefixes.
+ * @returns {string}
+ */
+function nsMapBombScript(depth) {
+	return [
+		'var DOMParser = require(' + JSON.stringify(LIB) + ').DOMParser;',
+		'var open = "", close = "";',
+		'for (var i = 0; i < ' + depth + '; i++) {',
+		'  open += "<n" + i + ":a xmlns:n" + i + "=\\"urn:x:" + i + "\\">";',
+		'  close = "</n" + i + ":a>" + close;',
+		'}',
+		'new DOMParser().parseFromString("<root>" + open + "leaf" + close + "</root>", "text/xml");',
+	].join('\n')
+}
+
+describe('CWE-407 Inefficient Algorithmic Complexity', () => {
+	describe('quadratic namespace-map memory during parse (GHSA-965w-775f-mr7g)', () => {
+		// Unfixed: `appendElement` flat-copies the whole in-scope namespace map for
+		// every element that declares a prefix, so a document nesting N unique
+		// prefixes retains sum(1..N) = O(N^2) map entries at peak during parse and
+		// exhausts a small heap. Fixed: each scope's map inherits its parent via the
+		// prototype chain (O(1) own entries per element) so peak stays O(N).
+		//
+		// Calibrated on node 18: unfixed OOMs by depth 2000 under a 128 MB old-space;
+		// the linear fix parses depth 5000 in ~9 MB. The wide margin keeps the
+		// pass/fail stable across machines despite the absolute cap.
+		const DEPTH = 5000
+		const HEAP_MB = 128
+
+		test('a deeply namespaced document parses within a constrained heap', () => {
+			const res = runUnderHeapCap(nsMapBombScript(DEPTH), HEAP_MB)
+			expect(res.ok).toBe(true)
+		})
+	})
+})

--- a/test/algorithmic-complexity-regression.test.js
+++ b/test/algorithmic-complexity-regression.test.js
@@ -24,7 +24,7 @@
 const { describe, test, expect } = require('@jest/globals')
 const { spawnSync } = require('child_process')
 const path = require('path')
-const { DOMParser } = require('../lib')
+const { DOMParser, DOMImplementation } = require('../lib')
 
 const LIB = path.resolve(__dirname, '..', 'lib')
 
@@ -169,6 +169,59 @@ describe('CWE-407 Inefficient Algorithmic Complexity', () => {
 			const attackMs = fastestMs(() => tryParse(attack), 3)
 			const benignMs = fastestMs(() => tryParse(benign), 3)
 			expect(attackMs / Math.max(benignMs, 1)).toBeLessThan(RATIO_MAX)
+		})
+	})
+
+	describe('quadratic malformed-tag recovery re-scan and normalize (GHSA-93r5-fhx6-vmg9)', () => {
+		// Growth ratio over a 4x increase in size: quadratic ~16x, linear ~4x. The wide
+		// 4x spread keeps the two well apart despite timing noise; the threshold of 8
+		// separates them.
+		const RATIO_MAX = 8
+		// A silent errorHandler avoids flooding the console with the reported candidate
+		// on the (unfixed) quadratic path; parsing behaviour is unchanged.
+		const silent = function () {}
+
+		function parse(xml, mime) {
+			try {
+				new DOMParser({ errorHandler: silent }).parseFromString(xml, mime)
+			} catch (e) {
+				// default recovery reports (does not throw); timing is what matters
+			}
+		}
+
+		// Finding A: each interior `<` starting a malformed tag used to re-scan forward
+		// to the distant `>`, and one-character recovery repeated that O(n) times -> O(n^2).
+		// The `<`-in-tag-name guard bounds each re-scan, so parse time is linear.
+		test('Finding A: a malformed tag full of `<` parses in near-linear time', () => {
+			const build = (n) => '<r>' + 'a<'.repeat(n) + '</r>'
+			const t1 = fastestMs(() => parse(build(4000), 'text/xml'), 3)
+			const t2 = fastestMs(() => parse(build(16000), 'text/xml'), 3)
+			expect(t2 / t1).toBeLessThan(RATIO_MAX)
+		})
+
+		// Finding B (parse-triggered): recovery emits one single-character text node per
+		// recovered character, so a parent gathers K adjacent text siblings that
+		// `endDocument`'s `normalize()` used to merge in O(K^2). The O(K) merge keeps it
+		// linear. `a<>` keeps each re-scan short so the cost isolates to `normalize()`.
+		test('Finding B: parse-triggered adjacent-text normalize is near-linear', () => {
+			const build = (n) => '<r>' + 'a<>'.repeat(n) + '</r>'
+			const t1 = fastestMs(() => parse(build(4000), 'text/html'), 3)
+			const t2 = fastestMs(() => parse(build(16000), 'text/html'), 3)
+			expect(t2 / t1).toBeLessThan(RATIO_MAX)
+		})
+
+		// Finding B (programmatic): the same O(K) normalize applies to a DOM built with
+		// createTextNode + appendChild, which no parser-side change would cover.
+		test('Finding B: programmatic adjacent-text normalize is near-linear', () => {
+			function normalizeK(k) {
+				const doc = new DOMImplementation().createDocument(null, 'r')
+				const root = doc.documentElement
+				for (var i = 0; i < k; i++) root.appendChild(doc.createTextNode('x'))
+				root.normalize()
+			}
+			const t1 = fastestMs(() => normalizeK(2000), 3)
+			const t2 = fastestMs(() => normalizeK(8000), 3)
+			expect(t2 / t1).toBeLessThan(RATIO_MAX)
 		})
 	})
 })

--- a/test/algorithmic-complexity-regression.test.js
+++ b/test/algorithmic-complexity-regression.test.js
@@ -139,4 +139,36 @@ describe('CWE-407 Inefficient Algorithmic Complexity', () => {
 			expect(t2 / t1).toBeLessThan(RATIO_MAX)
 		})
 	})
+
+	describe('CWE-1333 end-tag trailing-whitespace trim ReDoS (GHSA-x4fp-j954-r2f4)', () => {
+		// Unfixed: the end-tag name trim used an unanchored global regex `/[ \t\n\r]+$/g`.
+		// On a name shaped `whitespace-run + one non-whitespace char` (an end tag
+		// `</   …   x>`), the engine extends `[ws]+` to the end from every start position
+		// and then fails the `$` anchor — O(n^2) backtracking in the whitespace-run
+		// length. Fixed: an anchored trim runs in linear time.
+		//
+		// The attack input is compared against a benign same-size input (whitespace as
+		// text content, which never triggers the trim's backtracking). Unfixed the ratio
+		// is ~1300x+ and grows with size; fixed both are linear, so the ratio collapses.
+		// The threshold of 100 leaves an order of magnitude of headroom on each side and
+		// scales with host speed (both measurements do).
+		const N = 64 * 1024
+		const RATIO_MAX = 100
+
+		function tryParse(xml) {
+			try {
+				new DOMParser().parseFromString(xml, 'text/xml')
+			} catch (e) {
+				// malformed end tags may report/throw; timing is what matters here
+			}
+		}
+
+		test('an end tag with a long trailing-whitespace run trims in near-linear time', () => {
+			const attack = '<r></' + ' '.repeat(N) + 'x>'
+			const benign = '<r>' + ' '.repeat(N) + '</r>'
+			const attackMs = fastestMs(() => tryParse(attack), 3)
+			const benignMs = fastestMs(() => tryParse(benign), 3)
+			expect(attackMs / Math.max(benignMs, 1)).toBeLessThan(RATIO_MAX)
+		})
+	})
 })

--- a/test/algorithmic-complexity-regression.test.js
+++ b/test/algorithmic-complexity-regression.test.js
@@ -24,8 +24,29 @@
 const { describe, test, expect } = require('@jest/globals')
 const { spawnSync } = require('child_process')
 const path = require('path')
+const { DOMParser } = require('../lib')
 
 const LIB = path.resolve(__dirname, '..', 'lib')
+
+/**
+ * Returns the fastest wall-clock (ms) of `runs` executions of `fn` — the minimum
+ * is the least noise-inflated sample, so a growth ratio built from two such
+ * measurements is stable across fast and slow hosts.
+ *
+ * @param fn {() => void}
+ * @param runs {number}
+ * @returns {number}
+ */
+function fastestMs(fn, runs) {
+	var best = Infinity
+	for (var k = 0; k < runs; k++) {
+		var t = process.hrtime.bigint()
+		fn()
+		var d = Number(process.hrtime.bigint() - t) / 1e6
+		if (d < best) best = d
+	}
+	return best
+}
 
 /**
  * Runs `script` in a child node process whose V8 old-space is capped at `heapMb`
@@ -81,6 +102,41 @@ describe('CWE-407 Inefficient Algorithmic Complexity', () => {
 		test('a deeply namespaced document parses within a constrained heap', () => {
 			const res = runUnderHeapCap(nsMapBombScript(DEPTH), HEAP_MB)
 			expect(res.ok).toBe(true)
+		})
+	})
+
+	describe('quadratic attribute de-duplication during parse (GHSA-8344-3jmq-59r6)', () => {
+		// Unfixed: `DOMHandler.startElement` inserts each of M attributes via
+		// `setAttributeNode`, and every insert runs a linear membership scan of the
+		// already-inserted attributes (`setNamedItem` -> `getNamedItem`), so a single
+		// well-formed element carrying M distinct attributes costs 1+2+...+M = O(M^2).
+		// Fixed: a null-prototype membership index makes each insert O(1) -> O(M) total.
+		//
+		// Growth ratio over a 4x increase in M: quadratic ~16x, linear ~4x. Calibrated
+		// on node 18, the unfixed scan measures ~17.7x; the threshold of 8 (the log-space
+		// midpoint) separates the two with headroom and holds on slow CI.
+		const M1 = 4000
+		const M2 = 16000 // 4x M1
+		const RATIO_MAX = 8
+
+		function attrBomb(m) {
+			var parts = new Array(m)
+			for (var i = 0; i < m; i++) parts[i] = 'a' + i + '="x"'
+			return '<r ' + parts.join(' ') + '/>'
+		}
+
+		test('an element with many distinct attributes de-duplicates in sub-quadratic time', () => {
+			const xml1 = attrBomb(M1)
+			const xml2 = attrBomb(M2)
+			const t1 = fastestMs(
+				() => new DOMParser().parseFromString(xml1, 'text/xml'),
+				5
+			)
+			const t2 = fastestMs(
+				() => new DOMParser().parseFromString(xml2, 'text/xml'),
+				5
+			)
+			expect(t2 / t1).toBeLessThan(RATIO_MAX)
 		})
 	})
 })

--- a/test/dom/document.test.js
+++ b/test/dom/document.test.js
@@ -99,6 +99,24 @@ describe('Document.prototype', () => {
 			expect(doc.firstChild === doctype).toBe(true)
 		})
 	})
+	describe('createEntityReference', () => {
+		it('should create EntityReference with a valid name', () => {
+			const doc = new DOMImplementation().createDocument(null, '')
+			const eref = doc.createEntityReference('amp')
+			expect(eref.nodeType).toBe(doc.ENTITY_REFERENCE_NODE)
+			expect(eref.nodeName).toBe('amp')
+		})
+		it('should throw DOMException for a name that is not a valid XML Name', () => {
+			const doc = new DOMImplementation().createDocument(null, '')
+			expect(() => doc.createEntityReference('123')).toThrow(DOMException)
+		})
+		it('should throw DOMException for a name with a valid prefix but ill-formed remainder', () => {
+			const doc = new DOMImplementation().createDocument(null, '')
+			expect(() => doc.createEntityReference('safe; <injected/> &x')).toThrow(
+				DOMException
+			)
+		})
+	})
 	describe('insertBefore', () => {
 		it('should insert the first element and set `documentElement`', () => {
 			const doc = new DOMImplementation().createDocument(null, '')

--- a/test/dom/named-node-map.test.js
+++ b/test/dom/named-node-map.test.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const { DOMParser, XMLSerializer, DOMImplementation } = require('../../lib')
+
+// Characterization of the parse/DOM attribute de-duplication behaviour that the
+// O(M^2)->O(M) index refactor must preserve byte-for-byte (GHSA parse-dedup).
+// release-0.8.x has no NamedNodeMap unit coverage, so this suite is written from
+// scratch: it asserts current behaviour and stays green across the refactor.
+describe('NamedNodeMap de-duplication behaviour (characterization)', () => {
+	const doc = new DOMImplementation().createDocument(null, 'root')
+	const serialize = (el) => new XMLSerializer().serializeToString(el)
+
+	it('getNamedItem returns undefined when no attribute matches', () => {
+		const el = doc.createElement('e')
+		el.setAttribute('x', '1')
+		expect(el.attributes.getNamedItem('nope')).toBeUndefined()
+	})
+
+	it('getNamedItem returns the attribute matching by nodeName', () => {
+		const el = doc.createElement('e')
+		el.setAttribute('x', '1')
+		expect(el.attributes.getNamedItem('x')).toBe(el.attributes.item(0))
+	})
+
+	it('a duplicate nodeName keeps the first position and takes the last value', () => {
+		const el = doc.createElement('e')
+		const x1 = doc.createAttribute('x')
+		x1.value = '1'
+		el.setAttributeNode(x1)
+		const y = doc.createAttribute('y')
+		y.value = '9'
+		el.setAttributeNode(y)
+		const x2 = doc.createAttribute('x')
+		x2.value = '2'
+		const returned = el.setAttributeNode(x2)
+
+		expect(returned).toBe(x1) // the replaced attribute is returned
+		expect(el.attributes.length).toBe(2)
+		// last value wins, first occurrence's position kept (x before y)
+		expect(serialize(el)).toStrictEqual('<e x="2" y="9"/>')
+	})
+
+	it('setting the same attribute instance twice does not duplicate it', () => {
+		const el = doc.createElement('e')
+		const x = doc.createAttribute('x')
+		x.value = '1'
+		el.setAttributeNode(x)
+		el.setAttributeNode(x)
+		expect(el.attributes.length).toBe(1)
+	})
+
+	it('duplicate qualified names in different namespaces are kept distinct', () => {
+		const el = doc.createElement('e2')
+		const p = doc.createAttributeNS('P', 'p:x')
+		p.value = '1'
+		el.setAttributeNode(p)
+		const q = doc.createAttributeNS('Q', 'q:x')
+		q.value = '2'
+		el.setAttributeNode(q)
+
+		expect(el.attributes.length).toBe(2)
+		expect(serialize(el)).toStrictEqual(
+			'<e2 xmlns:p="P" p:x="1" xmlns:q="Q" q:x="2"/>'
+		)
+	})
+
+	it('many distinct attributes parse and serialize in source order', () => {
+		const names = Array.from({ length: 50 }, (_, i) => 'a' + i)
+		const source = '<r ' + names.map((n) => n + '="x"').join(' ') + '/>'
+		const el = new DOMParser().parseFromString(
+			source,
+			'text/xml'
+		).documentElement
+
+		expect(el.attributes.length).toBe(names.length)
+		expect(serialize(el)).toStrictEqual(source)
+	})
+})

--- a/test/dom/normalize.test.js
+++ b/test/dom/normalize.test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const { DOMImplementation } = require('../../lib')
+
+/**
+ * `Node#normalize()` merges each run of adjacent `Text` siblings into the first
+ * node of the run, which survives and carries the concatenated data (node
+ * identity / locator semantics). The O(K) rewrite (GHSA-93r5-fhx6-vmg9) must keep
+ * that invariant.
+ */
+describe('Node#normalize adjacent-text merge', () => {
+	const doc = () => new DOMImplementation().createDocument(null, 'root')
+
+	it('merges a run of adjacent text nodes into the first, which survives with the concatenated data', () => {
+		const d = doc()
+		const root = d.documentElement
+		const first = d.createTextNode('a')
+		root.appendChild(first)
+		root.appendChild(d.createTextNode('b'))
+		root.appendChild(d.createTextNode('c'))
+
+		root.normalize()
+
+		expect(root.childNodes.length).toBe(1)
+		expect(root.firstChild).toBe(first) // the first node survives (identity)
+		expect(first.data).toBe('abc')
+		expect(first.nodeValue).toBe('abc')
+		expect(first.length).toBe(3)
+		expect(root.lastChild).toBe(first)
+		expect(first.nextSibling).toBeNull()
+	})
+
+	it('merges only within a run, leaving non-text nodes and their boundaries intact', () => {
+		const d = doc()
+		const root = d.documentElement
+		const t1 = d.createTextNode('a')
+		root.appendChild(t1)
+		root.appendChild(d.createTextNode('b'))
+		const el = d.createElement('e')
+		root.appendChild(el)
+		const t2 = d.createTextNode('c')
+		root.appendChild(t2)
+		root.appendChild(d.createTextNode('d'))
+
+		root.normalize()
+
+		expect(root.childNodes.length).toBe(3)
+		expect(root.firstChild).toBe(t1)
+		expect(t1.data).toBe('ab')
+		expect(root.childNodes.item(1)).toBe(el)
+		expect(root.lastChild).toBe(t2)
+		expect(t2.data).toBe('cd')
+		expect(t1.nextSibling).toBe(el)
+		expect(el.previousSibling).toBe(t1)
+		expect(el.nextSibling).toBe(t2)
+		expect(t2.previousSibling).toBe(el)
+	})
+})

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -592,6 +592,53 @@ describe('XMLSerializer serializeToString requireWellFormed option', () => {
 				})
 			).toThrow(DOMException)
 		})
+
+		it('default: DocumentType with invalid name serializes verbatim — no throw', () => {
+			const doctype = new DOMImplementation().createDocumentType('html', '', '')
+			doctype.name =
+				'html><script xmlns="http://www.w3.org/1999/xhtml">alert(1)</script'
+			const dtDoc = new DOMImplementation().createDocument(
+				null,
+				'root',
+				doctype
+			)
+			let out
+			expect(
+				() => (out = new XMLSerializer().serializeToString(dtDoc))
+			).not.toThrow()
+			expect(out).toContain('<!DOCTYPE html><script')
+		})
+
+		it('requireWellFormed: true on DocumentType with ">" in name throws', () => {
+			const doctype = new DOMImplementation().createDocumentType('html', '', '')
+			doctype.name =
+				'html><script xmlns="http://www.w3.org/1999/xhtml">alert(1)</script'
+			const dtDoc = new DOMImplementation().createDocument(
+				null,
+				'root',
+				doctype
+			)
+			expect(() =>
+				new XMLSerializer().serializeToString(dtDoc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on DocumentType with whitespace in name throws', () => {
+			const doctype = new DOMImplementation().createDocumentType('html', '', '')
+			doctype.name = 'ht ml'
+			const dtDoc = new DOMImplementation().createDocument(
+				null,
+				'root',
+				doctype
+			)
+			expect(() =>
+				new XMLSerializer().serializeToString(dtDoc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
 	})
 
 	describe('Element', () => {

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -488,6 +488,74 @@ describe('XMLSerializer serializeToString requireWellFormed option', () => {
 				})
 			).toThrow(DOMException)
 		})
+
+		it('default: PI with ">" in target emits verbatim — no throw', () => {
+			const pi = doc.createProcessingInstruction('a>', 'data')
+			doc.documentElement.appendChild(pi)
+			expect(new XMLSerializer().serializeToString(doc.documentElement)).toBe(
+				'<root><?a> data?></root>'
+			)
+		})
+
+		it('requireWellFormed: true on PI with ">" in target throws', () => {
+			const pi = doc.createProcessingInstruction('a>', 'data')
+			doc.documentElement.appendChild(pi)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on PI with "?" in target throws', () => {
+			const pi = doc.createProcessingInstruction('a?b', 'data')
+			doc.documentElement.appendChild(pi)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on PI with whitespace in target throws', () => {
+			const pi = doc.createProcessingInstruction('a b', 'data')
+			doc.documentElement.appendChild(pi)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on PI with ":" in target throws', () => {
+			const pi = doc.createProcessingInstruction('ns:target', 'data')
+			doc.documentElement.appendChild(pi)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on PI with target "xml" throws', () => {
+			const pi = doc.createProcessingInstruction('xml', 'version="1.0"')
+			doc.documentElement.appendChild(pi)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		it('requireWellFormed: true on PI with target "XML" (uppercase) throws', () => {
+			const pi = doc.createProcessingInstruction('XML', 'data')
+			doc.documentElement.appendChild(pi)
+			expect(() =>
+				new XMLSerializer().serializeToString(doc, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
 	})
 
 	describe('DocumentType', () => {

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -804,6 +804,54 @@ describe('XMLSerializer serializeToString requireWellFormed option', () => {
 			const entityRef = xmlDoc.createEntityReference('amp')
 			expect(new XMLSerializer().serializeToString(entityRef)).toBe('&amp;')
 		})
+
+		test('requireWellFormed: true on valid EntityReference serializes as &name;', () => {
+			const xmlDoc = new DOMImplementation().createDocument(null, '')
+			const entityRef = xmlDoc.createEntityReference('amp')
+			expect(
+				new XMLSerializer().serializeToString(entityRef, false, null, {
+					requireWellFormed: true,
+				})
+			).toBe('&amp;')
+		})
+
+		test('default: EntityReference with ill-formed nodeName emits verbatim — no throw', () => {
+			const xmlDoc = new DOMImplementation().createDocument(null, '')
+			const entityRef = xmlDoc.createEntityReference('safe')
+			// Bypass the creation-time anchor via a direct nodeName write.
+			entityRef.nodeName = 'safe; <injected/> &x'
+			expect(new XMLSerializer().serializeToString(entityRef)).toBe(
+				'&safe; <injected/> &x;'
+			)
+		})
+
+		test('requireWellFormed: true on EntityReference with ill-formed nodeName throws', () => {
+			const xmlDoc = new DOMImplementation().createDocument(null, '')
+			const entityRef = xmlDoc.createEntityReference('safe')
+			entityRef.nodeName = 'safe; <injected/> &x'
+			expect(() =>
+				new XMLSerializer().serializeToString(entityRef, false, null, {
+					requireWellFormed: true,
+				})
+			).toThrow(DOMException)
+		})
+
+		test('round-trip: valid EntityReference serializes to &name; and re-parses', () => {
+			const xmlDoc = new DOMImplementation().createDocument(null, 'root')
+			const entityRef = xmlDoc.createEntityReference('amp')
+			const serialized = new XMLSerializer().serializeToString(
+				entityRef,
+				false,
+				null,
+				{ requireWellFormed: true }
+			)
+			expect(serialized).toBe('&amp;')
+			const reparsed = new DOMParser().parseFromString(
+				'<root>' + serialized + '</root>',
+				MIME_TYPE.XML_TEXT
+			)
+			expect(reparsed.documentElement.textContent).toBe('&')
+		})
 	})
 
 	describe('unknown node type (default case)', () => {

--- a/test/error/__snapshots__/reported-levels.test.js.snap
+++ b/test/error/__snapshots__/reported-levels.test.js.snap
@@ -10,7 +10,7 @@ Array [
 exports[`SYNTAX_AttributeEqualMissingValue with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: attribute value missed!!||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -24,7 +24,7 @@ Array [
 exports[`SYNTAX_AttributeEqualMissingValue with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: attribute value missed!!||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -38,7 +38,7 @@ Array [
 exports[`SYNTAX_AttributeMissingEndingQuote with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: attribute value no end '\\"' match||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -52,7 +52,7 @@ Array [
 exports[`SYNTAX_AttributeMissingEndingQuote with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: attribute value no end '\\"' match||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -66,7 +66,7 @@ Array [
 exports[`SYNTAX_ElementClosingNotConnected with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: elements closed character '/' and '>' must be connected to||@#[line:1,col:6]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -80,7 +80,7 @@ Array [
 exports[`SYNTAX_ElementClosingNotConnected with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: elements closed character '/' and '>' must be connected to||@#[line:1,col:6]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -96,7 +96,7 @@ Array [
   "[xmldom error]	end tag name: inner maybe not complete||@#[line:1,col:6]
     at parse (lib/sax.js:#2)",
   "[xmldom error]	element parse error: Error: [xmldom error]	end tag name: inner maybe not complete||@#[line:1,col:6]||@#[line:1,col:6]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -112,7 +112,7 @@ Array [
   "[xmldom error]	end tag name: inner maybe not complete||@#[line:1,col:6]
     at parse (lib/sax.js:#2)",
   "[xmldom error]	element parse error: Error: [xmldom error]	end tag name: inner maybe not complete||@#[line:1,col:6]||@#[line:1,col:6]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -128,7 +128,7 @@ Array [
   "[xmldom error]	end tag name: xml is not complete:xml||@#[line:1,col:1]
     at parse (lib/sax.js:#1)",
   "[xmldom error]	element parse error: Error: [xmldom error]	end tag name: xml is not complete:xml||@#[line:1,col:1]||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -144,7 +144,7 @@ Array [
   "[xmldom error]	end tag name: xml is not complete:xml||@#[line:1,col:1]
     at parse (lib/sax.js:#1)",
   "[xmldom error]	element parse error: Error: [xmldom error]	end tag name: xml is not complete:xml||@#[line:1,col:1]||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -158,7 +158,7 @@ Array [
 exports[`SYNTAX_InvalidAttributeName with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: invalid attribute:123||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -172,7 +172,7 @@ Array [
 exports[`SYNTAX_InvalidAttributeName with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: invalid attribute:123||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -186,7 +186,7 @@ Array [
 exports[`SYNTAX_InvalidTagName with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: invalid tagName:123||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -200,7 +200,7 @@ Array [
 exports[`SYNTAX_InvalidTagName with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	element parse error: Error: invalid tagName:123||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -214,9 +214,9 @@ Array [
 exports[`SYNTAX_UnclosedComment with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	Unclosed comment||@#[line:1,col:1]
-    at parseDCC (lib/sax.js:#21)",
+    at parseDCC (lib/sax.js:#22)",
   "[xmldom error]	element parse error: Error: [xmldom error]	Unclosed comment||@#[line:1,col:1]||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -230,9 +230,9 @@ Array [
 exports[`SYNTAX_UnclosedComment with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	Unclosed comment||@#[line:1,col:1]
-    at parseDCC (lib/sax.js:#21)",
+    at parseDCC (lib/sax.js:#22)",
   "[xmldom error]	element parse error: Error: [xmldom error]	Unclosed comment||@#[line:1,col:1]||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -246,9 +246,9 @@ Array [
 exports[`SYNTAX_UnexpectedEndOfInput with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	unexpected end of input||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#13)",
+    at parseElementStartPart (lib/sax.js:#14)",
   "[xmldom error]	element parse error: Error: [xmldom error]	unexpected end of input||@#[line:1,col:1]||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -262,9 +262,9 @@ Array [
 exports[`SYNTAX_UnexpectedEndOfInput with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	unexpected end of input||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#13)",
+    at parseElementStartPart (lib/sax.js:#14)",
   "[xmldom error]	element parse error: Error: [xmldom error]	unexpected end of input||@#[line:1,col:1]||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -278,7 +278,7 @@ Array [
 exports[`WF_AttributeMissingQuote with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"value\\" missed quot(\\")!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#14)",
+    at parseElementStartPart (lib/sax.js:#15)",
 ]
 `;
 
@@ -292,7 +292,7 @@ Array [
 exports[`WF_AttributeMissingQuote with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"value\\" missed quot(\\")!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#14)",
+    at parseElementStartPart (lib/sax.js:#15)",
 ]
 `;
 
@@ -306,7 +306,7 @@ Array [
 exports[`WF_AttributeMissingQuote2 with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"&\\" missed quot(\\")!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#17)",
+    at parseElementStartPart (lib/sax.js:#18)",
 ]
 `;
 
@@ -320,7 +320,7 @@ Array [
 exports[`WF_AttributeMissingQuote2 with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"&\\" missed quot(\\")!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#17)",
+    at parseElementStartPart (lib/sax.js:#18)",
 ]
 `;
 
@@ -334,7 +334,7 @@ Array [
 exports[`WF_AttributeMissingStartingQuote with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed start quot(\\")!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#10)",
+    at parseElementStartPart (lib/sax.js:#11)",
 ]
 `;
 
@@ -348,7 +348,7 @@ Array [
 exports[`WF_AttributeMissingStartingQuote with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed start quot(\\")!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#10)",
+    at parseElementStartPart (lib/sax.js:#11)",
 ]
 `;
 
@@ -362,7 +362,7 @@ Array [
 exports[`WF_AttributeMissingValue with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#15)",
+    at parseElementStartPart (lib/sax.js:#16)",
 ]
 `;
 
@@ -376,7 +376,7 @@ Array [
 exports[`WF_AttributeMissingValue with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#15)",
+    at parseElementStartPart (lib/sax.js:#16)",
 ]
 `;
 
@@ -392,7 +392,7 @@ Array [
 exports[`WF_AttributeMissingValue2 with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead2!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#18)",
+    at parseElementStartPart (lib/sax.js:#19)",
 ]
 `;
 
@@ -408,7 +408,7 @@ Array [
 exports[`WF_AttributeMissingValue2 with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead2!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#18)",
+    at parseElementStartPart (lib/sax.js:#19)",
 ]
 `;
 
@@ -422,7 +422,7 @@ Array [
 exports[`WF_AttributeValueMustAfterEqual with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute value must after \\"=\\"||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#8)",
+    at parseElementStartPart (lib/sax.js:#9)",
 ]
 `;
 
@@ -436,7 +436,7 @@ Array [
 exports[`WF_AttributeValueMustAfterEqual with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute value must after \\"=\\"||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#8)",
+    at parseElementStartPart (lib/sax.js:#9)",
 ]
 `;
 
@@ -454,6 +454,40 @@ Array [
 ]
 `;
 
+exports[`WF_EndTagTrailingContent with mimeType text/html should be reported as error 1`] = `
+Array [
+  "[xmldom error]	end tag name is followed by whitespace and trailing content: \\"a
+bogus\\"
+@#[line:1,col:1]",
+]
+`;
+
+exports[`WF_EndTagTrailingContent with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
+Array [
+  "[xmldom error]	end tag name is followed by whitespace and trailing content: \\"a||bogus\\"||@#[line:1,col:1]
+    at parse (lib/sax.js:#3)",
+  "[xmldom error]	element parse error: Error: [xmldom error]	end tag name is followed by whitespace and trailing content: \\"a||bogus\\"||@#[line:1,col:1]||@#[line:1,col:1]
+    at parse (lib/sax.js:#6)",
+]
+`;
+
+exports[`WF_EndTagTrailingContent with mimeType text/xml should be reported as error 1`] = `
+Array [
+  "[xmldom error]	end tag name is followed by whitespace and trailing content: \\"a
+bogus\\"
+@#[line:1,col:1]",
+]
+`;
+
+exports[`WF_EndTagTrailingContent with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
+Array [
+  "[xmldom error]	end tag name is followed by whitespace and trailing content: \\"a||bogus\\"||@#[line:1,col:1]
+    at parse (lib/sax.js:#3)",
+  "[xmldom error]	element parse error: Error: [xmldom error]	end tag name is followed by whitespace and trailing content: \\"a||bogus\\"||@#[line:1,col:1]||@#[line:1,col:1]
+    at parse (lib/sax.js:#6)",
+]
+`;
+
 exports[`WF_EntityDeclared with mimeType text/html should be reported as error 1`] = `
 Array [
   "[xmldom error]	entity not found:&e;
@@ -466,7 +500,7 @@ Array [
   "[xmldom error]	entity not found:&e;||@#[line:1,col:1]
     at replace (lib/sax.js:#0)",
   "[xmldom error]	element parse error: Error: [xmldom error]	entity not found:&e;||@#[line:1,col:1]||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -482,7 +516,7 @@ Array [
   "[xmldom error]	entity not found:&e;||@#[line:1,col:1]
     at replace (lib/sax.js:#0)",
   "[xmldom error]	element parse error: Error: [xmldom error]	entity not found:&e;||@#[line:1,col:1]||@#[line:1,col:1]
-    at parse (lib/sax.js:#5)",
+    at parse (lib/sax.js:#6)",
 ]
 `;
 
@@ -496,6 +530,6 @@ Array [
 exports[`WF_UnclosedXmlAttribute with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	unclosed xml attribute||@#[line:1,col:1]
-    at parse (lib/sax.js:#4)",
+    at parse (lib/sax.js:#5)",
 ]
 `;

--- a/test/error/__snapshots__/reported-levels.test.js.snap
+++ b/test/error/__snapshots__/reported-levels.test.js.snap
@@ -214,7 +214,7 @@ Array [
 exports[`SYNTAX_UnclosedComment with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	Unclosed comment||@#[line:1,col:1]
-    at parseDCC (lib/sax.js:#22)",
+    at parseDCC (lib/sax.js:#23)",
   "[xmldom error]	element parse error: Error: [xmldom error]	Unclosed comment||@#[line:1,col:1]||@#[line:1,col:1]
     at parse (lib/sax.js:#6)",
 ]
@@ -230,7 +230,7 @@ Array [
 exports[`SYNTAX_UnclosedComment with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	Unclosed comment||@#[line:1,col:1]
-    at parseDCC (lib/sax.js:#22)",
+    at parseDCC (lib/sax.js:#23)",
   "[xmldom error]	element parse error: Error: [xmldom error]	Unclosed comment||@#[line:1,col:1]||@#[line:1,col:1]
     at parse (lib/sax.js:#6)",
 ]
@@ -246,7 +246,7 @@ Array [
 exports[`SYNTAX_UnexpectedEndOfInput with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	unexpected end of input||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#14)",
+    at parseElementStartPart (lib/sax.js:#15)",
   "[xmldom error]	element parse error: Error: [xmldom error]	unexpected end of input||@#[line:1,col:1]||@#[line:1,col:1]
     at parse (lib/sax.js:#6)",
 ]
@@ -262,8 +262,36 @@ Array [
 exports[`SYNTAX_UnexpectedEndOfInput with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
 Array [
   "[xmldom error]	unexpected end of input||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#14)",
+    at parseElementStartPart (lib/sax.js:#15)",
   "[xmldom error]	element parse error: Error: [xmldom error]	unexpected end of input||@#[line:1,col:1]||@#[line:1,col:1]
+    at parse (lib/sax.js:#6)",
+]
+`;
+
+exports[`SYNTAX_UnexpectedLessThanInTagName with mimeType text/html should be reported as error 1`] = `
+Array [
+  "[xmldom error]	element parse error: Error: unexpected < in tag name: a
+@#[line:1,col:1]",
+]
+`;
+
+exports[`SYNTAX_UnexpectedLessThanInTagName with mimeType text/html should not catch Error thrown in errorHandler.error 1`] = `
+Array [
+  "[xmldom error]	element parse error: Error: unexpected < in tag name: a||@#[line:1,col:1]
+    at parse (lib/sax.js:#6)",
+]
+`;
+
+exports[`SYNTAX_UnexpectedLessThanInTagName with mimeType text/xml should be reported as error 1`] = `
+Array [
+  "[xmldom error]	element parse error: Error: unexpected < in tag name: a
+@#[line:1,col:1]",
+]
+`;
+
+exports[`SYNTAX_UnexpectedLessThanInTagName with mimeType text/xml should not catch Error thrown in errorHandler.error 1`] = `
+Array [
+  "[xmldom error]	element parse error: Error: unexpected < in tag name: a||@#[line:1,col:1]
     at parse (lib/sax.js:#6)",
 ]
 `;
@@ -278,7 +306,7 @@ Array [
 exports[`WF_AttributeMissingQuote with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"value\\" missed quot(\\")!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#15)",
+    at parseElementStartPart (lib/sax.js:#16)",
 ]
 `;
 
@@ -292,7 +320,7 @@ Array [
 exports[`WF_AttributeMissingQuote with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"value\\" missed quot(\\")!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#15)",
+    at parseElementStartPart (lib/sax.js:#16)",
 ]
 `;
 
@@ -306,7 +334,7 @@ Array [
 exports[`WF_AttributeMissingQuote2 with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"&\\" missed quot(\\")!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#18)",
+    at parseElementStartPart (lib/sax.js:#19)",
 ]
 `;
 
@@ -320,7 +348,7 @@ Array [
 exports[`WF_AttributeMissingQuote2 with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"&\\" missed quot(\\")!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#18)",
+    at parseElementStartPart (lib/sax.js:#19)",
 ]
 `;
 
@@ -334,7 +362,7 @@ Array [
 exports[`WF_AttributeMissingStartingQuote with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed start quot(\\")!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#11)",
+    at parseElementStartPart (lib/sax.js:#12)",
 ]
 `;
 
@@ -348,7 +376,7 @@ Array [
 exports[`WF_AttributeMissingStartingQuote with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed start quot(\\")!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#11)",
+    at parseElementStartPart (lib/sax.js:#12)",
 ]
 `;
 
@@ -362,7 +390,7 @@ Array [
 exports[`WF_AttributeMissingValue with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#16)",
+    at parseElementStartPart (lib/sax.js:#17)",
 ]
 `;
 
@@ -376,7 +404,7 @@ Array [
 exports[`WF_AttributeMissingValue with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#16)",
+    at parseElementStartPart (lib/sax.js:#17)",
 ]
 `;
 
@@ -392,7 +420,7 @@ Array [
 exports[`WF_AttributeMissingValue2 with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead2!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#19)",
+    at parseElementStartPart (lib/sax.js:#20)",
 ]
 `;
 
@@ -408,7 +436,7 @@ Array [
 exports[`WF_AttributeMissingValue2 with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute \\"attr\\" missed value!! \\"attr\\" instead2!!||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#19)",
+    at parseElementStartPart (lib/sax.js:#20)",
 ]
 `;
 
@@ -422,7 +450,7 @@ Array [
 exports[`WF_AttributeValueMustAfterEqual with mimeType text/html should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute value must after \\"=\\"||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#9)",
+    at parseElementStartPart (lib/sax.js:#10)",
 ]
 `;
 
@@ -436,7 +464,7 @@ Array [
 exports[`WF_AttributeValueMustAfterEqual with mimeType text/xml should escalate Error thrown in errorHandler.warning to errorHandler.error 1`] = `
 Array [
   "[xmldom warning]	attribute value must after \\"=\\"||@#[line:1,col:1]
-    at parseElementStartPart (lib/sax.js:#9)",
+    at parseElementStartPart (lib/sax.js:#10)",
 ]
 `;
 

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -106,6 +106,20 @@ const REPORTED = {
 		match: (msg) => /invalid tagName/.test(msg),
 	},
 	/**
+	 * Triggered by `parseElementStartPart` in lib/sax.js when a `<` appears where a
+	 * tag name is expected, caught in the main loop and reported via the
+	 * `element parse error:` wrapper. A `<` cannot occur inside a tag name, so the
+	 * scan stops there instead of running on to the next `>` (which would make
+	 * malformed input re-scan quadratically).
+	 *
+	 * @see https://www.w3.org/TR/xml/#NT-Name
+	 */
+	SYNTAX_UnexpectedLessThanInTagName: {
+		source: '<a<b/>',
+		level: 'error',
+		match: (msg) => /unexpected < in tag name/.test(msg),
+	},
+	/**
 	 * Triggered by lib/sax.js:602, caught in 208
 	 * This sample doesn't follow the specified grammar.
 	 * In the browser:

--- a/test/error/reported.js
+++ b/test/error/reported.js
@@ -70,6 +70,19 @@ const REPORTED = {
 		match: (msg) => /end tag name/.test(msg) && /maybe not complete/.test(msg),
 	},
 	/**
+	 * The XML `ETag` production is `'</' Name S? '>'`: a valid `Name` followed by whitespace and
+	 * non-whitespace residue (e.g. `</a\nbogus>`) is not well-formed. It was historically accepted
+	 * silently; it is now reported as a recoverable `error` while parsing recovers unchanged.
+	 *
+	 * @see https://www.w3.org/TR/2008/REC-xml-20081126/#NT-ETag
+	 */
+	WF_EndTagTrailingContent: {
+		source: '<a></a\nbogus>',
+		level: 'error',
+		match: (msg) =>
+			/end tag name is followed by whitespace and trailing content/.test(msg),
+	},
+	/**
 	 * This sample doesn't follow the specified grammar.
 	 * In the browser it is reported as `error on line 1 at column 6: Comment not terminated`.
 	 */

--- a/test/html/__snapshots__/normalize.test.js.snap
+++ b/test/html/__snapshots__/normalize.test.js.snap
@@ -58,7 +58,7 @@ exports[`html normalizer <div>&amp;&lt;123&456<789;&&</div> 1`] = `
 Object {
   "actual": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\">&amp;&lt;123&amp;456&lt;789;&amp;&amp;</div>",
   "error": Array [
-    "[xmldom error]	element parse error: Error: invalid tagName:789;&&<
+    "[xmldom error]	element parse error: Error: unexpected < in tag name: 789;&&
 @#[line:1,col:22]",
   ],
 }
@@ -76,7 +76,7 @@ Object {
   "error": Array [
     "[xmldom error]	element parse error: Error: invalid tagName:123e
 @#[line:1,col:6]",
-    "[xmldom error]	element parse error: Error: invalid tagName:a<br
+    "[xmldom error]	element parse error: Error: unexpected < in tag name: a
 @#[line:1,col:13]",
   ],
 }

--- a/test/parse/__snapshots__/locator.test.js.snap
+++ b/test/parse/__snapshots__/locator.test.js.snap
@@ -9,7 +9,7 @@ Object {
 exports[`DOMLocator logs error positions 1`] = `
 Object {
   "error": Array [
-    "[xmldom error]	element parse error: Error: invalid tagName:err<
+    "[xmldom error]	element parse error: Error: unexpected < in tag name: err
 @#[line:2,col:2]",
   ],
 }

--- a/test/parse/namespace.test.js
+++ b/test/parse/namespace.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { DOMParser } = require('../../lib')
+const { DOMParser, XMLSerializer } = require('../../lib')
 
 /**
  * Returns an array containing only one occurrence of every sting in `values` (like in a Set).
@@ -67,5 +67,36 @@ describe('XML Namespace Parse', () => {
 		expect(
 			documentElement.firstChild.nextSibling.lookupNamespaceURI('p')
 		).toStrictEqual('http://test.com')
+	})
+
+	it('prefix declared once at the root resolves and serializes unchanged when used deeply nested', () => {
+		const source =
+			'<r xmlns:p="http://root.com">' +
+			'<a><b><c><p:leaf p:attr="v"/></c></b></a>' +
+			'<a2 xmlns:q="http://shadow.com"><q:mid><p:leaf2/></q:mid></a2>' +
+			'</r>'
+		const { documentElement } = new DOMParser().parseFromString(
+			source,
+			'text/xml'
+		)
+
+		// `p`, declared only at the root, resolves for elements and attributes many
+		// levels down (inherited through the scope chain, not re-declared).
+		const leaf = documentElement.getElementsByTagName('p:leaf')[0]
+		expect(leaf.namespaceURI).toStrictEqual('http://root.com')
+		expect(leaf.getAttributeNode('p:attr').namespaceURI).toStrictEqual(
+			'http://root.com'
+		)
+		// A prefix declared at an inner scope resolves there while `p` still inherits.
+		const mid = documentElement.getElementsByTagName('q:mid')[0]
+		expect(mid.namespaceURI).toStrictEqual('http://shadow.com')
+		expect(
+			documentElement.getElementsByTagName('p:leaf2')[0].namespaceURI
+		).toStrictEqual('http://root.com')
+
+		// Behaviour-preserving: serialized output is byte-identical to the input.
+		expect(
+			new XMLSerializer().serializeToString(documentElement)
+		).toStrictEqual(source)
 	})
 })

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -283,3 +283,58 @@ describe('XML Node Parse', () => {
 		})
 	})
 })
+
+/**
+ * The XML `ETag` production is `'</' Name S? '>'`: only optional whitespace may follow the `Name`.
+ * A valid `Name` followed by whitespace and non-whitespace residue (e.g. `</a\nbogus>` or
+ * `</a bogus>`) is not well-formed, but historically it was silently accepted. It is now reported
+ * as a recoverable `error` (in both XML and HTML) while parsing recovers to byte-identical DOM.
+ */
+describe('end tag with trailing residue after the name', () => {
+	it.each([
+		['a space', ' '],
+		['a tab', '\t'],
+		['a line feed', '\n'],
+		['a carriage return', '\r'],
+	])(
+		'reports a recoverable error for %s residue and recovers to byte-identical DOM',
+		(_label, ws) => {
+			const source = '<a></a' + ws + 'junk>'
+
+			const cleanXml = new DOMParser()
+				.parseFromString('<a></a>', MIME_TYPE.XML_TEXT)
+				.toString()
+			const xml = getTestParser()
+			expect(
+				xml.parser.parseFromString(source, MIME_TYPE.XML_TEXT).toString()
+			).toBe(cleanXml)
+			expect(
+				(xml.errors.error || []).some((msg) =>
+					/followed by whitespace and trailing content/.test(msg)
+				)
+			).toBe(true)
+			expect(xml.errors.fatalError).toBeUndefined()
+
+			const cleanHtml = new DOMParser()
+				.parseFromString('<a></a>', MIME_TYPE.HTML)
+				.toString()
+			const html = getTestParser()
+			expect(
+				html.parser.parseFromString(source, MIME_TYPE.HTML).toString()
+			).toBe(cleanHtml)
+			expect(
+				(html.errors.error || []).some((msg) =>
+					/followed by whitespace and trailing content/.test(msg)
+				)
+			).toBe(true)
+		}
+	)
+
+	it('does not report a clean end tag with only trailing whitespace', () => {
+		const { errors, parser } = getTestParser()
+		expect(
+			parser.parseFromString('<a></a\r\n>', MIME_TYPE.XML_TEXT).toString()
+		).toBe('<a/>')
+		expect(errors.error).toBeUndefined()
+	})
+})

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -31,6 +31,22 @@ describe('XML Node Parse', () => {
 			expect(actual).toBe('<xml/>')
 		})
 	})
+	describe('a `<` where a tag name is expected (GHSA-93r5-fhx6-vmg9)', () => {
+		it('reports the distinct message with the raw candidate and recovers to the same DOM', () => {
+			const { parser, errors } = getTestParser()
+			const actual = parser
+				.parseFromString('<r>a<b</r>', MIME_TYPE.XML_TEXT)
+				.toString()
+
+			// DOM output is byte-identical to today's recovery (only the error text changed)
+			expect(actual).toBe('<r>a&lt;b</r>')
+			const messages = errors.error || []
+			expect(messages.some((m) => /unexpected < in tag name: b/.test(m))).toBe(
+				true
+			)
+			expect(messages.some((m) => /invalid tagName/.test(m))).toBe(false)
+		})
+	})
 	it('nested closing tag with whitespace', () => {
 		const actual = new DOMParser()
 			.parseFromString(

--- a/test/parse/parse-element.test.js
+++ b/test/parse/parse-element.test.js
@@ -15,6 +15,21 @@ describe('XML Node Parse', () => {
 				expect(actual).toBe('<xml/>')
 			}
 		)
+		// The end-tag trailing-whitespace trim must produce identical results whether
+		// the whitespace run is empty, short, long, or mixed — the anchored trim that
+		// replaced the backtracking `/[ \t\n\r]+$/g` keeps this byte-identical
+		// (GHSA-x4fp-j954-r2f4).
+		it.each([
+			'<xml></xml>',
+			'<xml></xml >',
+			'<xml></xml\t\r\n >',
+			'<xml></xml' + ' '.repeat(500) + '>',
+		])('trailing-whitespace end tag %#', (input) => {
+			const actual = new DOMParser()
+				.parseFromString(input, 'text/xml')
+				.toString()
+			expect(actual).toBe('<xml/>')
+		})
 	})
 	it('nested closing tag with whitespace', () => {
 		const actual = new DOMParser()

--- a/test/xmltest/__snapshots__/not-wf.test.js.snap
+++ b/test/xmltest/__snapshots__/not-wf.test.js.snap
@@ -10,7 +10,7 @@ Object {
   "error": Array [
     "[xmldom error]	element parse error: Error: invalid attribute:?
 @#[line:2,col:1]",
-    "[xmldom error]	element parse error: Error: invalid tagName:a<
+    "[xmldom error]	element parse error: Error: unexpected < in tag name: a
 @#[line:4,col:1]",
   ],
   "warning": Array [


### PR DESCRIPTION
## Backport security release 0.8.15 — parser/DOM DoS, serializer name checks, end-tag reporting

Tier 2 security release backport for the `0.8.x` LTS line. Carries the same parser/DOM
denial-of-service and `requireWellFormed` serializer name-check families as the `0.9.12` release, plus
the `0.8.x`-only end-tag ReDoS fix and the scope-B backport of the not-well-formed end-tag report.
The `0.9.x`-only fixes (raw-text amplification `6mj3`; the multiline serializer/creation-time bypasses
`jxjr`/`vr34`/`3px3`) do **not** apply to this line. Every fix is **non-breaking**: DoS fixes are
byte-identical, name checks are opt-in via `{ requireWellFormed: true }`, and the end-tag report is
recoverable (byte-identical DOM).

### Fixes — parser/DOM denial-of-service (default parse path)

- [**GHSA-965w-775f-mr7g**](https://github.com/xmldom/xmldom/security/advisories/GHSA-965w-775f-mr7g)
  — quadratic namespace-map memory. Prototype-chain inheritance of the in-scope namespace map;
  byte-identical output, O(N) memory instead of O(N²).
- [**GHSA-8344-3jmq-59r6**](https://github.com/xmldom/xmldom/security/advisories/GHSA-8344-3jmq-59r6)
  — quadratic `NamedNodeMap` attribute de-duplication. Single-level null-prototype index keyed on
  `nodeName` on the parse-time dedup path (O(M) instead of O(M²)); attribute order and duplicate
  resolution byte-identical. `0.8.x` had no `named-node-map` coverage, so the characterization set is
  added from scratch.
- [**GHSA-x4fp-j954-r2f4**](https://github.com/xmldom/xmldom/security/advisories/GHSA-x4fp-j954-r2f4)
  — end-tag trailing-whitespace trim ReDoS. The trim is anchored so it runs in linear time instead of
  backtracking quadratically; trimmed output is byte-identical. `0.8.x`-only.
- [**GHSA-93r5-fhx6-vmg9**](https://github.com/xmldom/xmldom/security/advisories/GHSA-93r5-fhx6-vmg9)
  — quadratic malformed-input recovery (two findings, one advisory): the malformed tag-name scan
  terminates at an embedded `<` (linear recovery), and `normalize()` merges adjacent text nodes in
  O(K) instead of O(K²) (also reachable programmatically). Only the reported error-message text
  changes; DOM output is unchanged.

### Fixes — `requireWellFormed` serializer name checks (opt-in)

- [**GHSA-27p8-2357-5qqv**](https://github.com/xmldom/xmldom/security/advisories/GHSA-27p8-2357-5qqv)
  — DocType `name` injection. Under `{ requireWellFormed: true }` the serializer validates the DocType
  `name` as an XML `Name`, throwing `InvalidStateError` otherwise.
- [**GHSA-c7q8-3ch8-vqpv**](https://github.com/xmldom/xmldom/security/advisories/GHSA-c7q8-3ch8-vqpv)
  — processing-instruction target injection. `0.8.x` had no PI-target check at all; the whole target
  validation (XML `NCName`, reject case-insensitive `xml`) is new here, throwing `InvalidStateError`.
- [**GHSA-6gmq-8vp8-gcm6**](https://github.com/xmldom/xmldom/security/advisories/GHSA-6gmq-8vp8-gcm6)
  — `EntityReference` `nodeName` injection. `createEntityReference()` rejects an invalid `Name` at
  creation, and under `requireWellFormed` the serializer validates the `nodeName` as an XML `Name`.

### Fixes — parser end-tag reporting (scope-B backport)

- [**GHSA-6h8r-xr42-gp59**](https://github.com/xmldom/xmldom/security/advisories/GHSA-6h8r-xr42-gp59)
  — parser silently accepted a not-well-formed end tag (valid name followed by trailing content).
  `0.8.x` previously validated no end-tag residue; an equivalent check is added, reported as a
  recoverable `error` in both XML and HTML. Parsing still recovers to the byte-identical DOM. The
  `0.9.x`-only serializer/creation-time siblings of this advisory family do not apply to this line.

### Commits (grouped by family)

- **Serializer name checks:** DocType name, PI target, EntityReference (incl. the non-breaking
  `createEntityReference` creation-time anchor); synchronized serializer `@throws` docs.
- **End-tag report:** not-well-formed end-tag residue check (`#4` scope-B backport).
- **DoS:** prototype-chain NS map; attribute-dedup characterization tests (from scratch) +
  null-prototype index; anchored end-tag trim; malformed-recovery `<`-guard (registered `sax.js`
  message under `test/error/`) + O(K) `normalize()`.

Each DoS fix additionally lands a deterministic complexity-regression guard in
`test/algorithmic-complexity-regression.test.js` (CWE-407).

Deferred to the next breaking release (`0.10.0`): escalating the not-well-formed end-tag acceptance to
a consistent `fatalError`. The `0.8.x` creation-time DocType-name gap is consciously left unfixed (it
cannot be closed without a breaking change).
