### PR TITLE
feat: accept true as serializer options shorthand

### DIFF
--- a/examples/typescript-node-es6/src/index.ts
+++ b/examples/typescript-node-es6/src/index.ts
@@ -164,6 +164,18 @@ const doc = new DOMParser({
 	onError: onWarningStopParsing,
 }).parseFromString(source, MIME_TYPE.XML_TEXT);
 assert(new XMLSerializer().serializeToString(doc), source);
+// `true` is shorthand for `{ requireWellFormed: true }`; the source is well-formed so it serializes unchanged
+assert(new XMLSerializer().serializeToString(doc, true), source);
+assert(doc.childNodes.toString(true), doc.childNodes.toString());
+// the maximum options object, exercising every supported property
+assert(
+	new XMLSerializer().serializeToString(doc, {
+		requireWellFormed: true,
+		splitCDATASections: true,
+		nodeFilter: (node) => node,
+	}),
+	source
+);
 new DOMParser({
 	onError: (level, msg) => {
 		switch (level) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -795,7 +795,7 @@ declare module '@xmldom/xmldom' {
 		 * Accepts the same options as `XMLSerializer.prototype.serializeToString`.
 		 */
 		toString(
-			options?: XMLSerializerOptions | ((node: T) => T | undefined)
+			options?: XMLSerializerOptions | ((node: T) => T | undefined) | true
 		): string;
 		/**
 		 * Filters the NodeList based on a predicate.
@@ -1605,8 +1605,9 @@ declare module '@xmldom/xmldom' {
 		 *
 		 * When `options.requireWellFormed` is `true`, throws `InvalidStateError` for content that
 		 * would produce ill-formed XML. When `options.splitCDATASections` is `false`,
-		 * CDATASection data is emitted verbatim. Passing a function as `options` is treated as a
-		 * legacy `nodeFilter` for backward compatibility.
+		 * CDATASection data is emitted verbatim. Passing `true` as `options` is shorthand for `{
+		 * requireWellFormed: true }`. Passing a function as `options` is treated as a legacy
+		 * `nodeFilter` for backward compatibility.
 		 *
 		 * __This implementation differs from the specification:__ - CDATASection serialization is
 		 * not specified by W3C DOM Parsing or WHATWG DOM Parsing (see
@@ -1649,7 +1650,10 @@ declare module '@xmldom/xmldom' {
 		 */
 		serializeToString(
 			node: Node,
-			options?: XMLSerializerOptions | ((node: Node) => Node | null | undefined)
+			options?:
+				| XMLSerializerOptions
+				| ((node: Node) => Node | null | undefined)
+				| true
 		): string;
 	}
 	// END ./lib/dom.js

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -331,10 +331,11 @@ NodeList.prototype = {
 	 * Returns a string representation of the NodeList.
 	 *
 	 * Accepts the same `options` object as `XMLSerializer.prototype.serializeToString`
-	 * (`requireWellFormed`, `splitCDATASections`, `nodeFilter`). Passing a function is treated as
-	 * a legacy `nodeFilter` for backward compatibility.
+	 * (`requireWellFormed`, `splitCDATASections`, `nodeFilter`). Passing `true` is shorthand for
+	 * `{ requireWellFormed: true }`. Passing a function is treated as a legacy `nodeFilter` for
+	 * backward compatibility.
 	 *
-	 * @param {Object | function} [options]
+	 * @param {Object | function | true} [options]
 	 * @param {boolean} [options.requireWellFormed=false]
 	 * @param {boolean} [options.splitCDATASections=true]
 	 * @param {function} [options.nodeFilter]
@@ -342,7 +343,9 @@ NodeList.prototype = {
 	 */
 	toString: function (options) {
 		var opts;
-		if (typeof options === 'function') {
+		if (options === true) {
+			opts = { requireWellFormed: true, splitCDATASections: true, nodeFilter: null };
+		} else if (typeof options === 'function') {
 			opts = { requireWellFormed: false, splitCDATASections: true, nodeFilter: options };
 		} else if (!!options) {
 			opts = {
@@ -3081,8 +3084,9 @@ function XMLSerializer() {}
  * against the next breaking milestone.
  *
  * @param {Node} node
- * @param {Object | function} [options]
- * Options object, or a legacy nodeFilter function (backward compatible).
+ * @param {Object | function | true} [options]
+ * Options object, or `true` as shorthand for `{ requireWellFormed: true }`, or a legacy
+ * nodeFilter function (backward compatible).
  * @param {boolean} [options.requireWellFormed=false]
  * When `true`, throws `InvalidStateError` for content that would produce ill-formed XML.
  * @param {boolean} [options.splitCDATASections=true]
@@ -3124,7 +3128,9 @@ function nodeSerializeToString(options) {
 	// Normalize the user-supplied options into a single internal opts object so that the
 	// internal serializer always works with a consistent shape rather than positional flags.
 	var opts;
-	if (typeof options === 'function') {
+	if (options === true) {
+		opts = { requireWellFormed: true, splitCDATASections: true, nodeFilter: null };
+	} else if (typeof options === 'function') {
 		opts = { requireWellFormed: false, splitCDATASections: true, nodeFilter: options };
 	} else if (options != null) {
 		opts = {

--- a/test/dom/serializer.test.js
+++ b/test/dom/serializer.test.js
@@ -665,6 +665,30 @@ describe('XMLSerializer.serializeToString', () => {
 		});
 	});
 
+	describe('true (shorthand for { requireWellFormed: true })', () => {
+		test('true on CDATA with "]]>" throws InvalidStateError', () => {
+			const cdata = doc.createCDATASection('safe');
+			cdata.data = 'foo]]>bar';
+			doc.documentElement.appendChild(cdata);
+			expectDOMException(() => new XMLSerializer().serializeToString(doc, true), 'InvalidStateError');
+		});
+
+		test('true produces the same output as { requireWellFormed: true } for well-formed content', () => {
+			doc.documentElement.appendChild(doc.createTextNode('valid text'));
+			expect(new XMLSerializer().serializeToString(doc, true)).toBe(
+				new XMLSerializer().serializeToString(doc, { requireWellFormed: true })
+			);
+		});
+
+		test('true differs from omitting options: omitted splits "]]>" while true throws', () => {
+			const cdata = doc.createCDATASection('safe');
+			cdata.data = 'foo]]>bar';
+			doc.documentElement.appendChild(cdata);
+			expect(new XMLSerializer().serializeToString(doc)).toBe('<root><![CDATA[foo]]]]><![CDATA[>bar]]></root>');
+			expectDOMException(() => new XMLSerializer().serializeToString(doc, true), 'InvalidStateError');
+		});
+	});
+
 	describe('Attribute', () => {
 		test('serializes an attribute node directly as name="value"', () => {
 			const el = doc.createElement('el');
@@ -789,6 +813,13 @@ describe('Node.toString', () => {
 			doc.documentElement.appendChild(cdata);
 			expectDOMException(() => doc.toString({ requireWellFormed: true }), 'InvalidStateError');
 		});
+
+		test('node.toString(true) on node with "]]>" in CDATA child throws InvalidStateError', () => {
+			const cdata = doc.createCDATASection('safe');
+			cdata.data = 'foo]]>bar';
+			doc.documentElement.appendChild(cdata);
+			expectDOMException(() => doc.toString(true), 'InvalidStateError');
+		});
 	});
 });
 
@@ -813,6 +844,13 @@ describe('NodeList.toString', () => {
 			cdata.data = 'foo]]>bar';
 			doc.documentElement.appendChild(cdata);
 			expectDOMException(() => doc.documentElement.childNodes.toString({ requireWellFormed: true }), 'InvalidStateError');
+		});
+
+		test('nodeList.toString(true) on list containing CDATA with "]]>" throws InvalidStateError', () => {
+			const cdata = doc.createCDATASection('safe');
+			cdata.data = 'foo]]>bar';
+			doc.documentElement.appendChild(cdata);
+			expectDOMException(() => doc.documentElement.childNodes.toString(true), 'InvalidStateError');
 		});
 	});
 });


### PR DESCRIPTION
`requireWellFormed` is the option for enabling the latest security fixes shipped with 0.9.x as an opt-in, but enabling it means passing the object `{ requireWellFormed: true }` as the serializer's second argument. During the recent security advisory work an LLM reached for `true` instead of that object and it had no effect — a plausible mistake for humans and LLMs reading about the opt-in and try the simplest thing. This lowers that friction by accepting `true` as a shorthand for exactly that object, on `XMLSerializer.serializeToString`, `Node.toString`, and `NodeList.toString`.

Until now `true` was silently swallowed as a no-op: it is truthy but has no `requireWellFormed` property, so it fell through to the default options and serialized identically to omitting the argument — which is precisely why the mistake goes unnoticed. This repurposes that meaningless value, so no documented input changes behavior. The published type is the literal `true`, not `boolean`: — `false` is deliberately not offered as a meaningful option.

**How has this been tested?**

Full jest suite passes (2016 tests). New cases in `test/dom/serializer.test.js` cover `true` across all three entry points: it throws `InvalidStateError` on ill-formed content (CDATA containing `]]>`) and produces byte-identical output to `{ requireWellFormed: true }` on well-formed content. `npm run test:types` compiles and runs the typed example under TypeScript 3.9, 4.9, and 5.9; lint and format:check are clean.

**How has this been documented?**

Updated the JSDoc at both option-normalization sites in `lib/dom.js` and the `serializeToString` / `NodeList.toString` signatures in `index.d.ts`. The typed example (`examples/typescript-node-es6`) now exercises `serializeToString(doc, true)`, `childNodes.toString(true)`, and the maximal options object with every supported property.